### PR TITLE
Allow Dialogs in Journal Playback

### DIFF
--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
@@ -310,7 +310,7 @@ namespace pyRevitCLI {
                     else {
                         // try parse the engine version as an integer e.g. 277 for 2.7.7
                         if (int.TryParse(engStrVer, out var engIntVer))
-                            engineVersion = (PyRevitEngineVersion)engIntVer;                        
+                            engineVersion = (PyRevitEngineVersion)engIntVer;
                     }
 
                     if (engineVersion is null) {
@@ -550,7 +550,8 @@ namespace pyRevitCLI {
                                 PurgeTempFiles = arguments["--purge"].IsTrue,
                                 ImportPath = TryGetValue("--import", null)
                             },
-                            targetIsFileList: true
+                            targetIsFileList: true,
+                            allowDialogs = arguments["--allowdialogs"].IsTrue
                         );
                     }
                     else
@@ -561,7 +562,8 @@ namespace pyRevitCLI {
                             runOptions: new PyRevitRunnerOptions() {
                                 PurgeTempFiles = arguments["--purge"].IsTrue,
                                 ImportPath = TryGetValue("--import", null)
-                            }
+                            },
+                            allowDialogs = arguments["--allowdialogs"].IsTrue
                         );
                 }
             }
@@ -699,8 +701,8 @@ namespace pyRevitCLI {
                         Console.WriteLine(string.Format("User {0} config",
                                                         PyRevitConfigs.GetUserCanConfig() ? "CAN" : "CAN NOT"));
 
-                } 
-                
+                }
+
                 else if (all("colordocs")) {
                     if (any("enable", "disable"))
                         PyRevitConfigs.SetColorizeDocs(arguments["enable"].IsTrue);
@@ -889,7 +891,7 @@ namespace pyRevitCLI {
 
                 else if (TryGetValue("<doctor_command>") is var doctorCommand && doctorCommand != null)
                     PyRevitCLIAppCmds.RunDoctor(doctorCommand, dryRun: arguments["--dryrun"].IsTrue);
-                
+
                 else if (all("doctor", "--list"))
                     PyRevitCLIAppCmds.RunDoctor("--list");
 

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIAppHelps.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIAppHelps.cs
@@ -11,7 +11,7 @@ namespace pyRevitCLI {
         internal static void
         PrintHelp(PyRevitCLICommandType commandType) {
             switch (commandType) {
-                
+
                 case PyRevitCLICommandType.Main:
                     BuildHelp(
                         null,
@@ -57,7 +57,7 @@ namespace pyRevitCLI {
                         }
                     );
                     break;
-                
+
                 case PyRevitCLICommandType.Env:
                     BuildHelp(
                         new List<string>() { "env" },
@@ -297,6 +297,7 @@ namespace pyRevitCLI {
                             { "<model_file>",           "Target Revit model file path" },
                             { "--purge",                "Remove temporary run environment after completion" },
                             { "--import=<import_path>", "Copy content of this folder into the runtime temp path." },
+                            { "--allowdialogs",         "To allow dialogs during journal playback" }
                         });
                     break;
 
@@ -447,7 +448,7 @@ namespace pyRevitCLI {
             if (options != null) {
                 baseHelp += header + Environment.NewLine;
                 foreach (var optionPair in options) {
-                    baseHelp += 
+                    baseHelp +=
                         string.Format(outputFormat, optionPair.Key, optionPair.Value)
                         + Environment.NewLine;
                 }

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIRevitCmds.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIRevitCmds.cs
@@ -154,7 +154,7 @@ namespace pyRevitCLI {
         }
 
         internal static void
-        RunExtensionCommand(string commandName, string targetFile, string revitYear, PyRevitRunnerOptions runOptions, bool targetIsFileList = false) {
+        RunExtensionCommand(string commandName, string targetFile, string revitYear, PyRevitRunnerOptions runOptions, bool targetIsFileList = false, bool allowDialogs = false) {
             // verify command
             if (commandName is null || commandName == string.Empty)
                 throw new Exception("Command name must be provided.");
@@ -163,7 +163,7 @@ namespace pyRevitCLI {
             int revitYearNumber = 0;
             int.TryParse(revitYear, out revitYearNumber);
 
-            
+
             // setup a list of models
             var modelFiles = new List<string>();
             // if target file is a list of model paths
@@ -176,7 +176,7 @@ namespace pyRevitCLI {
             else
                 modelFiles.Add(targetFile);
 
-            
+
             // verify all models are accessible
             foreach (string modelFile in modelFiles)
                 if (!CommonUtils.VerifyFile(modelFile))
@@ -256,7 +256,8 @@ namespace pyRevitCLI {
                         attachment,
                         commandScriptPath,
                         modelFiles,
-                        runOptions
+                        runOptions,
+                        allowDialogs
                     );
 
                     // print results (exec env)
@@ -288,7 +289,7 @@ namespace pyRevitCLI {
                     }
                 }
             }
-            
+
         }
 
         // privates:

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRunner.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRunner.cs
@@ -118,7 +118,7 @@ Jrn.Data ""TaskDialogResult"" , ""Do you want to save changes to Untitled?"", ""
                 string.Format(
                     JournalTemplate,                                    // template string
                     CommonUtils.GetISOTimeStampNow(),                   // timestamp with format: 27-Oct-2016 19:33:31.459
-                    AllowDialogs ? 1 : 0,                               // whether journal playback should allow dialogs
+                    AllowDialogs ? 0 : 1,                               // whether journal playback should allow dialogs
                     Script,                                             // script path
                     "",                                                 // sys paths
                     string.Join(";", ModelPaths),                       // model paths

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRunner.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRunner.cs
@@ -14,11 +14,11 @@ using pyRevitLabs.TargetApps.Revit;
 namespace pyRevitLabs.PyRevit {
     public class PyRevitRunnerCommand {
         public PyRevitRunnerCommand(string commandPath) => Path = commandPath;
-        
+
         public override string ToString() {
             return $"{Name} | \"{Path}\"";
         }
-        
+
         public string Name => System.IO.Path.GetFileName(Path).Replace(PyRevitConsts.ExtensionUICommandPostfix, "");
         public string Path { get; }
     }
@@ -26,10 +26,11 @@ namespace pyRevitLabs.PyRevit {
     public class PyRevitRunnerExecEnv {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-        public PyRevitRunnerExecEnv(PyRevitAttachment attachment, string script, IEnumerable<string> modelPaths) {
+        public PyRevitRunnerExecEnv(PyRevitAttachment attachment, string script, IEnumerable<string> modelPaths, bool allowDialogs) {
             Attachment = attachment;
             Script = script;
             ModelPaths = modelPaths;
+            AllowDialogs = allowDialogs;
 
             // check if clone is compatible
             if (!CommonUtils.VerifyFile(PyRevitCloneRunner))
@@ -54,22 +55,23 @@ namespace pyRevitLabs.PyRevit {
 ' 0:< 'C {0};
 Dim Jrn
 Set Jrn = CrsJournalScript
-Jrn.Directive ""DebugMode"", ""PerformAutomaticActionInErrorDialog"", 1
+Jrn.Directive ""DebugMode"", ""PerformAutomaticActionInErrorDialog"", {1}
 Jrn.Directive ""DebugMode"", ""PermissiveJournal"", 1
 Jrn.RibbonEvent ""TabActivated:Add-Ins""
 Jrn.RibbonEvent ""Execute external command:CustomCtrl_%CustomCtrl_%Add-Ins%pyRevitRunner%PyRevitRunnerCommand:PyRevitRunner.PyRevitRunnerCommand""
 Jrn.Data ""APIStringStringMapJournalData""  _
     , 4 _
-    , ""ScriptSource"" , ""{1}"" _
-    , ""SearchPaths"" , ""{2}"" _
-    , ""Models"" , ""{3}"" _
-    , ""LogFile"" , ""{4}""
+    , ""ScriptSource"" , ""{2}"" _
+    , ""SearchPaths"" , ""{3}"" _
+    , ""Models"" , ""{4}"" _
+    , ""LogFile"" , ""{5}""
 Jrn.Command ""SystemMenu"" , ""Quit the application; prompts to save projects , ID_APP_EXIT""
 Jrn.Data ""TaskDialogResult"" , ""Do you want to save changes to Untitled?"", ""No"", ""IDNO""
 ";
 
         public PyRevitAttachment Attachment { get; private set; }
         public string Script { get; private set; }
+        public bool AllowDialogs {get; private set;}
         public IEnumerable<string> ModelPaths { get; private set; }
 
         public RevitProduct Revit { get { return Attachment.Product; } }
@@ -101,8 +103,8 @@ Jrn.Data ""TaskDialogResult"" , ""Do you want to save changes to Untitled?"", ""
         }
 
         // MDJ added code to copy all .addin files and subdirs into the batch running context.
-        // This is to workaround built-in Revit addins like the NavisExporter not being available while using pyRevit batch. 
-        // Per MSDN, the below code is a relatively safe way to recurse through dirs and copy: http://msdn.microsoft.com/en-us/library/system.io.directoryinfo.aspx 
+        // This is to workaround built-in Revit addins like the NavisExporter not being available while using pyRevit batch.
+        // Per MSDN, the below code is a relatively safe way to recurse through dirs and copy: http://msdn.microsoft.com/en-us/library/system.io.directoryinfo.aspx
 
         public void CopyExistingAddons(string sourceDirectory) {
             var targetDirectoryInfo = new DirectoryInfo(WorkingDirectory);
@@ -116,6 +118,7 @@ Jrn.Data ""TaskDialogResult"" , ""Do you want to save changes to Untitled?"", ""
                 string.Format(
                     JournalTemplate,                                    // template string
                     CommonUtils.GetISOTimeStampNow(),                   // timestamp with format: 27-Oct-2016 19:33:31.459
+                    AllowDialogs ? 1 : 0,                               // whether journal playback should allow dialogs
                     Script,                                             // script path
                     "",                                                 // sys paths
                     string.Join(";", ModelPaths),                       // model paths
@@ -172,7 +175,8 @@ Jrn.Data ""TaskDialogResult"" , ""Do you want to save changes to Untitled?"", ""
         public static PyRevitRunnerExecEnv Run(PyRevitAttachment attachment,
                                                string scriptPath,
                                                IEnumerable<string> modelPaths,
-                                               PyRevitRunnerOptions opts = null) {
+                                               PyRevitRunnerOptions opts = null,
+                                               bool allowDialogs = false) {
             var product = attachment.Product;
             var clone = attachment.Clone;
             var engineVer = attachment.Engine != null ? attachment.Engine.Version : 0;
@@ -185,7 +189,7 @@ Jrn.Data ""TaskDialogResult"" , ""Do you want to save changes to Untitled?"", ""
             if (opts is null)
                 opts = new PyRevitRunnerOptions();
 
-            var execEnv = new PyRevitRunnerExecEnv(attachment, scriptPath, modelPaths);
+            var execEnv = new PyRevitRunnerExecEnv(attachment, scriptPath, modelPaths, allowDialogs);
 
             // purge files if requested
             if (opts.ImportPath != null)


### PR DESCRIPTION
One of my use cases need to handle `DialogBoxShowingEvent` while executing scripts via CLI run, so I've added an optional switch to the `run` command, to make this possible.
It is to be noted, that the Journal Playback will be aborted, and it turns into Interactive Mode if any `DialogBoxShowingEvent` occurs , so the Dialog_Revit_JournalAbort DialogBox should be handled as well, and the python script has to take over, and close revit once its finished executing. Here is an example for that:
```
from System import EventHandler
from System.Diagnostics import Process
from Autodesk.Revit.UI.Events import DialogBoxShowingEventArgs,

from pyrevit import script

close_revit = False


def dialog_handler(sender, e):
    if e.DialogId == 'Dialog_Revit_JournalAbort':
        global close_revit
        close_revit = True
        e.OverrideResult(2)


uiapp = revit.HOST_APP.uiapp
uiapp.DialogBoxShowing += EventHandler[DialogBoxShowingEventArgs](dialog_handler)

# your code here

uiapp.DialogBoxShowing -= EventHandler[DialogBoxShowingEventArgs](dialog_handler)

if close_revit:
    process = Process.GetCurrentProcess()
    closed = process.CloseMainWindow()
```
