### PR TITLE
Scripts improvements

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack2/Inspect.pulldown/ListElementsOfSelectedLevel.pushbutton/ListElementsOfSelectedLevel_script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack2/Inspect.pulldown/ListElementsOfSelectedLevel.pushbutton/ListElementsOfSelectedLevel_script.py
@@ -18,32 +18,25 @@ from pyrevit import forms
 
 __title__ = 'List Elements of Selected Level(s)'
 __author__ = 'Frederic Beaupere'
-__context__ = 'selection'
+# __context__ = 'selection'
 __contact__ = 'https://github.com/frederic-beaupere'
 __credits__ = 'http://eirannejad.github.io/pyRevit/credits/'
 __doc__ = 'Lists all Elements of the selected level(s).'
 
-
 output = script.get_output()
-
-output.print_md("####LIST ALL ELEMENTS ON SELECTED LEVEL(S):")
-output.print_md('By: [{}]({})'.format(__author__, __contact__))
-
 
 all_elements = DB.FilteredElementCollector(revit.doc)\
                  .WhereElementIsNotElementType()\
                  .ToElements()
 
-selection = revit.get_selection()
-
-levels = []
-for el in selection:
-    if el.Category.Id.IntegerValue == int(DB.BuiltInCategory.OST_Levels):
-        levels.append(el)
+levels = forms.select_levels(use_selection=True)
 
 if not levels:
     forms.alert('At least one Level element must be selected.')
 else:
+    output.print_md("####LIST ALL ELEMENTS ON SELECTED LEVEL(S):")
+    output.print_md('By: [{}]({})'.format(__author__, __contact__))
+
     all_count = all_elements.Count
     print('\n' + str(all_count) + ' Elements found in project.')
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Selected Viewports To Selected Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Selected Viewports To Selected Sheets.pushbutton/script.py
@@ -44,6 +44,7 @@ allSheetedSchedules = DB.FilteredElementCollector(revit.doc)\
 
 
 selected_sheets = forms.select_sheets(title='Select Target Sheets',
+                                      filterfunc=lambda e: not e.IsPlaceholder,
                                       button_name='Select Sheets')
 
 # get a list of viewports to be copied, updated

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Sheets to Open Documents.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Sheets to Open Documents.pushbutton/script.py
@@ -78,7 +78,7 @@ def get_dest_docs():
 
 
 def get_source_sheets():
-    sheet_elements = forms.select_sheets(button_name='Copy Sheets')
+    sheet_elements = forms.select_sheets(button_name='Copy Sheets', use_selection=True, use_active_view=True)
 
     if not sheet_elements:
         sys.exit(0)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Decrement Selected Sheet Numbers.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Decrement Selected Sheet Numbers.pushbutton/script.py
@@ -16,7 +16,7 @@ logger = script.get_logger()
 
 shift = -1
 
-selected_sheets = forms.select_sheets(title='Select Sheets')
+selected_sheets = forms.select_sheets(title='Select Sheets', use_selection=True)
 if not selected_sheets:
     script.exit()
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Move Selected Viewports To Selected Sheet.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Move Selected Viewports To Selected Sheet.pushbutton/script.py
@@ -13,6 +13,7 @@ __doc__ = 'Open the source sheet. Run this script and select destination '\
 selViewports = []
 
 dest_sheet = forms.select_sheets(title='Select Target Sheets',
+                                 filterfunc=lambda e: not e.IsPlaceholder,
                                  button_name='Select Sheets',
                                  multiple=False,
                                  use_selection=True)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Move Selected Viewports To Selected Sheet.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Move Selected Viewports To Selected Sheet.pushbutton/script.py
