### PR TITLE
fix: add cpython compatibility

### DIFF
--- a/pyrevitlib/pyrevit/framework.py
+++ b/pyrevitlib/pyrevit/framework.py
@@ -86,7 +86,10 @@ ASSEMBLY_FILE_EXT = '.dll'
 
 ipy_assmname = '{prefix}IronPython'.format(prefix=eng.EnginePrefix)
 ipy_dllpath = op.join(eng.EnginePath, ipy_assmname + ASSEMBLY_FILE_EXT)
-clr.AddReferenceToFileAndPath(ipy_dllpath)
+if compat.PY3:
+    clr.AddReference(ipy_dllpath)
+else:
+    clr.AddReferenceToFileAndPath(ipy_dllpath)
 
 import IronPython
 

--- a/pyrevitlib/pyrevit/revit/events.py
+++ b/pyrevitlib/pyrevit/revit/events.py
@@ -9,6 +9,8 @@ mlogger = get_logger(__name__)
 
 
 class FuncAsEventHandler(UI.IExternalEventHandler):
+    __namespace__ = EXEC_PARAMS.exec_id
+
     def __init__(self, handler_func, purge=True):
         self.name = 'FuncAsEventHandler'
         self.handler_group_id = None

--- a/pyrevitlib/pyrevit/runtime/__init__.py
+++ b/pyrevitlib/pyrevit/runtime/__init__.py
@@ -281,10 +281,7 @@ def get_references():
 
 
 def _generate_runtime_asm():
-    source_list = []
-    for source_file in _get_source_files():
-        source_list.append(source_file)
-
+    source_list = list(_get_source_files())
     # now try to compile
     try:
         mlogger.debug('Compiling base types to: %s', RUNTIME_ASSM_FILE)
@@ -293,13 +290,14 @@ def _generate_runtime_asm():
             outputPath=RUNTIME_ASSM_FILE,
             references=Array[str](
                 get_references()
-                ),
+            ),
             defines=Array[str]([
                 "REVIT{}".format(HOST_APP.version),
                 "REVIT{}".format(HOST_APP.subversion.replace('.', '_'))
-                ]),
-            debug=False
-            )
+            ]),
+            debug=False,
+            messages=List[str]()
+        )
         # log results
         logfile = RUNTIME_ASSM_FILE.replace('.dll', '.log')
         with open(logfile, 'w') as lf:

--- a/pyrevitlib/pyrevit/userconfig.py
+++ b/pyrevitlib/pyrevit/userconfig.py
@@ -667,21 +667,18 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         mlogger.debug('cpython engines dict: %s', cpy_engines_dict)
 
         if cpy_engines_dict:
-            # find latest cpython engine
-            latest_cpyengine = \
-                max(cpy_engines_dict.values(), key=lambda x: x.Version)
-
             # grab cpython engine configured to be used by user
             try:
                 cpyengine_ver = int(self.cpython_engine_version)
             except Exception:
                 cpyengine_ver = 000
 
-            # grab the engine by version or default to latest
-            cpyengine = \
-                cpy_engines_dict.get(cpyengine_ver, latest_cpyengine)
-            # return full dll assembly path
-            return cpyengine
+            try:
+                return cpy_engines_dict[cpyengine_ver]
+            except KeyError:
+                # return the latest cpython engine
+                # HACK for CPython compatibility
+                return max(cpy_engines_dict.values(), key=lambda x: str(x.Version))
         else:
             mlogger.error('Can not determine cpython engines for '
                           'current attachment: %s', attachment)


### PR DESCRIPTION
This is my first attempt at closing #1438

It's not at all a comprehensive fix for now, I only tried a direct import of the following:

```py
from pyrevit import EXEC_PARAMS
from pyrevit import revit
from pyrevit import script
from pyrevit.revit import Transaction
```

There's an ugly hack to get the latest cpython engine version: I couldn't get the integer from the `Version` property, so I used `str()` to compare them.
