### PR TITLE
Copy/Paste state improvements

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/Copy State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/Copy State.pushbutton/script.py
@@ -70,7 +70,6 @@ def make_picklable_list(curve_loops):
             p1 = (rvt_line.GetEndPoint(0).X, rvt_line.GetEndPoint(0).Y)
             p2 = (rvt_line.GetEndPoint(1).X, rvt_line.GetEndPoint(1).Y)
             cloop_lines.append((p1, p2))
-
         
         all_cloops.append(cloop_lines)
     return all_cloops
@@ -169,7 +168,6 @@ elif selected_option == 'Viewport Placement on Sheet':
     transmatrix = TransformationMatrix()
     revtransmatrix = TransformationMatrix()
 
-
     def sheet_to_view_transform(sheetcoord):
         global transmatrix
         newx = \
@@ -185,7 +183,6 @@ elif selected_option == 'Viewport Placement on Sheet':
                / (transmatrix.sourcemax.Y - transmatrix.sourcemin.Y))
 
         return DB.XYZ(newx, newy, 0.0)
-
 
     def set_tansform_matrix(selvp, selview):
         # making sure the cropbox is active.
@@ -273,8 +270,6 @@ elif selected_option == 'Viewport Placement on Sheet':
                     if viewspecificelements:
                         selview.UnhideElements(
                             List[DB.ElementId](viewspecificelements)
-                        )
-
                             )
 
     datafile = \

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/Copy State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/Copy State.pushbutton/script.py
@@ -10,13 +10,10 @@ from pyrevit import script
 import copy_paste_state_utils
 
 
-__doc__ = 'Copies the state of desired parameter of the active' \
-          ' view to memory. e.g. Visibility Graphics settings or' \
 __doc__ = 'Copies the state of desired parameter of the active'\
           ' view to memory. e.g. Visibility Graphics settings or'\
           ' Zoom state. Run it and see how it works.'
 
-__author__ = 'Gui Talarico\n' \
 __author__ = 'Gui Talarico\n'\
              'Ehsan Iran-Nejad'
 
@@ -87,7 +84,6 @@ selected_option = \
          'Visibility Graphics',
          'Crop Region'],
         message='Select property to be copied to memory:'
-    )
         )
 
 
@@ -197,14 +193,9 @@ elif selected_option == 'Viewport Placement on Sheet':
         cboxvisible = selview.CropBoxVisible
         cboxannoparam = selview.get_Parameter(
             DB.BuiltInParameter.VIEWER_ANNOTATION_CROP_ACTIVE
-        )
             )
 
         cboxannostate = cboxannoparam.AsInteger()
-        curviewelements = DB.FilteredElementCollector(revit.doc) \
-            .OwnedByView(selview.Id) \
-            .WhereElementIsNotElementType() \
-            .ToElements()
         curviewelements = DB.FilteredElementCollector(revit.doc)\
                             .OwnedByView(selview.Id)\
                             .WhereElementIsNotElementType()\
@@ -218,10 +209,6 @@ elif selected_option == 'Viewport Placement on Sheet':
                     and el.Category is not None:
                 viewspecificelements.append(el.Id)
 
-        basepoints = DB.FilteredElementCollector(revit.doc) \
-            .OfClass(DB.BasePoint) \
-            .WhereElementIsNotElementType() \
-            .ToElements()
         basepoints = DB.FilteredElementCollector(revit.doc)\
                        .OfClass(DB.BasePoint)\
                        .WhereElementIsNotElementType()\

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/Copy State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/Copy State.pushbutton/script.py
@@ -12,9 +12,12 @@ import copy_paste_state_utils
 
 __doc__ = 'Copies the state of desired parameter of the active' \
           ' view to memory. e.g. Visibility Graphics settings or' \
+__doc__ = 'Copies the state of desired parameter of the active'\
+          ' view to memory. e.g. Visibility Graphics settings or'\
           ' Zoom state. Run it and see how it works.'
 
 __author__ = 'Gui Talarico\n' \
+__author__ = 'Gui Talarico\n'\
              'Ehsan Iran-Nejad'
 
 
@@ -71,6 +74,7 @@ def make_picklable_list(curve_loops):
             p2 = (rvt_line.GetEndPoint(1).X, rvt_line.GetEndPoint(1).Y)
             cloop_lines.append((p1, p2))
 
+        
         all_cloops.append(cloop_lines)
     return all_cloops
 
@@ -84,6 +88,8 @@ selected_option = \
          'Crop Region'],
         message='Select property to be copied to memory:'
     )
+        )
+
 
 if selected_option == 'View Zoom/Pan State':
     datafile = \
@@ -192,12 +198,17 @@ elif selected_option == 'Viewport Placement on Sheet':
         cboxannoparam = selview.get_Parameter(
             DB.BuiltInParameter.VIEWER_ANNOTATION_CROP_ACTIVE
         )
