### PR TITLE
Add Favourite Categories to Isolate button

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/Pick.splitpushbutton/Pick.pushbutton/pick_config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/Pick.splitpushbutton/Pick.pushbutton/pick_config.py
@@ -10,7 +10,7 @@ from pyrevit import script
 
 
 logger = script.get_logger()
-my_config = script.get_config()
+my_config = script.get_config("favourite_categories")
 
 
 # somehow DB.BuiltInCategory.OST_Truss does not have a corresponding DB.Category

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Isolate.pushbutton/isolate_config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Isolate.pushbutton/isolate_config.py
@@ -1,0 +1,82 @@
+"""Activates selection tool that picks a specific type of element.
+
+Shift-Click:
+Pick favorites from all available categories
+"""
+# pylint: disable=E0401,W0703,C0103
+from pyrevit import revit, DB
+from pyrevit import forms
+from pyrevit import script
+
+
+logger = script.get_logger()
+my_config = script.get_config("favourite_categories")
+
+
+# somehow DB.BuiltInCategory.OST_Truss does not have a corresponding DB.Category
+FREQUENTLY_SELECTED_CATEGORIES = [
+    DB.BuiltInCategory.OST_AreaSchemeLines,
+    DB.BuiltInCategory.OST_Columns,
+    DB.BuiltInCategory.OST_StructuralColumns,
+    DB.BuiltInCategory.OST_Doors,
+    DB.BuiltInCategory.OST_Floors,
+    DB.BuiltInCategory.OST_StructuralFraming,
+    DB.BuiltInCategory.OST_Walls,
+    DB.BuiltInCategory.OST_Windows,
+]
+
+
+class FSCategoryItem(forms.TemplateListItem):
+    """Wrapper class for frequently selected category list item"""
+    pass
+
+
+def load_configs():
+    """Load list of frequently selected categories from configs or defaults"""
+    fscats = my_config.get_option('fscats', [])
+    revit_cats = [revit.query.get_category(x)
+                  for x in (fscats or FREQUENTLY_SELECTED_CATEGORIES)]
+    return filter(None, revit_cats)
+
+
+def save_configs(categories):
+    """Save given list of categories as frequently selected"""
+    my_config.fscats = [x.Name for x in categories]
+    script.save_config()
+
+
+def reset_defaults(options):
+    """Reset frequently selected categories to defaults"""
+    defaults = [revit.query.get_category(x)
+                for x in FREQUENTLY_SELECTED_CATEGORIES]
+    default_names = [x.Name for x in defaults if x]
+    for opt in options:
+        if opt.name in default_names:
+            opt.checked = True
+
+
+def configure_fscats():
+    """Ask for users frequently selected categories"""
+    prev_fscats = load_configs()
+    all_cats = revit.doc.Settings.Categories
+    prev_fscatnames = [x.Name for x in prev_fscats]
+    fscats = forms.SelectFromList.show(
+        sorted(
+            [FSCategoryItem(x,
+                            checked=x.Name in prev_fscatnames,
+                            name_attr='Name')
+             for x in all_cats],
+            key=lambda x: x.name
+            ),
+        title='Select Favorite Categories',
+        button_name='Apply',
+        multiselect=True,
+        resetfunc=reset_defaults
+    )
+    if fscats:
+        save_configs(fscats)
+    return fscats
+
+
+if __name__ == "__main__":
+    configure_fscats()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Isolate.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Isolate.pushbutton/script.py
@@ -1,120 +1,113 @@
 """Isolates specific elements in current view and
 put the view in isolate element mode
 """
-#pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
+# pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
 from pyrevit.framework import List
 from pyrevit import forms
 from pyrevit import revit, DB
