### PR TITLE
Fix #1732 import export family config

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
@@ -237,7 +237,7 @@ def read_configs(selected_fparam_names,
         if HOST_APP.is_newer_than(2022):  # ParameterType deprecated in 2023
             fparam_type = sparam.fparam.Definition.GetDataType()
             fparam_type_str = fparam_type.TypeId
-            fparam_group = sparam.fparam.Definition.GetGroupTypeId().TypeId
+            fparam_group = sparam.fparam.Definition.GetGroupTypeId()
         else:
             fparam_type = sparam.fparam.Definition.ParameterType
             fparam_type_str = str(fparam_type)
@@ -321,8 +321,7 @@ def store_sharedparam_def(shared_params):
         try:
             exported_sparams_grp.Definitions.Create(sparamdef_create_options)
         except Exceptions.ArgumentException:
-            forms.alert("A parameter with the same GUID already exists.\nParameter: {} will be ignored.".format(
-                sparam.Definition.Name))
+            forms.alert("A parameter with the same GUID already exists.\nParameter: {} will be ignored.".format(sparam.Definition.Name))
 
 
 def get_shared_param_def_contents(shared_params):
@@ -335,7 +334,7 @@ def get_shared_param_def_contents(shared_params):
             file_id=coreutils.get_file_name(family_cfg_file),
             add_cmd_name=True
         )
-    # make sure the file exists and it is empty
+    # make sure the ParameterGroup file exists and it is empty
     open(temp_defs_filepath, 'wb').close()
     # swap existing shared param with temp
     existing_sharedparam_file = HOST_APP.app.SharedParametersFilename

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
@@ -12,7 +12,7 @@ parameters:
     <parameter-name>:
         type: <Autodesk.Revit.DB.ParameterType> or
         <Autodesk.Revit.DB.ParameterTypeId Members> (2022+)
-        group: <Autodesk.Revit.DB.BuiltInParameterGroup>  or
+        group: <Autodesk.Revit.DB.BuiltInParameterGroup> or
         <Autodesk.Revit.DB.GroupTypeId Members> (2022+)
         instance: <true|false>
         reporting: <true|false>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
@@ -9,30 +9,30 @@ by the presence of their GUID.
 The structure of this config file is as shown below:
 
 parameters:
-	<parameter-name>:
-		type: <Autodesk.Revit.DB.ParameterType>
-		category: <Autodesk.Revit.DB.BuiltInParameterGroup>
-		instance: <true|false>
-		reporting: <true|false>
-		formula: <str>
-		default: <str>
+    <parameter-name>:
+        type: <Autodesk.Revit.DB.ParameterType> or <Autodesk.Revit.DB.ParameterTypeId Members> (2022+)
+        group: <Autodesk.Revit.DB.BuiltInParameterGroup>  or <Autodesk.Revit.DB.GroupTypeId Members> (2022+)
+        instance: <true|false>
+        reporting: <true|false>
+        formula: <str>
+        default: <str>
 types:
-	<type-name>:
-		<parameter-name>: <value>
-		<parameter-name>: <value>
-		...
+    <type-name>:
+        <parameter-name>: <value>
+        <parameter-name>: <value>
+        ...
 
 
 Example:
 
 parameters:
-	Shelf Height (Upper):
-		type: Length
-		category: PG_GEOMETRY
-		instance: false
+    Shelf Height (Upper):
+        type: Length
+        group: PG_GEOMETRY or Geometry (2022+)
+        instance: false
 types:
-	24D"x36H":
-		Shelf Height (Upper): 3'-0"
+    24D"x36H":
+        Shelf Height (Upper): 3'-0"
 
 Note: If a parameter is in the revit file and the yaml file,
 but shared in one and family in the other, after import,
