### PR TITLE
Fix pick_file, pick_excel_file

### DIFF
--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -2229,7 +2229,7 @@ def pick_folder(title=None):
             return fb_dlg.SelectedPath
 
 
-def pick_file(file_ext='', files_filter='', init_dir='',
+def pick_file(file_ext='*', files_filter='', init_dir='',
               restore_dir=True, multi_file=False, unc_paths=False):
     r"""Pick file dialog to select a destination file.
 
@@ -2328,8 +2328,7 @@ def pick_excel_file(save=False):
     """
     if save:
         return save_file(file_ext='xlsx')
-    return pick_file(files_filter='All Files (*.*)|*.*|'
-                     'Excel Workbook (*.xlsx)|*.xlsx|'
+    return pick_file(files_filter='Excel Workbook (*.xlsx)|*.xlsx|'
                      'Excel 97-2003 Workbook|*.xls')
 
 


### PR DESCRIPTION
Currently, `pick_file` has empty default `file_ext`, so when we `pick_file()`, filter would be `*.` (not `*.*` as it should be) meaning no file is available for selection.
Similarly, `pick_excel_file` should have its filter fixed to only `xlsx` and `xls`.
This PR fix that behaviour.
Please have a look @eirannejad 
Thanks!