### PR TITLE
Failure swallower context

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Family QuickCheck.pushbutton/FamilyQuickcheck_script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Family QuickCheck.pushbutton/FamilyQuickcheck_script.py
@@ -6,15 +6,24 @@ github.com/frederic-beaupere
 """
 #pylint: disable=invalid-name,import-error,superfluous-parens,broad-except
 
-from pyrevit import revit, DB
-from pyrevit import script
+from pyrevit import revit, script, DB, forms
+from pyrevit.revit import FailureSwallowerContext
 
 
 __author__ = 'Frederic Beaupere\n{{author}}'
 
-
 logger = script.get_logger()
 output = script.get_output()
+
+checked_families = 0
+count_errors = 0
+count_warnings = 0
+cancelled = False
+
+def update_output_title():
+    output.set_title("Family QuickCheck (Err:{} Warn:{})"
+                     .format(count_errors, count_warnings))
+
 
 all_families = DB.FilteredElementCollector(revit.doc)\
                  .OfClass(DB.Family)\
@@ -22,21 +31,41 @@ all_families = DB.FilteredElementCollector(revit.doc)\
 
 editable_families = [x for x in all_families if x.IsEditable]
 total_count = len(editable_families)
-checked_families = 0
 
 output.reset_progress()
 
-for fam in editable_families:
-    fam_name = revit.query.get_name(fam)
-    logger.debug("attempt to open family: %s", fam_name)
+with FailureSwallowerContext(force=True) as swallower:
     try:
-        fam_doc = revit.doc.EditFamily(fam)
-        fam_doc.Close(False)
-        print(":white_heavy_check_mark: %s" % fam_name)
+        for fam in editable_families:
+            # cancel if output window was closed
+            if output.window.ClosedByUser:
+                break
+            fam_name = revit.query.get_name(fam)
+            logger.debug("attempt to open family: %s", fam_name)
+            try:
+                fam_doc = revit.doc.EditFamily(fam)
+                fam_doc.Close(False)
+                swallowed_warnings = swallower.get_swallowed()
+                if swallowed_warnings:
+                    logger.warning(":warning: %s | warning: %s", fam.Name,
+                                   ", ".join(set(swallowed_warnings)))
+                    count_warnings += 1
+                    update_output_title()
+                else:
+                    print(":white_heavy_check_mark: %s" % fam_name)
+            except Exception as ex:
+                logger.error(":cross_mark: %s | error: %s", fam.Name, ex)
+                count_errors += 1
+                update_output_title()
+            checked_families += 1
+            output.update_progress(checked_families, total_count)
     except Exception as ex:
-        logger.error(":cross_mark: %s | error: %s", fam.Name, str(ex))
-
-    checked_families += 1
-    output.update_progress(checked_families, total_count)
+        logger.error(ex)
 
 print("\nChecked: {} families.".format(checked_families))
+if not count_errors and count_warnings:
+    output.log_success("Finished. No errors found.")
+elif count_errors:
+    output.log_warning("{} families seem to be corrupted".format(count_errors))
+if count_warnings:
+    logger.warning("{} families have warnings".format(count_warnings))

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Save Families.pushbutton/SaveFamilies_script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Save Families.pushbutton/SaveFamilies_script.py
@@ -4,41 +4,83 @@ import os.path as op
 from pyrevit import revit
 from pyrevit import forms
 from pyrevit import script
+from pyrevit.revit import FailureSwallowerContext
 
 
 logger = script.get_logger()
 output = script.get_output()
 
-
 family_dict = {}
+saved_families = 0
+count_errors = 0
+count_warnings = 0
+
+
 for family in revit.query.get_families(revit.doc, only_editable=True):
     if family.FamilyCategory:
         family_dict[
             "%s: %s" % (family.FamilyCategory.Name, family.Name)
             ] = family
+if not family_dict:
+    script.exit()
 
-if family_dict:
-    selected_families = \
-        forms.SelectFromList.show(
-            sorted(family_dict.keys()),
-            title="Select Families to Save",
-            multiselect=True)
+selected_families = \
+    forms.SelectFromList.show(
+        sorted(family_dict.keys()),
+        title="Select Families to Save",
+        multiselect=True)
+if not selected_families:
+    forms.alert("Can not find any families that can be saved in this model.",
+                exitscript=True)
 
-    if selected_families:
-        dest_folder = forms.pick_folder()
-        if dest_folder:
-            total_work = len(selected_families)
+dest_folder = forms.pick_folder()
+if not dest_folder:
+    script.exit()
+
+total_work = len(selected_families)
+
+with forms.ProgressBar(title="Saving families..."
+                             " ({value} of {max_value})",
+                       cancellable=True) as pb:
+    with FailureSwallowerContext() as swallower:
+        try:
             for idx, family in enumerate(
                     [family_dict[x] for x in selected_families]):
-                family_filepath = op.join(dest_folder, family.Name + ".rfa")
+                if pb.cancelled:
+                    break
+                family_filepath = op.join(dest_folder,
+                                          family.Name + ".rfa")
                 logger.info("Saving %s ..." % family_filepath)
                 try:
                     family_doc = revit.doc.EditFamily(family)
                     family_doc.SaveAs(family_filepath)
                     family_doc.Close(False)
+                    saved_families += 1
                 except Exception as ex:
-                    logger.error('Error saving family %s | %s',
+                    logger.error("Error saving family %s | %s",
                                  family_filepath, ex)
-                output.update_progress(idx + 1, total_work)
+                    count_errors += 1
+                # check if warnings were swallowed
+                swallowed_warnings = swallower.get_swallowed()
+                if swallowed_warnings:
+                    logger.warning("Warnings in family %s | %s",
+                                   family.Name,
+                                   ", ".join(set(swallowed_warnings)))
+                    count_warnings += 1
+                pb.update_progress(idx + 1, total_work)
+        except Exception as ex:
+            logger.error(ex)
+# show results
+if saved_families == len(selected_families):
+    forms.alert("Saved: {} families.".format(saved_families))
 else:
-    forms.alert("Can not find any families that can be saved in this model.")
+    forms.alert("Saved: {} of {} families."
+                .format(saved_families, len(selected_families)))
+if not count_errors and count_warnings and saved_families:
+    output.log_success("Finished")
+elif count_errors:
+    output.log_warning("{} families cannot be saved"
+                       .format(count_errors))
+if count_warnings:
+    logger.warning("{} families have warnings"
+                   .format(count_warnings))


### PR DESCRIPTION
Hey Ehsan!

Here I wanted to solve the problem of pop ups with warning while you're checking or exporting families.

I know there is an option `swallow_errors` for `revit.db.transaction`. I wanted to have something similar to apply without transaction. Here is a usage sample:

```
with FailureSwallowerContext(force=True) as swallower: 
   # `force` solves to resolve not only warnings but errors as well
   for fam in families:
      revit.doc.EditFamily(fam)
      if swallower.get_swallowed():
         logger.warn("Warnings swallowed")
```

I've also implemented it into "Families Save" and "QuickCheck" tools.

Please have a look. There are my comments in review
