### PR TITLE
Sync Views bugfix, Copy State improvements

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
@@ -32,14 +32,15 @@ if available_actions:
                 )
         if selected_action:
             action = action_options[selected_action]
+        else:
+            script.exit()
     else:
         action = available_actions[0]
 
-    if action:
-        try:
-            action().paste()
-        except PyRevitException as ex:
-            forms.alert(ex.msg)
+    try:
+        action().paste()
+    except PyRevitException as ex:
+        forms.alert(ex.msg)
 else:
     forms.alert('No available actions for this view or no saved'
                 ' data found. Use "Copy State" first.')

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Paste State.pushbutton/script.py
@@ -17,7 +17,8 @@ __authors__ = ['Gui Talarico', '{{author}}', 'Alex Melnikov']
 # collect actions that are valid in this context
 available_actions = [
     x for x in copypastestate.get_actions()
-    if x.validate_context() and script.data_exists(x.__name__)
+    if x.validate_context() and script.data_exists(x.__name__,
+        this_project=x.this_project)
 ]
 
 if available_actions:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
@@ -72,7 +72,7 @@ class ViewZoomPanStateAction(basetypes.CopyPasteStateAction):
         dir_orient = vzps_data.dir_orient
 
         active_ui_view = revit.uidoc.GetOpenUIViews()[0]
-        if revit.active_view.ViewType == view_type:
+        if revit.active_view.ViewType != view_type:
             raise PyRevitException(
                 'Saved view type (%s) is different from active view (%s)'
                 % (vzps_data.view_type, type(revit.active_view).__name__))

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
@@ -730,7 +730,7 @@ class FilterOverridesAction(basetypes.CopyPasteStateAction):
             forms.CommandSwitchWindow.show(
                 ['Active/Selected View', 'Select View Templates'],
                 message='Where do you want to paste filters?'
-                ) == 'Select Templates'
+                ) == 'Select View Templates'
         if mode_templates:
             views = forms.select_viewtemplates()
         else:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
@@ -43,6 +43,7 @@ class ViewZoomPanStateData(object):
 class ViewZoomPanStateAction(basetypes.CopyPasteStateAction):
     name = 'View Zoom/Pan State'
     invalid_context_msg = "Type of active view is not supported"
+    this_project = False
 
     def copy(self):
         active_view = revit.active_view
@@ -60,12 +61,14 @@ class ViewZoomPanStateAction(basetypes.CopyPasteStateAction):
                 view_type=active_view.ViewType,
                 corner_pts=active_ui_view.GetZoomCorners(),
                 dir_orient=dir_orient
-            )
+            ),
+            this_project=False
         )
 
     def paste(self):
         # load data
-        vzps_data = script.load_data(slot_name=self.__class__.__name__)
+        vzps_data = script.load_data(slot_name=self.__class__.__name__,
+                                     this_project=False)
 
         view_type = vzps_data.view_type
         vc1, vc2 = vzps_data.corner_pts
@@ -124,6 +127,7 @@ class SectionBox3DStateAction(basetypes.CopyPasteStateAction):
     name = '3D Section Box State'
     invalid_context_msg = \
         "You must be on a 3D view to copy and paste 3D section box."
+    this_project = False
 
     def copy(self):
         section_box = revit.active_view.GetSectionBox()
@@ -134,11 +138,13 @@ class SectionBox3DStateAction(basetypes.CopyPasteStateAction):
             data=SectionBox3DStateData(
                 section_box=section_box,
                 view_orientation=view_orientation
-            )
+            ),
+            this_project=False
         )
 
     def paste(self):
-        sb3d_data = script.load_data(slot_name=self.__class__.__name__)
+        sb3d_data = script.load_data(slot_name=self.__class__.__name__,
+                                     this_project=False)
 
         active_ui_view = revit.uidoc.GetOpenUIViews()[0]
         with revit.Transaction('Paste Section Box Settings'):
@@ -217,6 +223,7 @@ class CropRegionAction(basetypes.CopyPasteStateAction):
     name = 'Crop Region'
     invalid_context_msg = \
         "Activate a view or select at least one cropable viewport"
+    this_project = False
 
     @staticmethod
     def get_cropable_views():
@@ -252,7 +259,8 @@ class CropRegionAction(basetypes.CopyPasteStateAction):
                     cropregion_curveloop=cropregion_curve_loop,
                     crop_bbox=crop_bbox,
                     is_active=view.CropBoxActive
-                )
+                ),
+                this_project=False
             )
         else:
             raise PyRevitException(
@@ -260,7 +268,8 @@ class CropRegionAction(basetypes.CopyPasteStateAction):
                 )
 
     def paste(self):