+import isolate_config
+
+__doc__ = "Isolates specific elements in current view and " "put the view in isolate element mode."
 
 
-element_cats = {
-    "Area Lines": DB.BuiltInCategory.OST_AreaSchemeLines,
-    "Doors": DB.BuiltInCategory.OST_Doors,
-    "Room Separation Lines": DB.BuiltInCategory.OST_RoomSeparationLines,
-    "Walls": DB.BuiltInCategory.OST_Walls,
-    "Furniture": DB.BuiltInCategory.OST_Furniture,
-    "Furniture Systems": DB.BuiltInCategory.OST_FurnitureSystems,
-    "Plumbing Fixtures": DB.BuiltInCategory.OST_PlumbingFixtures,
-    "Columns": DB.BuiltInCategory.OST_Columns,
-    "Curtain Systems": DB.BuiltInCategory.OST_Curtain_Systems,
-    "Room Tags": None,
-    "Model Groups": None,
-    "Painted Elements": None,
-    "Model Elements": None,
-}
+def main():
+    element_cats = isolate_config.load_configs()
 
+    select_options = sorted(x.Name for x in element_cats) + [
+        "Room Tags",
+        "Model Groups",
+        "Painted Elements",
+        "Model Elements",
+    ]
 
-selected_switch = forms.CommandSwitchWindow.show(
-    sorted(element_cats.keys()), message="Temporarily isolate elements of type:"
-)
+    selected_switch = forms.CommandSwitchWindow.show(select_options, message="Temporarily isolate elements of type:")
 
+    if selected_switch:
+        curview = revit.active_view
 
-if selected_switch:
-    curview = revit.active_view
+        tg = DB.TransactionGroup(revit.doc, "Isolate {}".format(selected_switch))
+        tg.Start()
+        # reset temporary hide/isolate before filtering elements
+        t1 = DB.Transaction(revit.doc, "Reset temporary hide/isolate")
+        t1.Start()
+        curview.DisableTemporaryViewMode(DB.TemporaryViewMode.TemporaryHideIsolate)
+        t1.Commit()
 
-    if selected_switch == "Room Tags":
-        roomtags = (
-            DB.FilteredElementCollector(revit.doc, curview.Id)
-            .OfCategory(DB.BuiltInCategory.OST_RoomTags)
-            .WhereElementIsNotElementType()
-            .ToElementIds()
-        )
+        if selected_switch == "Room Tags":
+            roomtags = (
+                DB.FilteredElementCollector(revit.doc, curview.Id)
+                .OfCategory(DB.BuiltInCategory.OST_RoomTags)
+                .WhereElementIsNotElementType()
+                .ToElementIds()
+            )
 
-        rooms = (
-            DB.FilteredElementCollector(revit.doc, curview.Id)
-            .OfCategory(DB.BuiltInCategory.OST_Rooms)
-            .WhereElementIsNotElementType()
-            .ToElementIds()
-        )
+            rooms = (
+                DB.FilteredElementCollector(revit.doc, curview.Id)
+                .OfCategory(DB.BuiltInCategory.OST_Rooms)
+                .WhereElementIsNotElementType()
+                .ToElementIds()
+            )
 
-        allelements = []
-        allelements.extend(rooms)
-        allelements.extend(roomtags)
-        element_to_isolate = List[DB.ElementId](allelements)
+            allelements = []
+            allelements.extend(rooms)
+            allelements.extend(roomtags)
+            element_to_isolate = List[DB.ElementId](allelements)
 
-    elif selected_switch == "Model Groups":
-        elements = (
-            DB.FilteredElementCollector(revit.doc, curview.Id)
-            .WhereElementIsNotElementType()
-            .ToElementIds()
-        )
+        elif selected_switch == "Model Groups":
+            elements = DB.FilteredElementCollector(revit.doc, curview.Id).WhereElementIsNotElementType().ToElementIds()
+            modelgroups = []
+            expanded = []
+            for elid in elements:
+                el = revit.doc.GetElement(elid)
+                if isinstance(el, DB.Group) and not el.ViewSpecific:
+                    modelgroups.append(elid)
+                    members = el.GetMemberIds()
+                    expanded.extend(list(members))
+            expanded.extend(modelgroups)
+            element_to_isolate = List[DB.ElementId](expanded)
 
