### PR TITLE
"Copy/Paste state - Viewport position" tool improvements

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Copy State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Copy State.pushbutton/script.py
@@ -127,8 +127,6 @@ elif selected_option == 'Viewport Placement on Sheet':
     selview = selvp = None
     vpboundaryoffset = 0.01
     activeSheet = revit.active_view
-    transmatrix = vpu.TransformationMatrix()
-    revtransmatrix = vpu.TransformationMatrix()
 
     datafile = \
         script.get_document_data_file(file_id='SaveViewportLocation',
@@ -138,9 +136,9 @@ elif selected_option == 'Viewport Placement on Sheet':
     view = revit.doc.GetElement(vport.ViewId)
     if view is not None and isinstance(view, DB.ViewPlan):
         with revit.TransactionGroup('Copy Viewport Location'):
-            vpu.set_tansform_matrix(vport, view)
+            transmatrix = vpu.set_tansform_matrix(vport, view, vpboundaryoffset)
             center = vport.GetBoxCenter()
-            modelpoint = vpu.sheet_to_view_transform(center)
+            modelpoint = vpu.transform_by_matrix(center, transmatrix)
             center_pt = vpu.Point(center.X, center.Y, center.Z)
             model_pt = vpu.Point(modelpoint.X, modelpoint.Y, modelpoint.Z)
             with open(datafile, 'wb') as fp:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Copy State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Copy State.pushbutton/script.py
@@ -1,13 +1,11 @@
-import os
-import os.path as op
 import pickle
 
 from pyrevit import HOST_APP
-from pyrevit.framework import List
-from pyrevit import revit, DB, UI
+
+from pyrevit import revit, DB
 from pyrevit import forms
 from pyrevit import script
-
+import viewport_placement_utils as vpu
 
 __doc__ = 'Copies the state of desired parameter of the active'\
           ' view to memory. e.g. Visibility Graphics settings or'\
@@ -15,49 +13,13 @@ __doc__ = 'Copies the state of desired parameter of the active'\
 
 __authors__ = ['Gui Talarico', '{{author}}']
 
-
-class Point:
-    def __init__(self, x, y, z):
-        self.x = x
-        self.y = y
-        self.z = z
+logger = script.get_logger()
 
 
 class BasePoint:
     def __init__(self):
         self.x = 0
         self.y = 0
-
-
-class BBox:
-    def __init__(self):
-        self.minx = 0
-        self.miny = 0
-        self.minz = 0
-        self.maxx = 0
-        self.maxy = 0
-        self.maxz = 0
-
-
-class ViewOrient:
-    def __init__(self):
-        self.eyex = 0
-        self.eyey = 0
-        self.eyez = 0
-        self.forwardx = 0
-        self.forwardy = 0
-        self.forwardz = 0
-        self.upx = 0
-        self.upy = 0
-        self.upz = 0
-
-
-class TransformationMatrix:
-    def __init__(self):
-        self.sourcemin = None
-        self.sourcemax = None
-        self.destmin = None
-        self.destmax = None
 
 
 def make_picklable_list(curve_loops):
@@ -120,7 +82,7 @@ elif selected_option == '3D Section Box State':
         sb = av.GetSectionBox()
         viewOrientation = av.GetOrientation()
 
-        sbox = BBox()
+        sbox = vpu.BBox()
         sbox.minx = sb.Min.X
         sbox.miny = sb.Min.Y
         sbox.minz = sb.Min.Z
@@ -128,7 +90,7 @@ elif selected_option == '3D Section Box State':
         sbox.maxy = sb.Max.Y
         sbox.maxz = sb.Max.Z
 
-        vo = ViewOrient()
+        vo = vpu.ViewOrient()
         vo.eyex = viewOrientation.EyePosition.X
         vo.eyey = viewOrientation.EyePosition.Y
         vo.eyez = viewOrientation.EyePosition.Z
@@ -158,159 +120,45 @@ elif selected_option == 'Viewport Placement on Sheet':
     pyrevit Notice:
     pyrevit: repository at https://github.com/eirannejad/pyrevit
     """
+    vport = vpu.select_viewport()
+
     originalviewtype = ''
 
     selview = selvp = None
     vpboundaryoffset = 0.01
     activeSheet = revit.active_view
-    transmatrix = TransformationMatrix()
-    revtransmatrix = TransformationMatrix()
-
-    def sheet_to_view_transform(sheetcoord):
-        global transmatrix
-        newx = \
-            transmatrix.destmin.X \
-            + (((sheetcoord.X - transmatrix.sourcemin.X)
-                * (transmatrix.destmax.X - transmatrix.destmin.X))
-               / (transmatrix.sourcemax.X - transmatrix.sourcemin.X))
-
-        newy = \
-            transmatrix.destmin.Y \
-            + (((sheetcoord.Y - transmatrix.sourcemin.Y)
-                * (transmatrix.destmax.Y - transmatrix.destmin.Y))
-               / (transmatrix.sourcemax.Y - transmatrix.sourcemin.Y))
-
-        return DB.XYZ(newx, newy, 0.0)
-
-    def set_tansform_matrix(selvp, selview):
-        # making sure the cropbox is active.
-        cboxactive = selview.CropBoxActive
-        cboxvisible = selview.CropBoxVisible
-        cboxannoparam = selview.get_Parameter(
-            DB.BuiltInParameter.VIEWER_ANNOTATION_CROP_ACTIVE
-            )
-
-        cboxannostate = cboxannoparam.AsInteger()
-        curviewelements = DB.FilteredElementCollector(revit.doc)\
-                            .OwnedByView(selview.Id)\
-                            .WhereElementIsNotElementType()\
-                            .ToElements()
-
-        viewspecificelements = []
-        for el in curviewelements:
-            if el.ViewSpecific \
-                    and not el.IsHidden(selview) \
-                    and el.CanBeHidden(selview) \
-                    and el.Category is not None:
-                viewspecificelements.append(el.Id)
-
-        basepoints = DB.FilteredElementCollector(revit.doc)\
-                       .OfClass(DB.BasePoint)\
-                       .WhereElementIsNotElementType()\
-                       .ToElements()
-
-        excludecategories = ['Survey Point',
-                             'Project Base Point']
-        for el in basepoints:
-            if el.Category and el.Category.Name in excludecategories:
-                viewspecificelements.append(el.Id)
-
-        with revit.TransactionGroup('Activate & Read Cropbox Boundary'):
-            with revit.Transaction('Hiding all 2d elements'):
-                if viewspecificelements:
-                    try:
-                        selview.HideElements(List[DB.ElementId](viewspecificelements))
-                    except Exception as e:
-                        logger.debug(e)
-
-            with revit.Transaction('Activate & Read Cropbox Boundary'):
-                selview.CropBoxActive = True
-                selview.CropBoxVisible = False
-                cboxannoparam.Set(0)
-
-                # get view min max points in modelUCS.
-                modelucsx = []
-                modelucsy = []
-                crsm = selview.GetCropRegionShapeManager()
-
-                cllist = crsm.GetCropShape()
-                if len(cllist) == 1:
-                    cl = cllist[0]
-                    for l in cl:
-                        modelucsx.append(l.GetEndPoint(0).X)
-                        modelucsy.append(l.GetEndPoint(0).Y)
-                    cropmin = DB.XYZ(min(modelucsx), min(modelucsy), 0.0)
-                    cropmax = DB.XYZ(max(modelucsx), max(modelucsy), 0.0)
-
-                    # get vp min max points in sheetUCS
-                    ol = selvp.GetBoxOutline()
-                    vptempmin = ol.MinimumPoint
-                    vpmin = DB.XYZ(vptempmin.X + vpboundaryoffset,
-                                   vptempmin.Y + vpboundaryoffset, 0.0)
-                    vptempmax = ol.MaximumPoint
-                    vpmax = DB.XYZ(vptempmax.X - vpboundaryoffset,
-                                   vptempmax.Y - vpboundaryoffset, 0.0)
-
-                    transmatrix.sourcemin = vpmin
-                    transmatrix.sourcemax = vpmax
-                    transmatrix.destmin = cropmin
-                    transmatrix.destmax = cropmax
-
-                    revtransmatrix.sourcemin = cropmin
-                    revtransmatrix.sourcemax = cropmax
-                    revtransmatrix.destmin = vpmin
-                    revtransmatrix.destmax = vpmax
-
-                    selview.CropBoxActive = cboxactive
-                    selview.CropBoxVisible = cboxvisible
-                    cboxannoparam.Set(cboxannostate)
-
-                    if viewspecificelements:
-                        selview.UnhideElements(
-                            List[DB.ElementId](viewspecificelements)
-                            )
+    transmatrix = vpu.TransformationMatrix()
+    revtransmatrix = vpu.TransformationMatrix()
 
     datafile = \
         script.get_document_data_file(file_id='SaveViewportLocation',
                                       file_ext='pym',
                                       add_cmd_name=False)
 
-    selected_ids = revit.get_selection().element_ids
+    view = revit.doc.GetElement(vport.ViewId)
+    if view is not None and isinstance(view, DB.ViewPlan):
+        with revit.TransactionGroup('Copy Viewport Location'):
+            vpu.set_tansform_matrix(vport, view)
+            center = vport.GetBoxCenter()
+            modelpoint = vpu.sheet_to_view_transform(center)
+            center_pt = vpu.Point(center.X, center.Y, center.Z)
+            model_pt = vpu.Point(modelpoint.X, modelpoint.Y, modelpoint.Z)
+            with open(datafile, 'wb') as fp:
+                originalviewtype = 'ViewPlan'
+                pickle.dump(originalviewtype, fp)
+                pickle.dump(center_pt, fp)
+                pickle.dump(model_pt, fp)
 
-    if len(selected_ids) == 1:
-        vport_id = selected_ids[0]
-        try:
-            vport = revit.doc.GetElement(vport_id)
-        except Exception:
-            forms.alert('Select exactly one viewport.')
-
-        if isinstance(vport, DB.Viewport):
-            view = revit.doc.GetElement(vport.ViewId)
-            if view is not None and isinstance(view, DB.ViewPlan):
-                with revit.TransactionGroup('Copy Viewport Location'):
-                    set_tansform_matrix(vport, view)
-                    center = vport.GetBoxCenter()
-                    modelpoint = sheet_to_view_transform(center)
-                    center_pt = Point(center.X, center.Y, center.Z)
-                    model_pt = Point(modelpoint.X, modelpoint.Y, modelpoint.Z)
-                    with open(datafile, 'wb') as fp:
-                        originalviewtype = 'ViewPlan'
-                        pickle.dump(originalviewtype, fp)
-                        pickle.dump(center_pt, fp)
-                        pickle.dump(model_pt, fp)
-
-            elif view is not None and isinstance(view, DB.ViewDrafting):
-                center = vport.GetBoxCenter()
-                center_pt = Point(center.X, center.Y, center.Z)
-                with open(datafile, 'wb') as fp:
-                    originalviewtype = 'ViewDrafting'
-                    pickle.dump(originalviewtype, fp)
-                    pickle.dump(center_pt, fp)
-            else:
-                forms.alert('This tool only works with Plan, '
-                            'RCP, and Detail views and viewports.')
+    elif view is not None and isinstance(view, DB.ViewDrafting):
+        center = vport.GetBoxCenter()
+        center_pt = vpu.Point(center.X, center.Y, center.Z)
+        with open(datafile, 'wb') as fp:
+            originalviewtype = 'ViewDrafting'
+            pickle.dump(originalviewtype, fp)
+            pickle.dump(center_pt, fp)
     else:
-        forms.alert('Select exactly one viewport.')
+        forms.alert('This tool only works with Plan, '
+                    'RCP, and Detail views and viewports.')
 
 elif selected_option == 'Visibility Graphics':
     datafile = \

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
@@ -1,54 +1,15 @@
-import os
-import os.path as op
 import pickle
 
 from pyrevit import HOST_APP
-from pyrevit.framework import List
-from pyrevit import revit, DB, UI
+from pyrevit import revit, DB
 from pyrevit import forms
 from pyrevit import script
-
+import viewport_placement_utils as vpu
 
 __doc__ = 'Applies the copied state to the active view. '\
           'This works in conjunction with the Copy State tool.'
 
 logger = script.get_logger()
-
-
-class Point:
-    def __init__(self, x, y, z):
-        self.x = x
-        self.y = y
-        self.z = z
-
-
-class BasePoint:
-    def __init__(self):
-        self.x = 0
-        self.y = 0
-
-
-class BBox:
-    def __init__(self):
-        self.minx = 0
-        self.miny = 0
-        self.minz = 0
-        self.maxx = 0
-        self.maxy = 0
-        self.maxz = 0
-
-
-class ViewOrient:
-    def __init__(self):
-        self.eyex = 0
-        self.eyey = 0
-        self.eyez = 0
-        self.forwardx = 0
-        self.forwardy = 0
-        self.forwardz = 0
-        self.upx = 0
-        self.upy = 0
-        self.upz = 0
 
 
 class OriginalIsViewDrafting(Exception):
@@ -57,14 +18,6 @@ class OriginalIsViewDrafting(Exception):
 
 class OriginalIsViewPlan(Exception):
     pass
-
-
-class TransformationMatrix:
-    def __init__(self):
-        self.sourcemin = None
-        self.sourcemax = None
-        self.destmin = None
-        self.destmax = None
 
 
 def unpickle_line_list(all_cloops_data):
@@ -163,215 +116,85 @@ elif selected_switch == 'Viewport Placement on Sheet':
     pyrevit Notice:
     pyrevit: repository at https://github.com/eirannejad/pyrevit
     """
+    vport = vpu.select_viewport()
+
     PINAFTERSET = False
     originalviewtype = ''
 
     selview = selvp = None
     vpboundaryoffset = 0.01
     activeSheet = revit.uidoc.ActiveGraphicalView
-    transmatrix = TransformationMatrix()
-    revtransmatrix = TransformationMatrix()
-
-    def sheet_to_view_transform(sheetcoord):
-        global transmatrix
-        newx = \
-            transmatrix.destmin.X \
-            + (((sheetcoord.X - transmatrix.sourcemin.X)
-                * (transmatrix.destmax.X - transmatrix.destmin.X))
-               / (transmatrix.sourcemax.X - transmatrix.sourcemin.X))
-
-        newy = \
-            transmatrix.destmin.Y \
-            + (((sheetcoord.Y - transmatrix.sourcemin.Y)
-                * (transmatrix.destmax.Y - transmatrix.destmin.Y))
-               / (transmatrix.sourcemax.Y - transmatrix.sourcemin.Y))
-
-        return DB.XYZ(newx, newy, 0.0)
-
-    def view_to_sheet_transform(modelcoord):
-        global revtransmatrix
-        newx = \
-            revtransmatrix.destmin.X \
-            + (((modelcoord.X - revtransmatrix.sourcemin.X)
-                * (revtransmatrix.destmax.X - revtransmatrix.destmin.X))
-               / (revtransmatrix.sourcemax.X - revtransmatrix.sourcemin.X))
-
-        newy = \
-            revtransmatrix.destmin.Y \
-            + (((modelcoord.Y - revtransmatrix.sourcemin.Y)
-                * (revtransmatrix.destmax.Y - revtransmatrix.destmin.Y))
-               / (revtransmatrix.sourcemax.Y - revtransmatrix.sourcemin.Y))
-
-        return DB.XYZ(newx, newy, 0.0)
-
-    def set_tansform_matrix(selvp, selview):
-        # making sure the cropbox is active.
-        cboxactive = selview.CropBoxActive
-        cboxvisible = selview.CropBoxVisible
-        cboxannoparam = selview.get_Parameter(
-            DB.BuiltInParameter.VIEWER_ANNOTATION_CROP_ACTIVE
-            )
-        cboxannostate = cboxannoparam.AsInteger()
-        curviewelements = \
-            DB.FilteredElementCollector(revit.doc)\
-              .OwnedByView(selview.Id)\
-              .WhereElementIsNotElementType()\
-              .ToElements()
-
-        viewspecificelements = []
-        for el in curviewelements:
-            if el.ViewSpecific \
-                    and not el.IsHidden(selview) \
-                    and el.CanBeHidden(selview) \
-                    and el.Category is not None:
-                viewspecificelements.append(el.Id)
-
-        basepoints = DB.FilteredElementCollector(revit.doc)\
-                       .OfClass(DB.BasePoint)\
-                       .WhereElementIsNotElementType()\
-                       .ToElements()
-
-        excludecategories = ['Survey Point',
-                             'Project Base Point']
-        for el in basepoints:
-            if el.Category and el.Category.Name in excludecategories:
-                viewspecificelements.append(el.Id)
-
-        with revit.TransactionGroup('Activate & Read Cropbox Boundary'):
-            with revit.Transaction('Hiding all 2d elements'):
-                if viewspecificelements:
-                    try:
-                        selview.HideElements(List[DB.ElementId](viewspecificelements))
-                    except Exception as e:
-                        logger.debug(e)
-
-            with revit.Transaction('Activate & Read Cropbox Boundary'):
-                selview.CropBoxActive = True
-                selview.CropBoxVisible = False
-                cboxannoparam.Set(0)
-
-                # get view min max points in modelUCS.
-                modelucsx = []
-                modelucsy = []
-                crsm = selview.GetCropRegionShapeManager()
-
-                cllist = crsm.GetCropShape()
-                if len(cllist) == 1:
-                    cl = cllist[0]
-                    for l in cl:
-                        modelucsx.append(l.GetEndPoint(0).X)
-                        modelucsy.append(l.GetEndPoint(0).Y)
-                    cropmin = DB.XYZ(min(modelucsx), min(modelucsy), 0.0)
-                    cropmax = DB.XYZ(max(modelucsx), max(modelucsy), 0.0)
-
-                    # get vp min max points in sheetUCS
-                    ol = selvp.GetBoxOutline()
-                    vptempmin = ol.MinimumPoint
-                    vpmin = DB.XYZ(vptempmin.X + vpboundaryoffset,
-                                   vptempmin.Y + vpboundaryoffset, 0.0)
-                    vptempmax = ol.MaximumPoint
-                    vpmax = DB.XYZ(vptempmax.X - vpboundaryoffset,
-                                   vptempmax.Y - vpboundaryoffset, 0.0)
-
-                    transmatrix.sourcemin = vpmin
-                    transmatrix.sourcemax = vpmax
-                    transmatrix.destmin = cropmin
-                    transmatrix.destmax = cropmax
-
-                    revtransmatrix.sourcemin = cropmin
-                    revtransmatrix.sourcemax = cropmax
-                    revtransmatrix.destmin = vpmin
-                    revtransmatrix.destmax = vpmax
-
-                    selview.CropBoxActive = cboxactive
-                    selview.CropBoxVisible = cboxvisible
-                    cboxannoparam.Set(cboxannostate)
-
-                    if viewspecificelements:
-                        selview.UnhideElements(
-                            List[DB.ElementId](viewspecificelements)
-                            )
+    transmatrix = vpu.TransformationMatrix()
+    revtransmatrix = vpu.TransformationMatrix()
 
     datafile = \
         script.get_document_data_file(file_id='SaveViewportLocation',
                                       file_ext='pym',
                                       add_cmd_name=False)
-
-    selected_ids = revit.get_selection().element_ids
-
-    if len(selected_ids) == 1:
-        vport_id = selected_ids[0]
-        try:
-            vport = revit.doc.GetElement(vport_id)
-        except Exception:
-            DB.TaskDialog.Show('pyrevit',
-                               'Select exactly one viewport.')
-
-        if isinstance(vport, DB.Viewport):
-            view = revit.doc.GetElement(vport.ViewId)
-            if view is not None and isinstance(view, DB.ViewPlan):
-                with revit.TransactionGroup('Paste Viewport Location'):
-                    set_tansform_matrix(vport, view)
-                    try:
-                        with open(datafile, 'rb') as fp:
-                            originalviewtype = pickle.load(fp)
-                            if originalviewtype == 'ViewPlan':
-                                savedcen_pt = pickle.load(fp)
-                                savedmdl_pt = pickle.load(fp)
-                            else:
-                                raise OriginalIsViewDrafting
-                    except IOError:
-                        forms.alert('Could not find saved viewport '
-                                    'placement.\n'
-                                    'Copy a Viewport Placement first.')
-                    except OriginalIsViewDrafting:
-                        forms.alert('Viewport placement info is from a '
-                                    'drafting view and can not '
-                                    'be applied here.')
+                                      
+    view = revit.doc.GetElement(vport.ViewId)
+    if view is not None and isinstance(view, DB.ViewPlan):
+        with revit.TransactionGroup('Paste Viewport Location'):
+            vpu.set_tansform_matrix(vport, view, vpboundaryoffset)
+            try:
+                with open(datafile, 'rb') as fp:
+                    originalviewtype = pickle.load(fp)
+                    if originalviewtype == 'ViewPlan':
+                        savedcen_pt = pickle.load(fp)
+                        savedmdl_pt = pickle.load(fp)
                     else:
-                        savedcenter_pt = DB.XYZ(savedcen_pt.x,
-                                                savedcen_pt.y,
-                                                savedcen_pt.z)
-                        savedmodel_pt = DB.XYZ(savedmdl_pt.x,
-                                               savedmdl_pt.y,
-                                               savedmdl_pt.z)
-                        with revit.Transaction('Apply Viewport Placement'):
-                            center = vport.GetBoxCenter()
-                            centerdiff = \
-                                view_to_sheet_transform(savedmodel_pt) - center
-                            vport.SetBoxCenter(savedcenter_pt - centerdiff)
-                            if PINAFTERSET:
-                                vport.Pinned = True
-
-            elif view is not None and isinstance(view, DB.ViewDrafting):
-                try:
-                    with open(datafile, 'rb') as fp:
-                        originalviewtype = pickle.load(fp)
-                        if originalviewtype == 'ViewDrafting':
-                            savedcen_pt = pickle.load(fp)
-                        else:
-                            raise OriginalIsViewPlan
-                except IOError:
-                    forms.alert('Could not find saved viewport '
-                                'placement.\n'
-                                'Copy a Viewport Placement first.')
-                except OriginalIsViewPlan:
-                    forms.alert('Viewport placement info is from '
-                                'a model view and can not be '
-                                'applied here.')
-                else:
-                    savedcenter_pt = DB.XYZ(savedcen_pt.x,
-                                            savedcen_pt.y,
-                                            savedcen_pt.z)
-                    with revit.Transaction('Apply Viewport Placement'):
-                        vport.SetBoxCenter(savedcenter_pt)
-                        if PINAFTERSET:
-                            vport.Pinned = True
+                        raise OriginalIsViewDrafting
+            except IOError:
+                forms.alert('Could not find saved viewport '
+                            'placement.\n'
+                            'Copy a Viewport Placement first.')
+            except OriginalIsViewDrafting:
+                forms.alert('Viewport placement info is from a '
+                            'drafting view and can not '
+                            'be applied here.')
             else:
-                forms.alert('This tool only works with Plan, '
-                            'RCP, and Detail views and viewports.')
+                savedcenter_pt = DB.XYZ(savedcen_pt.x,
+                                        savedcen_pt.y,
+                                        savedcen_pt.z)
+                savedmodel_pt = DB.XYZ(savedmdl_pt.x,
+                                       savedmdl_pt.y,
+                                       savedmdl_pt.z)
+                with revit.Transaction('Apply Viewport Placement'):
+                    center = vport.GetBoxCenter()
+                    centerdiff = \
+                        vpu.view_to_sheet_transform(savedmodel_pt) - center
+                    vport.SetBoxCenter(savedcenter_pt - centerdiff)
+                    if PINAFTERSET:
+                        vport.Pinned = True
+
+    elif view is not None and isinstance(view, DB.ViewDrafting):
+        try:
+            with open(datafile, 'rb') as fp:
+                originalviewtype = pickle.load(fp)
+                if originalviewtype == 'ViewDrafting':
+                    savedcen_pt = pickle.load(fp)
+                else:
+                    raise OriginalIsViewPlan
+        except IOError:
+            forms.alert('Could not find saved viewport '
+                        'placement.\n'
+                        'Copy a Viewport Placement first.')
+        except OriginalIsViewPlan:
+            forms.alert('Viewport placement info is from '
+                        'a model view and can not be '
+                        'applied here.')
+        else:
+            savedcenter_pt = DB.XYZ(savedcen_pt.x,
+                                    savedcen_pt.y,
+                                    savedcen_pt.z)
+            with revit.Transaction('Apply Viewport Placement'):
+                vport.SetBoxCenter(savedcenter_pt)
+                if PINAFTERSET:
+                    vport.Pinned = True
     else:
-        forms.alert('Select exactly one viewport.')
+        forms.alert('This tool only works with Plan, '
+                    'RCP, and Detail views and viewports.')
+
 
 elif selected_switch == 'Visibility Graphics':
     datafile = \

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
@@ -124,8 +124,6 @@ elif selected_switch == 'Viewport Placement on Sheet':
     selview = selvp = None
     vpboundaryoffset = 0.01
     activeSheet = revit.uidoc.ActiveGraphicalView
-    transmatrix = vpu.TransformationMatrix()
-    revtransmatrix = vpu.TransformationMatrix()
 
     datafile = \
         script.get_document_data_file(file_id='SaveViewportLocation',
@@ -135,7 +133,7 @@ elif selected_switch == 'Viewport Placement on Sheet':
     view = revit.doc.GetElement(vport.ViewId)
     if view is not None and isinstance(view, DB.ViewPlan):
         with revit.TransactionGroup('Paste Viewport Location'):
-            vpu.set_tansform_matrix(vport, view, vpboundaryoffset)
+            revtransmatrix = vpu.set_tansform_matrix(vport, view, vpboundaryoffset, reverse=True)
             try:
                 with open(datafile, 'rb') as fp:
                     originalviewtype = pickle.load(fp)
@@ -162,7 +160,7 @@ elif selected_switch == 'Viewport Placement on Sheet':
                 with revit.Transaction('Apply Viewport Placement'):
                     center = vport.GetBoxCenter()
                     centerdiff = \
-                        vpu.view_to_sheet_transform(savedmodel_pt) - center
+                        vpu.transform_by_matrix(savedmodel_pt, revtransmatrix) - center
                     vport.SetBoxCenter(savedcenter_pt - centerdiff)
                     if PINAFTERSET:
                         vport.Pinned = True

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/viewport_placement_utils.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/viewport_placement_utils.py
@@ -1,0 +1,179 @@
+from pyrevit import revit, script, forms, DB
+from pyrevit.framework import List
+
+logger = script.get_logger()
+
+class Point:
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+class BBox:
+    def __init__(self):
+        self.minx = 0
+        self.miny = 0
+        self.minz = 0
+        self.maxx = 0
+        self.maxy = 0
+        self.maxz = 0
+
+
+class ViewOrient:
+    def __init__(self):
+        self.eyex = 0
+        self.eyey = 0
+        self.eyez = 0
+        self.forwardx = 0
+        self.forwardy = 0
+        self.forwardz = 0
+        self.upx = 0
+        self.upy = 0
+        self.upz = 0
+
+
+
+class TransformationMatrix:
+    def __init__(self):
+        self.sourcemin = None
+        self.sourcemax = None
+        self.destmin = None
+        self.destmax = None
+
+
+def sheet_to_view_transform(sheetcoord):
+    global transmatrix
+    newx = \
+        transmatrix.destmin.X \
+        + (((sheetcoord.X - transmatrix.sourcemin.X)
+            * (transmatrix.destmax.X - transmatrix.destmin.X))
+           / (transmatrix.sourcemax.X - transmatrix.sourcemin.X))
+
+    newy = \
+        transmatrix.destmin.Y \
+        + (((sheetcoord.Y - transmatrix.sourcemin.Y)
+            * (transmatrix.destmax.Y - transmatrix.destmin.Y))
+           / (transmatrix.sourcemax.Y - transmatrix.sourcemin.Y))
+
+    return DB.XYZ(newx, newy, 0.0)
+
+
+def view_to_sheet_transform(modelcoord):
+    global revtransmatrix
+    newx = \
+        revtransmatrix.destmin.X \
+        + (((modelcoord.X - revtransmatrix.sourcemin.X)
+            * (revtransmatrix.destmax.X - revtransmatrix.destmin.X))
+           / (revtransmatrix.sourcemax.X - revtransmatrix.sourcemin.X))
+
+    newy = \
+        revtransmatrix.destmin.Y \
+        + (((modelcoord.Y - revtransmatrix.sourcemin.Y)
+            * (revtransmatrix.destmax.Y - revtransmatrix.destmin.Y))
+           / (revtransmatrix.sourcemax.Y - revtransmatrix.sourcemin.Y))
+
+    return DB.XYZ(newx, newy, 0.0)
+
+
+def set_tansform_matrix(selvp, selview, vpboundaryoffset):
+    # making sure the cropbox is active.
+    cboxactive = selview.CropBoxActive
+    cboxvisible = selview.CropBoxVisible
+    cboxannoparam = selview.get_Parameter(
+        DB.BuiltInParameter.VIEWER_ANNOTATION_CROP_ACTIVE
+        )
+    cboxannostate = cboxannoparam.AsInteger()
+    curviewelements = \
+        DB.FilteredElementCollector(revit.doc)\
+          .OwnedByView(selview.Id)\
+          .WhereElementIsNotElementType()\
+          .ToElements()
+
+    viewspecificelements = []
+    for el in curviewelements:
+        if el.ViewSpecific \
+                and not el.IsHidden(selview) \
+                and el.CanBeHidden(selview) \
+                and el.Category is not None:
+            viewspecificelements.append(el.Id)
+
+    basepoints = DB.FilteredElementCollector(revit.doc)\
+                   .OfClass(DB.BasePoint)\
+                   .WhereElementIsNotElementType()\
+                   .ToElements()
+
+    excludecategories = ['Survey Point',
+                         'Project Base Point']
+    for el in basepoints:
+        if el.Category and el.Category.Name in excludecategories:
+            viewspecificelements.append(el.Id)
+
+    with revit.TransactionGroup('Activate & Read Cropbox Boundary'):
+        with revit.Transaction('Hiding all 2d elements'):
+            if viewspecificelements:
+                try:
+                    selview.HideElements(List[DB.ElementId](viewspecificelements))
+                except Exception as e:
+                    logger.debug(e)
+
+        with revit.Transaction('Activate & Read Cropbox Boundary'):
+            selview.CropBoxActive = True
+            selview.CropBoxVisible = False
+            cboxannoparam.Set(0)
+
+            # get view min max points in modelUCS.
+            modelucsx = []
+            modelucsy = []
+            crsm = selview.GetCropRegionShapeManager()
+
+            cllist = crsm.GetCropShape()
+            if len(cllist) == 1:
+                cl = cllist[0]
+                for l in cl:
+                    modelucsx.append(l.GetEndPoint(0).X)
+                    modelucsy.append(l.GetEndPoint(0).Y)
+                cropmin = DB.XYZ(min(modelucsx), min(modelucsy), 0.0)
+                cropmax = DB.XYZ(max(modelucsx), max(modelucsy), 0.0)
+
+                # get vp min max points in sheetUCS
+                ol = selvp.GetBoxOutline()
+                vptempmin = ol.MinimumPoint
+                vpmin = DB.XYZ(vptempmin.X + vpboundaryoffset,
+                               vptempmin.Y + vpboundaryoffset, 0.0)
+                vptempmax = ol.MaximumPoint
+                vpmax = DB.XYZ(vptempmax.X - vpboundaryoffset,
+                               vptempmax.Y - vpboundaryoffset, 0.0)
+
+                transmatrix.sourcemin = vpmin
+                transmatrix.sourcemax = vpmax
+                transmatrix.destmin = cropmin
+                transmatrix.destmax = cropmax
+
+                revtransmatrix.sourcemin = cropmin
+                revtransmatrix.sourcemax = cropmax
+                revtransmatrix.destmin = vpmin
+                revtransmatrix.destmax = vpmax
+
+                selview.CropBoxActive = cboxactive
+                selview.CropBoxVisible = cboxvisible
+                cboxannoparam.Set(cboxannostate)
+
+                if viewspecificelements:
+                    selview.UnhideElements(List[DB.ElementId](viewspecificelements))
+
+
+def select_viewport():
+    vport = None
+    selected_ids = revit.get_selection().element_ids
+    if selected_ids:
+        vport_id = selected_ids[0]
+        try:
+            vport = revit.doc.GetElement(vport_id)
+        except:
+            pass
+        if not isinstance(vport_id, DB.Viewport):
+            vport = None
+    if not vport:
+        forms.alert('Select exactly one viewport.', exitscript=True)
+    return vport


### PR DESCRIPTION
Hey Ehsan, 
Hey Gui

I've got several feedbacks on "Copy/Paste state - Copy viewport position" tool from my colleagues.
So am trying to make it work better in certain cases (but the work is still in progress)

Therefore I think it would be great if @gtalarico would have a look as well.

Please, let me know if I can break something or if I shouldn't touch it at all.

- [x] support Sheets with different TitleBlock locations

- [x] hide viewport on a sheet when getting a cropbox

- [x] allow to choose ProjectBasePoint as origin (instead of Cropbox)

- [ ] show the option "By ProjectBasePoint" only if possible

- [ ] allow to choose cropbox alignment (top left, bottom left etc.) (optional, with __shiftclick__?)

- [ ] support Sections/Elevation views (by project base point)

- [ ] support active view (not selected viewport)

- [ ] support Pasting to multiple selected elements at once (relevant for all Copy/Paste modes)


Thank you too