### PR TITLE
Attempt to fix tags manager

### DIFF
--- a/extensions/pyRevitTags.extension/lib/tagsmgr.py
+++ b/extensions/pyRevitTags.extension/lib/tagsmgr.py
@@ -555,8 +555,11 @@ def apply_tags(element, tags, config=None):
                                                 space=False,
                                                 spare=False)
         if esystems:
-            for esys in esystems:
-                apply_tags(esys, tags, config=config)
+            try:
+                for esys in esystems:
+                    apply_tags(esys, tags, config=config)
+            except Exception as apply_err:
+                raise(apply_err)
 
     if config.append:
         el_tags = extract_tags(element)

--- a/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/Manage Tags.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/Manage Tags.pushbutton/bundle.yaml
@@ -9,6 +9,6 @@ title:
     Tags
 tooltip:
   ru: Управляет марками в проекте или выделенными элементами.
-  en_us: Manage tags in project or selected elements
+  en_us: Manage tags in project or selected elements - you need to create a 'doctag' and apply it to the document categories before using the tag tools
 help_url: '{{docpath}}FYNDSAypWlg'
 author: '{{author}}'

--- a/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/Tag.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/Tag.pushbutton/bundle.yaml
@@ -9,6 +9,6 @@ title:
     Selected
 tooltip:
   ru: Применяет марку к выделенным элементам.
-  en_us: Apply tag to selected elements
+  en_us: Apply tag to selected elements - you need to create a 'doctag' and apply it to the document categories before using the tag tools
 help_url: '{{docpath}}FYNDSAypWlg'
 author: '{{author}}'

--- a/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/TagsConfig.panelbutton/bundle.yaml
+++ b/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/TagsConfig.panelbutton/bundle.yaml
@@ -3,5 +3,5 @@ title:
   en_us: Tags Config
 tooltip:
   ru: Открывает настройки маркирования.
-  en_us: Tags configuration options
+  en_us: Tags configuration options - you need to create a 'doctag' and apply it to the document categories before using the tag tools
 context: zero-doc

--- a/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/tagstack.stack/Clear Tags.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/tagstack.stack/Clear Tags.pushbutton/bundle.yaml
@@ -3,5 +3,5 @@ title:
   en_us: Clear Tags
 tooltip:
   ru: Очищает информацию о марках выделенных элементов.
-  en_us: Clear tag information from selected elements
+  en_us: Clear tag information from selected elements - you need to create a 'doctag' and apply it to the document categories before using the tag tools
 author: '{{author}}'

--- a/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/tagstack.stack/Match Tags.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTags.extension/pyRevit.tab/Packages & Tags.panel/tagstack.stack/Match Tags.pushbutton/bundle.yaml
@@ -3,5 +3,5 @@ title:
   en_us: Match Tags
 tooltip:
   ru: Сравнивает марки между выделенными элементами.
-  en_us: Match Tags between selected elements
+  en_us: Match Tags between selected elements - you need to create a 'doctag' and apply it to the document categories before using the tag tools
 author: '{{author}}'

--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -970,10 +970,17 @@ def get_connected_circuits(element, spare=False, space=False):
         circuit_types.append(DB.Electrical.CircuitType.Spare)
     if space:
         circuit_types.append(DB.Electrical.CircuitType.Space)
-
-    if element.MEPModel and element.MEPModel.ElectricalSystems:
-        return [x for x in element.MEPModel.ElectricalSystems
-                if x.CircuitType in circuit_types]
+    if circuit_types !=[DB.Electrical.CircuitType.Circuit]:
+        if HOST_APP.is_newer_than(2021, or_equal=True): # deprecation of ElectricalSystems in 2021
+            if element.MEPModel and element.MEPModel.GetElectricalSystems:
+                return [x for x in element.MEPModel.GetElectricalSystems
+                        if x.CircuitType in circuit_types]
+        else:
+            if element.MEPModel and element.MEPModel.ElectricalSystems:
+                return [x for x in element.MEPModel.ElectricalSystems
+                        if x.CircuitType in circuit_types]
+    else:
+        return element
 
 
 def get_element_categories(elements):


### PR DESCRIPTION
Not my cleanest but should solve a couple of issues such as https://github.com/eirannejad/pyRevit/issues/1364 and https://github.com/eirannejad/pyRevit/issues/1632

Added "you need to create a 'doctag' and apply it to the document categories before using the tag tools" to bundle files
It took me a bit to figure out why I couldn't use the tools at first