+            )
 
         cboxannostate = cboxannoparam.AsInteger()
         curviewelements = DB.FilteredElementCollector(revit.doc) \
             .OwnedByView(selview.Id) \
             .WhereElementIsNotElementType() \
             .ToElements()
+        curviewelements = DB.FilteredElementCollector(revit.doc)\
+                            .OwnedByView(selview.Id)\
+                            .WhereElementIsNotElementType()\
+                            .ToElements()
 
         viewspecificelements = []
         for el in curviewelements:
@@ -211,6 +222,10 @@ elif selected_option == 'Viewport Placement on Sheet':
             .OfClass(DB.BasePoint) \
             .WhereElementIsNotElementType() \
             .ToElements()
+        basepoints = DB.FilteredElementCollector(revit.doc)\
+                       .OfClass(DB.BasePoint)\
+                       .WhereElementIsNotElementType()\
+                       .ToElements()
 
         excludecategories = ['Survey Point',
                              'Project Base Point']
@@ -273,6 +288,7 @@ elif selected_option == 'Viewport Placement on Sheet':
                             List[DB.ElementId](viewspecificelements)
                         )
 
+                            )
 
     datafile = \
         script.get_document_data_file(file_id='SaveViewportLocation',

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/lib/copy_paste_state_utils.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack3/lib/copy_paste_state_utils.py
@@ -1,0 +1,83 @@
+from pyrevit import DB, revit
+
+def get_view(element, allow_active_view=False):
+    """
+    Tries to get a view from selected elements (Viewport, View)
+    or get an active view (if allow_active_view is True)
+    :param element: element to extract view from (Viewport, View)
+    :param allow_active_view: take active view if element is not a view
+    :return: DB.View element
+    """
+    view = None
+    # try to get view of selected viewport
+    if isinstance(element, DB.Viewport):
+        view = element.Document.GetElement(element.ViewId)
+    # get selected views, e.g. from ProjectBrowser
+    if isinstance(element, DB.View) and not view:
+        view = element
+    if not view and allow_active_view:
+        view = revit.activeview
+    return view
+
+def get_viewport(element, allow_active_view=False):
+    """
+    Tries to get a viewport from selected elements (Viewport, View)
+    or get a viewport from an active view (if allow_active_view is True)
+    :param element: element to extract viewport from (Viewport, View)
+    :param allow_active_view: take viewport of active view
+    :return: DB.Viewport element
+    """
+    viewport = None
+    # try to get viewport of selected view
+    if isinstance(element, DB.View):
+        viewport = get_viewport_by_view(element)
+    # get selected viewports
+    if isinstance(element, DB.Viewport) and not viewport:
+        viewport = element
+    # get current view viewport
+    if not viewport and allow_active_view:
+        viewport = get_viewport_by_view(revit.activeview)
+    return viewport
+
+
+def get_views(elements):
+    result = []
+    for e in elements:
+        result.append(get_view(e))
+    if not result:
+        result = [revit.activeview]
+    return result
+
+
+def get_viewports(elements):
+    result = []
+    for e in elements:
+        result.append(get_viewport(e))
+    if not result:
+        result = [get_viewport_by_view(revit.activeview)]
+    return result
+
+
+def get_viewport_by_view(view):
+    sheet = get_view_sheet(view)
+    if not sheet:
+        return
+    cl = DB.FilteredElementCollector(view.Document)\
+        .WhereElementIsNotElementType().OfClass(DB.Viewport)
+    viewports = list(filter(lambda v: v.ViewId == view.Id, cl.ToElements()))
+    if len(viewports) == 0:
+        return
+    return viewports[0]
+
+def get_view_sheet(view):
+    sheet_num_param = view.get_Parameter(
+        DB.BuiltInParameter.VIEWPORT_SHEET_NUMBER)
+    if not sheet_num_param:
+        return None
+    sheet_num = sheet_num_param.AsString()
+    cl = DB.FilteredElementCollector(view.Document)\
+        .WhereElementIsNotElementType().OfClass(DB.ViewSheet)
+    sheets = list(filter(lambda s: s.SheetNumber == sheet_num, cl.ToElements()))
+    if len(sheets) == 0:
+        return
+    return sheets[0]


### PR DESCRIPTION
Hey Ehsan! I've done a couple of improvements for Selection - Copy/Paste state tools.

I'd got feedback from a colleague, that it's not intuitive to use it with Viewports. E.g. before copy/paste crop box you have to activate a view. But in opposite to copy viewport location you have to go back to Sheet and select a viewport.

So I've basically isolated two methods (located in `lib` of `memo.stack3`):

- get view(s) from selection
- get viewports(s) from selection

which works both when view and viewports selected, as well as returns active view or viewport of an active view.

The second major change is that now it is possible to Paste state for multiple views/viewports. E.g. you can select views in the project browser or viewports on a sheet.

Hope you'll find that useful
