### PR TITLE
Fixed unicode error on call to json.dumps in slackclient lib

### DIFF
--- a/site-packages/slackclient/server.py
+++ b/site-packages/slackclient/server.py
@@ -260,7 +260,7 @@ class Server(object):
         response = self.api_requester.do(self.token, method, kwargs, timeout=timeout)
         response_json = json.loads(response.text)
         response_json["headers"] = dict(response.headers)
-        return json.dumps(response_json)
+        return json.dumps(response_json, ensure_ascii=False)
 
 # TODO: Move the error types defined below into the .exceptions namespace. This would be a semver
 # major change because any clients already referencing these types in order to catch them


### PR DESCRIPTION
forgot this is a really easy fix. opened an issue on slackclient but who knows if they will accept it