-        modelgroups = []
-        expanded = []
-        for elid in elements:
-            el = revit.doc.GetElement(elid)
-            if isinstance(el, DB.Group) and not el.ViewSpecific:
-                modelgroups.append(elid)
-                members = el.GetMemberIds()
-                expanded.extend(list(members))
+        elif selected_switch == "Painted Elements":
+            element_to_isolate = List[DB.ElementId]()
+            elements = DB.FilteredElementCollector(revit.doc, curview.Id).WhereElementIsNotElementType().ToElementIds()
+            for elId in elements:
+                el = revit.doc.GetElement(elId)
+                if len(list(el.GetMaterialIds(True))) > 0:
+                    element_to_isolate.Append(elId)
+                elif isinstance(el, DB.Wall) and el.IsStackedWall:
+                    memberWalls = el.GetStackedWallMemberIds()
+                    for mwid in memberWalls:
+                        mw = revit.doc.GetElement(mwid)
+                        if len(list(mw.GetMaterialIds(True))) > 0:
+                            element_to_isolate.Append(elId)
 
-        expanded.extend(modelgroups)
-        element_to_isolate = List[DB.ElementId](expanded)
+        elif selected_switch == "Model Elements":
+            element_to_isolate = []
 
-    elif selected_switch == "Painted Elements":
-        element_set = []
+            elements = DB.FilteredElementCollector(revit.doc, curview.Id).WhereElementIsNotElementType().ToElementIds()
+            for elid in elements:
+                el = revit.doc.GetElement(elid)
+                if not el.ViewSpecific:  # and not isinstance(el, DB.Dimension):
+                    element_to_isolate.append(elid)
 
-        elements = (
-            DB.FilteredElementCollector(revit.doc, curview.Id)
-            .WhereElementIsNotElementType()
-            .ToElementIds()
-        )
+            element_to_isolate = List[DB.ElementId](element_to_isolate)
 
-        for elId in elements:
-            el = revit.doc.GetElement(elId)
-            if len(list(el.GetMaterialIds(True))) > 0:
-                element_set.append(elId)
-            elif isinstance(el, DB.Wall) and el.IsStackedWall:
-                memberWalls = el.GetStackedWallMemberIds()
-                for mwid in memberWalls:
-                    mw = revit.doc.GetElement(mwid)
-                    if len(list(mw.GetMaterialIds(True))) > 0:
-                        element_set.append(elId)
-        element_to_isolate = List[DB.ElementId](element_set)
+        else:
+            element_to_isolate = (
+                DB.FilteredElementCollector(revit.doc, curview.Id)
+                .OfCategory(revit.query.get_builtincategory(selected_switch))
+                .WhereElementIsNotElementType()
+                .ToElementIds()
+            )
 
-    elif selected_switch == "Model Elements":
-        elements = (
-            DB.FilteredElementCollector(revit.doc, curview.Id)
-            .WhereElementIsNotElementType()
-            .ToElementIds()
-        )
-
-        element_to_isolate = []
-        for elid in elements:
-            el = revit.doc.GetElement(elid)
-            if not el.ViewSpecific:  # and not isinstance(el, DB.Dimension):
-                element_to_isolate.append(elid)
-
-        element_to_isolate = List[DB.ElementId](element_to_isolate)
-
-    else:
-        element_to_isolate = (
-            DB.FilteredElementCollector(revit.doc, curview.Id)
-            .OfCategory(element_cats[selected_switch])
-            .WhereElementIsNotElementType()
-            .ToElementIds()
-        )
-
-    # now that list of elements is ready, let's isolate them in the active view
-    with revit.Transaction("Isolate {}".format(selected_switch)):
+        # now that list of elements is ready, let's isolate them in the active view
+        t2 = DB.Transaction(revit.doc, "Isolate {}".format(selected_switch))
+        t2.Start()
         curview.IsolateElementsTemporary(element_to_isolate)
+        t2.Commit()
+        tg.Assimilate()
+        # with revit.Transaction("Isolate {}".format(selected_switch)):
+        #     curview.IsolateElementsTemporary(element_to_isolate)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@eirannejad please have a look

I also changed config section of Pick button to use in common with Isolate button and named it `"favourite_categories"`

One change in Isolate behaviour: I reset temporary hide/isolate mode for current view first, then we go filtering for elements to isolate. Do you think that's a more convenient workflow, instead of filtering based on currently isolated elements?