### PR TITLE
#1704

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit1.stack/Match.splitpushbutton/Match Properties.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit1.stack/Match.splitpushbutton/Match Properties.pushbutton/script.py
@@ -114,7 +114,7 @@ def recall():
     """Load last matched properties from memory."""
     data = []
     try:
-        with open(MEMFILE, 'r') as mf:
+        with open(MEMFILE, 'rb') as mf:
             data = pickle.load(mf)
     except Exception as ex:
         logger.debug(
@@ -125,7 +125,7 @@ def recall():
 
 def remember(src_props):
     """Save selected matched properties to memory."""
-    with open(MEMFILE, 'w') as mf:
+    with open(MEMFILE, 'wb') as mf:
         pickle.dump(src_props, mf)
 
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/mema.stack/MAppend.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/mema.stack/MAppend.pushbutton/script.py
@@ -11,13 +11,13 @@ selection = revit.get_selection()
 selected_ids = {str(elid.IntegerValue) for elid in selection.element_ids}
 
 try:
-    f = open(datafile, 'r')
+    f = open(datafile, 'rb')
     prevsel = pickle.load(f)
     new_selection = prevsel.union(selected_ids)
     f.close()
 except Exception:
     new_selection = selected_ids
 
-f = open(datafile, 'w')
+f = open(datafile, 'wb')
 pickle.dump(new_selection, f)
 f.close()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/mema.stack/MRead.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/mema.stack/MRead.pushbutton/script.py
@@ -11,7 +11,7 @@ datafile = script.get_document_data_file("SelList", "pym")
 
 
 try:
-    f = open(datafile, 'r')
+    f = open(datafile, 'rb')
     current_selection = pickle.load(f)
     f.close()
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/mema.stack/MWrite.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/mema.stack/MWrite.pushbutton/script.py
@@ -9,6 +9,6 @@ datafile = script.get_document_data_file("SelList", "pym")
 selection = revit.get_selection()
 selected_ids = {str(elid.IntegerValue) for elid in selection.element_ids}
 
-f = open(datafile, 'w')
+f = open(datafile, 'wb')
 pickle.dump(selected_ids, f)
 f.close()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/MDeduct.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/MDeduct.pushbutton/script.py
@@ -12,14 +12,14 @@ selection = revit.get_selection()
 selected_ids = {str(elid.IntegerValue) for elid in selection.element_ids}
 
 try:
-    f = open(datafile, 'r')
+    f = open(datafile, 'rb')
     prevsel = pl.load(f)
     newsel = prevsel.difference(selected_ids)
     f.close()
-    f = open(datafile, 'w')
+    f = open(datafile, 'wb')
     pl.dump(newsel, f)
     f.close()
 except Exception:
-    f = open(datafile, 'w')
+    f = open(datafile, 'wb')
     pl.dump([], f)
     f.close()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/Save Memory as Selection.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/Save Memory as Selection.pushbutton/script.py
@@ -21,7 +21,7 @@ if op.exists(data_file):
         filter_name = \
             'SavedSelection_' + coreutils.timestamp()
 
-    with open(data_file, 'r') as f:
+    with open(data_file, 'rb') as f:
         cursel = pl.load(f)
 
     with revit.Transaction('pySaveSelection'):

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/lib/iter_selection.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/lib/iter_selection.py
@@ -20,7 +20,7 @@ def iterate(mode, step_size=1):
     selection = revit.get_selection()
 
     if op.exists(index_datafile):
-        with open(index_datafile, 'r') as f:
+        with open(index_datafile, 'rb') as f:
             idx = pickle.load(f)
 
         if mode == '-':
@@ -32,7 +32,7 @@ def iterate(mode, step_size=1):
 
     if op.exists(datafile):
         try:
-            with open(datafile, 'r') as df:
+            with open(datafile, 'rb') as df:
                 cursel = pickle.load(df)
 
             if cursel:
@@ -43,7 +43,7 @@ def iterate(mode, step_size=1):
 
                 selection.set_to([DB.ElementId(int(list(cursel)[idx]))])
 
-                with open(index_datafile, 'w') as f:
+                with open(index_datafile, 'wb') as f:
                     pickle.dump(idx, f)
         except Exception as io_err:
             logger.error(

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/Sync Views.smartbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/Sync Views.smartbutton/script.py
@@ -67,7 +67,7 @@ def copy_zoomstate(sender, args):
             # get zoom corners
             cornerlist = current_ui_view.GetZoomCorners()
             # and save the info
-            f = open(get_datafile(event_doc), 'w')
+            f = open(get_datafile(event_doc), 'wb')
             try:
                 # dump current view type
                 pl.dump(type(args.CurrentActiveView).__name__, f)
@@ -108,7 +108,7 @@ def apply_zoomstate(sender, args):
                 return
 
             # load zoom data
-            f = open(get_datafile(event_doc), 'r')
+            f = open(get_datafile(event_doc), 'rb')
             try:
                 view_type_saved = pl.load(f)
                 if view_type_saved != type(args.CurrentActiveView).__name__:


### PR DESCRIPTION
This PR is to address the issue #1704 

Basically I replaced `w` and `r` by the `wb` and `rb` to specify binary modes during `open` command. 
Did it everywhere where I could find usage of pickle module:
 - memo buttons
 - sync view smart button 

Tested in IPY277 and IPY340 on Revit 2023 | Version: 23.1.10.4