### PR TITLE
Manage Packages - sorting revisions by Sequence number

### DIFF
--- a/extensions/pyRevitTags.extension/lib/pkgmgr.py
+++ b/extensions/pyRevitTags.extension/lib/pkgmgr.py
@@ -176,13 +176,22 @@ def get_commit_points():
                         idx=idx,
                         name=docpkg.pkg_name))
     # grab revisions
+    # added x.SequenceNumber instead of x.Description
     docrevs = revit.query.get_revisions()
+    docrevsFiltered = []
+    for i, x in enumerate(docrevs):
+        # filter just Alphanumeric revisions
+        # if str(x.NumberType) == 'Alphanumeric':
+        #     docrevsFiltered.append(x)
+        docrevsFiltered.append(x)
+    sortedDocrevsFiltered = sorted(docrevsFiltered, key=lambda x: x.SequenceNumber)
+
     commit_points.extend([
         CommitPoint(cptype=CommitPointTypes.Revision,
                     target=x.Id.IntegerValue,
                     idx=last_docpkg_idx + i + 1,
-                    name=x.Description)
-        for i, x in enumerate(docrevs)
+                    name=x.SequenceNumber)
+        for i, x in enumerate(sortedDocrevsFiltered)
         ])
 
     sorted_cpoints = sorted(commit_points, key=lambda x: x.idx)

--- a/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/Manage Packages.pushbutton/script.py
+++ b/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/Manage Packages.pushbutton/script.py
@@ -148,7 +148,7 @@ class SheetItem(object):
 
     @staticmethod
     def build_commit_sort_param(commit_point):
-        return 'sort_{}{}'.format(commit_point.cptype, commit_point.idx)
+        return 'sort_{}{}'.format(commit_point.cptype, commit_point.name)
 
     def get_order(self, param_name):
         return self._csheet.revit_sheet.LookupParameter(param_name).AsInteger()
@@ -236,7 +236,6 @@ class ManagePackagesWindow(forms.WPFWindow):
             commit_column = Windows.Controls.DataGridTemplateColumn()
             commit_column.Header = commit_point.name
             commit_column.CanUserSort = True
-            commit_column.MinWidth = 50
             commit_column.SortMemberPath = sort_param
             # commit_column.SortDirection = \
             #     ComponentModel.ListSortDirection.Descending


### PR DESCRIPTION
Hi,
in our company we use pyRevit. We started to use Manage Packages feature to manage revisions. I noted that if you rearange Revisions (Move Up & Move Down) they won't be sorted as they are in Revit. It seems they are sorted by ID now.

I think sorting revisions by Sequence number could fix this issue. I tried to fix it. After some testing on our larger projects it seems it works.

Another change I would propose is replace original Description in schedule header by Sequence number. I know that every company has different workflow. We f.e. write few words describing the changes in the revisions in the description. This makes project with few dozens of revisions very untidy and you need to scroll a lot. Originally I tried to rotate text of the heading by 90°. But I think showing Sequence number might be maybe better option. Hopefully you will find your revision faster.

**Revisions not sorted properly**
![1](https://user-images.githubusercontent.com/61110750/74670253-0e551000-51a9-11ea-8e3e-347e6ab03872.PNG)

**Exact same file - the order of the revisions should be the same but it isn't**
![Capture](https://user-images.githubusercontent.com/61110750/74670269-18770e80-51a9-11ea-8a04-87eea5d38fc3.PNG)

**Suggested change - revisions are sorted by Sequence Number and Sequence Number is in the schedulle heading.**
![460758066-Capture](https://user-images.githubusercontent.com/61110750/74683262-a0b8dc00-51c8-11ea-8b64-fe591db9e307.png)
I also added option to view just alphanumeric revisions as we f.e. use numeric revisions for revision clouds which we don't want to publish or track. I commented these lines as it is most likely not straightforward and not useful for anybody.

The reason of doing this was too long time of processing all the data in larger project. For examle in project with over 100 revisions and 800 sheets it took a few minutes to open the Manage Packages window. When I played with it I noticed that maybe number of commit points are crucial and not number of revisions or sheets. I will try to add some kind of filtering before window opens to cut the time for larger projects.

Sorry for long message and thank you for developing pyRevit :)
David