-        cr_data = script.load_data(slot_name=self.__class__.__name__)
+        cr_data = script.load_data(slot_name=self.__class__.__name__,
+                                   this_project=False)
         crv_loop = cr_data.cropregion_curveloop
         with revit.Transaction('Paste Crop Region'):
             for view in CropRegionAction.get_cropable_views():
@@ -326,6 +335,7 @@ class ViewportPlacementData(object):
 class ViewportPlacementAction(basetypes.CopyPasteStateAction):
     name = 'Viewport Placement on Sheet'
     invalid_context_msg = "At least one viewport must be selected"
+    this_project = False
 
     @staticmethod
     def calculate_offset(view, offset_uv, alignment):
@@ -558,11 +568,13 @@ class ViewportPlacementAction(basetypes.CopyPasteStateAction):
                 alignment=alignment,
                 center=center,
                 offset_uv=offset_uv if alignment == ALIGNMENT_CROPBOX else None
-            )
+            ),
+            this_project=False
         )
 
     def paste(self):
-        vp_data = script.load_data(slot_name=self.__class__.__name__)
+        vp_data = script.load_data(slot_name=self.__class__.__name__,
+                                   this_project=False)
 
         viewports = revit.get_selection().include(DB.Viewport)
         align_axis = None

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/basetypes.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/basetypes.py
@@ -39,6 +39,7 @@ class CopyPasteStateAction(object):
     """
     name = None
     invalid_context_msg = None
+    this_project = True
 
     def copy(self):
         """Performs copy action.

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/Sync Views.smartbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/Sync Views.smartbutton/script.py
@@ -60,15 +60,15 @@ def copyzoomstate(sender, args):
             try:
                 pl.dump(type(args.CurrentActiveView).__name__, f)
                 # dump zoom and center
-                pl.dump(revit.serializable.serialize_list(cornerlist), f)
+                pl.dump([revit.serialize(corner) for corner in cornerlist], f)
                 # dump ViewOrientation3D
                 if isinstance(args.CurrentActiveView, DB.View3D):
                     orientation = args.CurrentActiveView.GetOrientation()
-                    pl.dump(revit.serializable.ViewOrientation3D(orientation),
+                    pl.dump(revit.serialize(orientation),
                             f)
                 elif isinstance(args.CurrentActiveView, DB.ViewSection):
                     direction = args.CurrentActiveView.ViewDirection
-                    pl.dump(revit.serializable.XYZ(direction), f)
+                    pl.dump(revit.serialize(direction), f)
             except Exception:
                 pass
             finally:

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -708,3 +708,26 @@ def load_data(slot_name, this_project=True):
 
     with open(data_file, 'r') as dfile:
         return pickle.load(dfile)
+
+
+def data_exists(slot_name, this_project=True):
+    """Checks if data file in a specified slot and for certain project exists.
+
+    Args:
+        slot_name (type): desc
+        this_project (bool): data belongs to this project only
+
+    Returns:
+        bool: true if the path exists
+    """
+    # for this specific project?
+    if this_project:
+        data_file = get_document_data_file(file_id=slot_name,
+                                           file_ext=DATAFEXT,
+                                           add_cmd_name=False)
+    # for any project file
+    else:
+        data_file = get_data_file(file_id=slot_name,
+                                  file_ext=DATAFEXT,
+                                  add_cmd_name=False)
+    return os.path.exists(data_file)


### PR DESCRIPTION
Hey Ehsan,

Sorry, missed your message in the last PR. Here are the same changes as in #893, with no outdated commits + one more bugfix. I've seen you've already made some changes in these files. If so, please have a look at the last commit:

* e348ffa - Fix CopyState - ViewZoomPanState
 
_Here are the old changes, from previous PR:_

So it looks like we messed up Sync View (also in Copy State) a bit. It stopped working at all in the new release.

I did the fixes (bf7a39e , cced091) and added a couple of improvements:

  * e745bc1, d9dbb9e Paste State script - show only actions with data

> Added a new method into `pyrevit.script` which returns true if datafile exists. Can be moved out of there if it's too narrow case.

  * f35ca4a Copy State - allow to copy between projects

> I can name several use cases when it's necessary: to navigate in two linked model (e.g. structural and architectural, it should also work in two Revit sessions), to compare visual differences with an older version of a model. 

> It won't work with Filters and V/G Settings, unfortunately, so there are a couple of extra lines to say which method only for `this_project`.

> I was wondering if it is possible to do the same for 'Sync Views'. Doing it directly could be annoying if you switching between not connected projects. I was thinking about enabling it with Shift Click but couldn't find a good solution for that. 

  * a20cc71 Copy Filter Overrides - support active view, fixes

> When I code this part before, the idea was to be able to copy from active_view and paste to active view. So I recovered this code. If no views selected, it gets or sets data for the active one.

Thanks,
Alex







