### PR TITLE
Fix ReNumber Viewports on Sheet

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit2.stack/ReNumber.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit2.stack/ReNumber.pushbutton/script.py
@@ -163,7 +163,10 @@ def get_elements_dict(builtin_cat):
     """Collect number:id information about target elements."""
     all_elements = \
         revit.query.get_elements_by_categories([builtin_cat])
-    return {get_number(x):x.Id for x in all_elements}
+    if builtin_cat == BIC.OST_Viewports:
+        return {get_number(x):x.Id for x in all_elements if x.SheetId == revit.active_view.Id}
+    else:
+        return {get_number(x):x.Id for x in all_elements}
 
 
 def find_replacement_number(existing_number, elements_dict):


### PR DESCRIPTION
Changed get_elements_dict to only collect Viewports from the active Sheet.
Right now the tool might fail to assign a new number to the View with the target number on the current Sheet, if a View with the same number exists on any other Sheet.

