### PR TITLE
Update query.py

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -584,7 +584,7 @@ def get_linked_model_doc(linked_model):
 def find_first_legend(doc=None):
     doc = doc or DOCS.doc
     for view in DB.FilteredElementCollector(doc).OfClass(DB.View):
-        if view.ViewType == DB.ViewType.Legend:
+        if view.ViewType == DB.ViewType.Legend and not view.IsTemplate:
             return view
     return None
 


### PR DESCRIPTION
This is probably a very rare occurrence but when the first legend found happens to be a legend view template, it can cause addins like "Copy Legends" to fail.
This actually has a large effect in our office because the Revit template has a Legend View template which happens to be the first "Legend" found by the "find_first_legend" function.

Adding this code ensures that view templates are excluded from the collection

