### PR TITLE
Removed usage error in load_data example

### DIFF
--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -696,7 +696,7 @@ def load_data(slot_name, this_project=True):
         ...         return [x.deserialize() for x in self._elmnt_ids]
         ...
         ...
-        ... mydata = script.load_data("Selected Elements", element_ids)
+        ... mydata = script.load_data("Selected Elements")
         ... mydata.element_ids
         [<DB.ElementId>, <DB.ElementId>, <DB.ElementId>]
     """


### PR DESCRIPTION
Example had the de-serialization function of the CustomData object listed as a second argument, which didn't match the load_data function definition.

