### PR TITLE
add Revit 2020.2.1 (New Install) build number

### DIFF
--- a/bin/pyrevit-hosts.json
+++ b/bin/pyrevit-hosts.json
@@ -1094,4 +1094,15 @@
     "build": "20200220_1100",
     "target": "x64",
     "notes": "https://help.autodesk.com/view/RVT/2021/ENU/?guid=RevitReleaseNotes_2021release_html"
+}, {
+    "meta": {
+        "schema": "1.0",
+        "source": "https://help.autodesk.com/view/RVT/2020/ENU/?guid=RevitReleaseNotes_2020updates_html"
+    },
+    "product": "Autodesk Revit",
+    "release": "2020.2.1 (New Install)",
+    "version": "20.2.12.1",
+    "build": "20200210_1400",
+    "target": "x64",
+    "notes": "https://help.autodesk.com/view/RVT/2020/ENU/?guid=RevitReleaseNotes_2020updates_html"
 }]


### PR DESCRIPTION
Hi,
I've added my Revit installation build number to the pyrevit-hosts.json.

As a side note (I've also commented it on the notion "share revit build numbers" page), there's a [page on the Autodesk Knowledge](https://knowledge.autodesk.com/support/revit-products/learn-explore/caas/sfdcarticles/sfdcarticles/How-to-tie-the-Build-number-with-the-Revit-update.html) that holds all the versions and build numbers from 2016 (I had to look there to get the right name).