### PR TITLE
Fixing installer error "must be logged as administrator"

### DIFF
--- a/release/setupmaker/pyRevitSetup.iss
+++ b/release/setupmaker/pyRevitSetup.iss
@@ -23,6 +23,7 @@ AppCopyright=Copyright (c) 2014-2017 Ehsan Iran-Nejad
 DisableWelcomePage=no
 WizardImageFile=installerimage.bmp
 LicenseFile=LICENSE
+PrivilegesRequired=lowest
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Dear Ehsan, 

I was unable to run installer on computer without admin rights in my office. 

Then I figured out that one line in InnoSetup settings file resolves this issue. I tried to build an installer with it and it helped.

`PrivilegesRequired=lowest`

Hope it's matter. 

Thank you, 
Alex