@@ -40,8 +40,7 @@ the parameter won't change. So if it was shared in the revit file,
 but family in the yaml file, it will remain shared.
 """
 # pylint: disable=import-error,invalid-name,broad-except
-# TODO: export parameter ordering
-import codecs
+# FIXME export parameter ordering
 
 from pyrevit import HOST_APP
 from pyrevit import revit, DB
@@ -114,7 +113,7 @@ def get_param_typevalue(ftype, fparam):
         # support various types of params that reference other elements
         # these values can not be stored by their id since the same symbol
         # will most probably have a different id in another document
-        if HOST_APP.is_newer_than(2022): # ParameterType deprecated in 2023
+        if HOST_APP.is_newer_than(2022):  # ParameterType deprecated in 2023
             if DB.Category.IsBuiltInCategory(fparam.Definition.GetDataType()):
                 # storing type references by their name
                 fparam_value = get_symbol_name(ftype.AsElementId(fparam))
@@ -135,7 +134,7 @@ def get_param_typevalue(ftype, fparam):
         fparam_value = ftype.AsString(fparam)
 
     elif fparam.StorageType == DB.StorageType.Integer:
-        if HOST_APP.is_newer_than(2022): # ParameterType deprecated in 2023
+        if HOST_APP.is_newer_than(2022):  # ParameterType deprecated in 2023
             if DB.SpecTypeId.Boolean.YesNo == fparam.Definition.GetDataType():
                 fparam_value = \
                     'true' if ftype.AsInteger(fparam) == 1 else 'false'
@@ -221,7 +220,7 @@ def read_configs(selected_fparam_names,
         fparam_isreport = sparam.fparam.IsReporting
         fparam_formula = sparam.fparam.Formula
         fparam_shared = sparam.fparam.IsShared
-        if HOST_APP.is_newer_than(2022): # ParameterType deprecated in 2023
+        if HOST_APP.is_newer_than(2022):  # ParameterType deprecated in 2023
             fparam_type = sparam.fparam.Definition.GetDataType()
             fparam_type_str = fparam_type.TypeId
             fparam_group = sparam.fparam.Definition.GetGroupTypeId().TypeId
@@ -244,7 +243,7 @@ def read_configs(selected_fparam_names,
                 sparam.fparam.GUID
 
         # get the family category if param is FamilyType selector
-        if HOST_APP.is_newer_than(2022): # ParameterType deprecated in 2023
+        if HOST_APP.is_newer_than(2022):  # ParameterType deprecated in 2023
             if 'autodesk.revit.category.family' in fparam_type.TypeId:
                 cfgs_dict[PARAM_SECTION_NAME][fparam_name][PARAM_SECTION_CAT] = \
                     get_famtype_famcat(sparam.fparam)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
@@ -217,21 +217,22 @@ def read_configs(selected_fparam_names,
     # grab all parameter defs
     for sparam in sorted(export_sparams, reverse=True):
         fparam_name = sparam.fparam.Definition.Name
-        fparam_group = sparam.fparam.Definition.ParameterGroup
         fparam_isinst = sparam.fparam.IsInstance
         fparam_isreport = sparam.fparam.IsReporting
         fparam_formula = sparam.fparam.Formula
         fparam_shared = sparam.fparam.IsShared
         if HOST_APP.is_newer_than(2022): # ParameterType deprecated in 2023
             fparam_type = sparam.fparam.Definition.GetDataType()
-            fparam_type_str = str(fparam_type.TypeId)
+            fparam_type_str = fparam_type.TypeId
+            fparam_group = sparam.fparam.Definition.GetGroupTypeId().TypeId
         else:
             fparam_type = sparam.fparam.Definition.ParameterType
             fparam_type_str = str(fparam_type)
+            fparam_group = sparam.fparam.Definition.ParameterGroup
 
         cfgs_dict[PARAM_SECTION_NAME][fparam_name] = {
             PARAM_SECTION_TYPE: fparam_type_str,
-            PARAM_SECTION_GROUP: str(fparam_group),
+            PARAM_SECTION_GROUP: fparam_group,
             PARAM_SECTION_INST: fparam_isinst,
             PARAM_SECTION_REPORT: fparam_isreport,
             PARAM_SECTION_FORMULA: fparam_formula,
@@ -329,9 +330,9 @@ def get_shared_param_def_contents(shared_params):
     return revit.files.read_text(temp_defs_filepath)
 
 
-def save_configs(configs_dict, parma_file):
+def save_configs(configs_dict, param_file):
     # Load contents of yaml file into an ordered dict
-    return yaml.dump_dict(configs_dict, parma_file)
+    return yaml.dump_dict(configs_dict, param_file)
 
 
 if __name__ == '__main__':

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
@@ -39,7 +39,7 @@ but shared in one and family in the other, after import,
 the parameter won't change. So if it was shared in the revit file,
 but family in the yaml file, it will remain shared.
 """
-#pylint: disable=import-error,invalid-name,broad-except
+# pylint: disable=import-error,invalid-name,broad-except
 # TODO: export parameter ordering
 import codecs
 
@@ -66,7 +66,7 @@ PARAM_SECTION_INST = 'instance'
 PARAM_SECTION_REPORT = 'reporting'
 PARAM_SECTION_FORMULA = 'formula'
 PARAM_SECTION_DEFAULT = 'default'
