### PR TITLE
str() -> safe_strtype() in pyrevit.forms _nameattr

### DIFF
--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -308,7 +308,7 @@ class TemplateListItem(object):
         """Name property."""
         # get custom attr, or name or just str repr
         if self._nameattr:
-            return str(getattr(self.item, self._nameattr))
+            return safe_strtype(getattr(self.item, self._nameattr))
         elif hasattr(self.item, 'name'):
             return getattr(self.item, 'name', '')
         else:


### PR DESCRIPTION
Hey Ehsan! 

To continue my question about this issue with IPY 2.7.3 and unicode
https://github.com/eirannejad/pyRevit/issues/577

Shouldn't this line also be replaced with `safe_strtype`?