@@ -14,7 +14,8 @@ selViewports = []
 
 dest_sheet = forms.select_sheets(title='Select Target Sheets',
                                  button_name='Select Sheets',
-                                 multiple=False)
+                                 multiple=False,
+                                 use_selection=True)
 
 if dest_sheet:
     cursheet = revit.activeview

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Pin All Viewports.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Pin All Viewports.pushbutton/script.py
@@ -4,9 +4,7 @@ Shift-Click:
 Pin all viewports on active sheet.
 """
 
-import sys
-
-from pyrevit import revit, DB, UI
+from pyrevit import revit, DB
 from pyrevit import script
 from pyrevit import forms
 
@@ -38,7 +36,7 @@ if __shiftclick__:
         forms.alert('Active view must be a sheet.')
         script.exit()
 else:
-    sel_sheets = forms.select_sheets(title='Select Sheets')
+    sel_sheets = forms.select_sheets(title='Select Sheets', use_selection=True)
 
 
 if sel_sheets:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Rename Selected Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Rename Selected Sheets.pushbutton/script.py
@@ -16,7 +16,7 @@ def change_case(sheetlist, upper=True, verbose=False):
             sheetnameparam.Set(new_name)
 
 
-sel_sheets = forms.select_sheets(title='Select Sheets')
+sel_sheets = forms.select_sheets(title='Select Sheets', use_selection=True)
 
 if sel_sheets:
     selected_option, switches = \

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Select TitleBlocks on Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Select TitleBlocks on Sheets.pushbutton/script.py
@@ -10,7 +10,7 @@ logger = script.get_logger()
 
 
 def get_source_sheets():
-    sheet_elements = forms.select_sheets(button_name='Select TitleBlocks')
+    sheet_elements = forms.select_sheets(button_name='Select TitleBlocks', use_selection=True)
     if not sheet_elements:
         script.exit()
     return sheet_elements

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Convert Drafting to Legend.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Convert Drafting to Legend.pushbutton/script.py
@@ -23,7 +23,8 @@ all_legend_names = [revit.query.get_name(x)
 # get a list of selected legends
 drafting_views = forms.select_views(
     title='Select Drafting Views',
-    filterfunc=lambda x: x.ViewType == DB.ViewType.DraftingView)
+    filterfunc=lambda x: x.ViewType == DB.ViewType.DraftingView,
+    use_selection=True)
 
 
 if drafting_views:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Convert Legend to Drafting.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Convert Legend to Drafting.pushbutton/script.py
@@ -24,7 +24,8 @@ all_drafting_names = [revit.query.get_name(x)
 # get a list of selected legends
 legends = forms.select_views(
     title='Select Legends',
-    filterfunc=lambda x: x.ViewType == DB.ViewType.Legend)
+    filterfunc=lambda x: x.ViewType == DB.ViewType.Legend,
+    use_selection=True)
 
 if legends:
     # get the first style for Drafting views.

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Copy Legends as Drafting to Other Documents.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Copy Legends as Drafting to Other Documents.pushbutton/script.py
@@ -27,7 +27,8 @@ if not open_docs:
 # get a list of selected legends
 legends = forms.select_views(
     title='Select Drafting Views',
-    filterfunc=lambda x: x.ViewType == DB.ViewType.Legend)
+    filterfunc=lambda x: x.ViewType == DB.ViewType.Legend,
+    use_selection=True)
 
 if legends:
     for dest_doc in open_docs:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Copy Legends to Other Documents.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Legends.pulldown/Copy Legends to Other Documents.pushbutton/script.py
@@ -25,7 +25,8 @@ if not open_docs:
 # get a list of selected legends
 legends = forms.select_views(
     title='Select Drafting Views',
-    filterfunc=lambda x: x.ViewType == DB.ViewType.Legend)
+    filterfunc=lambda x: x.ViewType == DB.ViewType.Legend,
+    use_selection=True)
 
 if legends:
     for dest_doc in open_docs:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Add Views to Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Add Views to Sheets.pushbutton/script.py
@@ -18,29 +18,7 @@ logger = script.get_logger()
 selected_views = []
 
 
-if __shiftclick__:
-    selected_views = forms.select_views()
-else:
-    # get selection and verify a view is selected
-    selection = revit.get_selection()
-    if not selection.is_empty:
-        logger.debug('Getting views from selection.')
-        for el in selection:
-            if el.Category and el.Category.Id.IntegerValue == int(DB.BuiltInCategory.OST_Views):
-                logger.debug('Selected element referencing: {}'
-                             .format(el.Name))
-                target_view = revit.query.get_view_by_name(el.Name)
-                if target_view:
-                    logger.debug('Target view: {}'
-                                 .format(revit.query.get_name(target_view)))
-                    selected_views.append(target_view)
-    else:
-        selected_view = revit.activeview
-        if not isinstance(selected_view, DB.View):
-            forms.alert('Active view must be placable on a sheet.', exitscript=True)
-        logger.debug('Selected view: {}'.format(selected_view))
-        selected_views = [selected_view]
-
+selected_views = forms.select_views(use_selection=True, use_active_view=True)
 
 if selected_views:
     logger.debug('Selected views: {}'.format(len(selected_views)))

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Create Print Set From Selected Views.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Create Print Set From Selected Views.pushbutton/script.py
@@ -13,7 +13,7 @@ printmanager.PrintRange = DB.PrintRange.Select
 viewsheetsetting = printmanager.ViewSheetSetting
 
 # Collect selected views
-selected_views = forms.select_views()
+selected_views = forms.select_views(use_selection=True)
 if selected_views:
     myviewset = DB.ViewSet()
     for el in selected_views:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Duplicate Selected Views.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Duplicate Selected Views.pushbutton/script.py
@@ -27,7 +27,7 @@ def duplicate_views(viewlist, with_detailing=True):
                              .format(revit.query.get_name(el), duplerr))
 
 
-selected_views = forms.select_views(filterfunc=duplicableview)
+selected_views = forms.select_views(filterfunc=duplicableview, use_selection=True, use_active_view=True)
 
 if selected_views:
     selected_option = \

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Query View Referencing.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Query View Referencing.pushbutton/script.py
@@ -8,7 +8,7 @@ from pyrevit import script
 output = script.get_output()
 
 
-selected_views = forms.select_views(title="Select Views to List")
+selected_views = forms.select_views(title="Select Views to List", use_selection=True)
 
 if selected_views:
     selected_option, switches = \

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Remove Empty Tags.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Remove Empty Tags.pushbutton/script.py
@@ -11,7 +11,7 @@ from pyrevit import forms
 
 if __shiftclick__:  #pylint: disable=undefined-variable
     selected_views = \
-        forms.select_views(filterfunc=lambda x: isinstance(x, DB.ViewPlan))
+        forms.select_views(filterfunc=lambda x: isinstance(x, DB.ViewPlan), use_selection=True)
 else:
     selected_views = [revit.activeview]
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Remove Underlay From Selected Views.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Remove Underlay From Selected Views.pushbutton/script.py
@@ -10,7 +10,7 @@ from pyrevit import forms
 
 
 selected_views = \
-    forms.select_views(filterfunc=lambda x: isinstance(x, DB.ViewPlan))
+    forms.select_views(filterfunc=lambda x: isinstance(x, DB.ViewPlan), use_selection=True)
 
 if selected_views:
     with revit.Transaction('Batch Set Underlay to None'):

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Rename Selected Views.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack3/Views.pulldown/Rename Selected Views.pushbutton/script.py
@@ -20,7 +20,7 @@ def change_case(view_list, upper=True, verbose=False):
                       "\t{1}\n\n".format(orig_name, revit.query.get_name(view)))
 
 
-selected_views = forms.select_views()
+selected_views = forms.select_views(use_selection=True)
 
 if selected_views:
     selected_option, switches = \

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit1.stack3/Overkill.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit1.stack3/Overkill.pushbutton/script.py
@@ -178,6 +178,8 @@ if selected_option:
     detline_collector = \
         revit.query.get_elements_by_class(DB.CurveElement,
                                         view_id=revit.activeview.Id)
+    # filter to leave only Lines.
+    detline_collector = list(filter(lambda l: isinstance(l.GeometryCurve, DB.Line), detline_collector))
 
     # collect comparison info on each detail-lines geomtery
     logger.debug('Extracting 2d domains...')

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack3/Select.pulldown/Select All Vertical Reveals.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack3/Select.pulldown/Select All Vertical Reveals.pushbutton/script.py
@@ -1,5 +1,6 @@
-"""Selects all vertical reveals in the project."""
-
+"""Selects all vertical/horizontal reveals in the project.
+By default selects vertical ones. With Shift-CLick: horizontal."""
+__title__ = "Select vertical/horizontal Reveals"
 from pyrevit.framework import List
 from pyrevit import revit, DB
 
@@ -12,7 +13,7 @@ revealslist = cl.OfCategory(DB.BuiltInCategory.OST_Reveals)\
 selSet = []
 
 for el in revealslist:
-    if el.GetWallSweepInfo().IsVertical:
+    if el.GetWallSweepInfo().IsVertical != __shiftclick__:
         selSet.append(el.Id)
 
 revit.get_selection().set_to(selSet)

--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -509,7 +509,7 @@ class SelectFromList(TemplateUserInputWindow):
 
     def _prepare_context(self):
         if isinstance(self._context, dict) and self._context.keys():
-            self._update_ctx_groups(self._context.keys())
+            self._update_ctx_groups(sorted(self._context.keys()))
             new_ctx = {}
             for ctx_grp, ctx_items in self._context.items():
                 new_ctx[ctx_grp] = self._prepare_context_items(ctx_items)
@@ -1530,7 +1530,8 @@ def select_sheets(title='Select Sheets',
         button_name=button_name,
         width=width,
         multiselect=multiple,
-        checked_only=True
+        checked_only=True,
+        default_group='All Sheets'
         )
 
     return selected_sheets

--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -2488,5 +2488,5 @@ def ask_if_user_want_to_use_selection(type_name, filters, multiple=True, use_sel
         # ask user whether he wants to use preselected sheets or select them from a list
         result = alert("You have preselected %s. Do you want to use them?" % type_name,
                        options=options)
-        if results_dict in results_dict.keys():
+        if result in results_dict.keys():
             return results_dict[result]


### PR DESCRIPTION
Hey Ehsan! I've just finished small bunch of changes for`pyRevitTools` scripts and couple of changes in `pyrevitlib`. Hope you'll find that useful:

**Fixes:**
1642b337 Overkill - there was an exception, in case if there are non-DB.Line curvers in a project (e.g. Arcs)

**pyrevitlib improvements**
2316ecb9 542f9c91 select_sheets(), select_views() - I've added an option to use preselected elements (ones which pass through filter) instead of selecting them anew. User will be asked if he wants to select from List or use preselected Elements. 
In similar way, there is an option to use Active view instead of selecting it in list.

7039233a I've added select_levels() method which works the same way with preselected elements.

**Scripts improvements**
296e008e DrawingSet scripts - use pre-selected views if possible (an implementation of changes described above)
7039233a "List elements on selected levels" - ability to pick levels from list
123c7595 "Copy/Move viewports" - do not show Sheet Placeholders in a list

53e71351 "Select (vertical) Reveals" - now you can select also horizontal ones, using shiftclick