-PARAM_SECTION_GUID = 'GUID' # To store unique if of shared parameters
+PARAM_SECTION_GUID = 'GUID'  # To store unique if of shared parameters
 
 TYPES_SECTION_NAME = 'types'
 
@@ -115,7 +115,7 @@ def get_param_typevalue(ftype, fparam):
         # these values can not be stored by their id since the same symbol
         # will most probably have a different id in another document
         if HOST_APP.is_newer_than(2022): # ParameterType deprecated in 2023
-            if 'autodesk.revit.category.family' in fparam.Definition.GetDataType().TypeId:
+            if DB.Category.IsBuiltInCategory(fparam.Definition.GetDataType()):
                 # storing type references by their name
                 fparam_value = get_symbol_name(ftype.AsElementId(fparam))
             elif fparam.Definition.GetDataType() == \
@@ -126,7 +126,6 @@ def get_param_typevalue(ftype, fparam):
             if fparam.Definition.ParameterType == DB.ParameterType.FamilyType:
                 # storing type references by their name
                 fparam_value = get_symbol_name(ftype.AsElementId(fparam))
-
             elif fparam.Definition.ParameterType == \
                     DB.ParameterType.LoadClassification:
                 # storing load classifications by a unique id
@@ -140,8 +139,9 @@ def get_param_typevalue(ftype, fparam):
             if DB.SpecTypeId.Boolean.YesNo == fparam.Definition.GetDataType():
                 fparam_value = \
                     'true' if ftype.AsInteger(fparam) == 1 else 'false'
-            else:
-                DB.ParameterType.YesNo == fparam.Definition.ParameterType:
+        elif DB.ParameterType.YesNo == fparam.Definition.ParameterType:
+            fparam_value = \
+                'true' if ftype.AsInteger(fparam) == 1 else 'false'
         else:
             fparam_value = ftype.AsInteger(fparam)
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Export Family Config.pushbutton/script.py
@@ -237,7 +237,7 @@ def read_configs(selected_fparam_names,
         if HOST_APP.is_newer_than(2022):  # ParameterType deprecated in 2023
             fparam_type = sparam.fparam.Definition.GetDataType()
             fparam_type_str = fparam_type.TypeId
-            fparam_group = sparam.fparam.Definition.GetGroupTypeId()
+            fparam_group = sparam.fparam.Definition.GetGroupTypeId().TypeId
         else:
             fparam_type = sparam.fparam.Definition.ParameterType
             fparam_type_str = str(fparam_type)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Import Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Import Family Config.pushbutton/script.py
@@ -17,7 +17,8 @@ parameters:
     <parameter-name>:
         type: <Autodesk.Revit.DB.ParameterType> or
         <Autodesk.Revit.DB.ParameterTypeId Members> (2022+)
-        group: <Autodesk.Revit.DB.BuiltInParameterGroup>  or
+        
+        : <Autodesk.Revit.DB.BuiltInParameterGroup>  or
         <Autodesk.Revit.DB.GroupTypeId Members> (2022+)
         instance: <true|false>
         reporting: <true|false>
@@ -390,6 +391,7 @@ def ensure_params(fconfig):
         # going through the parameters in the yaml file
         # and ensure all defined parameters exist
         for pname, popts in param_cfgs.items():
+            print(popts)
             if pname and popts:
                 # extract param config from dict
                 pcfg = get_param_config(pname, popts)
@@ -520,10 +522,8 @@ if __name__ == '__main__':
                 ctype = family_mgr.CurrentType
                 if not ctype:
                     ctype = family_mgr.NewType(TEMP_TYPENAME)
-
                 ensure_params(family_configs)
                 ensure_types(family_configs)
-
                 # Restore current type
                 if ctype.Name != TEMP_TYPENAME:
                     family_mgr.CurrentType = ctype

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Import Family Config.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Import Family Config.pushbutton/script.py
@@ -17,7 +17,6 @@ parameters:
     <parameter-name>:
         type: <Autodesk.Revit.DB.ParameterType> or
         <Autodesk.Revit.DB.ParameterTypeId Members> (2022+)
-        
         : <Autodesk.Revit.DB.BuiltInParameterGroup>  or
         <Autodesk.Revit.DB.GroupTypeId Members> (2022+)
         instance: <true|false>


### PR DESCRIPTION
Due to changes in the parameter storage and description in the API, the import and export family config tool needs some love to adjust to 2022+ new api

So far it is still a work in progress 