### PR TITLE
Change type safely - non-English Revit support

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Change Element Type Safely.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Change Element Type Safely.pushbutton/script.py
@@ -12,46 +12,32 @@ __doc__ = 'Changes element type of the selected elements to a the element '\
 
 logger = script.get_logger()
 
-
-exclude_params = ['Family', 'Family Name', 'Family and Type',
-                  'Type', 'Type Name', 'Image']
-
+exclude_biparams = [DB.BuiltInParameter.ELEM_FAMILY_PARAM, # Family
+                   DB.BuiltInParameter.SYMBOL_FAMILY_NAME_PARAM, # Family Name
+                   DB.BuiltInParameter.ALL_MODEL_FAMILY_NAME, # Family and Type
+                   DB.BuiltInParameter.SYMBOL_FAMILY_AND_TYPE_NAMES_PARAM,
+                   DB.BuiltInParameter.ELEM_FAMILY_AND_TYPE_PARAM, 
+                   DB.BuiltInParameter.ELEM_TYPE_PARAM, # Type
+                   DB.BuiltInParameter.SYMBOL_NAME_PARAM,# Type Name
+                   DB.BuiltInParameter.ALL_MODEL_TYPE_NAME,
+                   DB.BuiltInParameter.ALL_MODEL_IMAGE] # Image
 
 def get_param_values(element):
     value_dict = {}
     for param in element.Parameters:
         param_name = param.Definition.Name
-        if not param.IsReadOnly and param_name not in exclude_params:
+        if not param.IsReadOnly and param.Definition.BuiltInParameter not in exclude_biparams:
             logger.debug('Getting param value: {}'.format(param_name))
-            if param.StorageType == DB.StorageType.Integer:
-                value_dict[param_name] = param.AsInteger()
-                logger.debug('Param value is Integer: {}'
-                             .format(value_dict[param_name]))
-
-            elif param.StorageType == DB.StorageType.Double:
-                value_dict[param_name] = param.AsDouble()
-                logger.debug('Param value is Double: {}'
-                             .format(value_dict[param_name]))
-
-            elif param.StorageType == DB.StorageType.String:
-                value_dict[param_name] = param.AsString()
-                logger.debug('Param value is String: {}'
-                             .format(value_dict[param_name]))
-
-            elif param.StorageType == DB.StorageType.ElementId:
-                value_dict[param_name] = param.AsElementId()
-                logger.debug('Param value is ElementId: {}'
-                             .format(value_dict[param_name]))
+            value_dict[param_name] = revit.db.query.get_param_value(param)
         else:
             logger.debug('Skipping param: {}'.format(param_name))
-
     return value_dict
 
 
 def set_param_values(element, value_dict):
     for param in element.Parameters:
         param_name = param.Definition.Name
-        if not param.IsReadOnly and param_name not in exclude_params:
+        if not param.IsReadOnly and param.Definition.BuiltInParameter not in exclude_biparams:
             if param_name in value_dict.keys():
                 param_value = value_dict[param_name]
                 try:


### PR DESCRIPTION
Hey Ehsan! 

I've change excluded parameter names to BuiltInParameters. Surprisingly, this was enough to make it work with German Revit.

Could you take a look, please