### PR TITLE
Settings window UI; fix duplicated extentions paths

### DIFF
--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
@@ -145,6 +145,10 @@ class SettingsWindow(forms.WPFWindow):
                     self.availableEngines.SelectedItem = engine_cfg
                     break
 
+            # if addin-file is not writable, lock changing of the engine
+            if not user_config.is_attachment_writable(attachment):
+                self.availableEngines.IsEnabled = False
+
             # now select the current runtime engine
             self.cpyengine = user_config.get_active_cpython_engine()
             for engine_cfg in self.cpythonEngines.ItemsSource:

--- a/pyrevitlib/pyrevit/userconfig.py
+++ b/pyrevitlib/pyrevit/userconfig.py
@@ -148,7 +148,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         if op.exists(EXTENSIONS_DEFAULT_DIR):
             dir_list.append(EXTENSIONS_DEFAULT_DIR)
         dir_list.extend(self.get_thirdparty_ext_root_dirs())
-        return dir_list
+        return list(set(dir_list))
 
     def get_thirdparty_ext_root_dirs(self, include_default=True):
         """Return a list of external extension directories set by the user.

--- a/pyrevitlib/pyrevit/userconfig.py
+++ b/pyrevitlib/pyrevit/userconfig.py
@@ -247,6 +247,15 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         hostver = int(HOST_APP.version)
         return TargetApps.Revit.PyRevit.GetAttached(hostver)
 
+    @staticmethod
+    def is_attachment_writable(attachment):
+        """Checks if addin-file of an attachment is writable"""
+        try:
+            open(attachment.Manifest.FilePath, a).close()
+            return True
+        except:
+            return False
+
 
 def find_config_file(target_path):
     """Find config file in target path."""

--- a/pyrevitlib/pyrevit/userconfig.py
+++ b/pyrevitlib/pyrevit/userconfig.py
@@ -251,7 +251,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
     def is_attachment_writable(attachment):
         """Checks if addin-file of an attachment is writable"""
         try:
-            open(attachment.Manifest.FilePath, a).close()
+            open(attachment.Manifest.FilePath, "a").close()
             return True
         except:
             return False


### PR DESCRIPTION
Hey Ehsan! There are couple of fixes, please have a look.

**1. UI Improvements of Settings window.**

If there is no write-access to pyRevit.addin file (if pyRevit deployed as admin), it locks iron python engine checkbox in Settings window.

**2. Remove duplicates from extentions folders list.** 
For me it was set in config.ini:

`userextensions = ["C:\\Users\\Alex\\AppData\\Roaming\\pyRevit\\Extensions"]`

and in `userconfig.py` there are lines:
```
if op.exists(EXTENSIONS_DEFAULT_DIR):
            dir_list.append(EXTENSIONS_DEFAULT_DIR)
```

which causes duplicated pathes as result of `get_ext_root_dirs()`. And finally all the extensions were reloaded two times on each reload.

I do not sure, but maybe it makes sence to remove `EXTENSIONS_DEFAULT_DIR` at all, because it being written into config from `pyrevitcli` anyway. When I install an extension from UI, it uses pyrevit cli, isn' it?

Thank you!