### PR TITLE
FamilyLoaderOptionsHandler modification

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/create.py
+++ b/pyrevitlib/pyrevit/revit/db/create.py
@@ -28,9 +28,12 @@ PARAM_VALUE_EVALUATORS = {
 
 # http://www.revitapidocs.com/2018.1/5da8e3c5-9b49-f942-02fc-7e7783fe8f00.htm
 class FamilyLoaderOptionsHandler(DB.IFamilyLoadOptions):
+    def __init__(self, overwriteParameterValues=True):
+        self._overwriteParameterValues = overwriteParameterValues
+
     def OnFamilyFound(self, familyInUse, overwriteParameterValues): #pylint: disable=W0613
         """A method called when the family was found in the target document."""
-        overwriteParameterValues.Value = True
+        overwriteParameterValues.Value = self._overwriteParameterValues
         return True
 
     def OnSharedFamilyFound(self,
@@ -39,7 +42,7 @@ class FamilyLoaderOptionsHandler(DB.IFamilyLoadOptions):
                             source, #pylint: disable=W0613
                             overwriteParameterValues): #pylint: disable=W0613
         source.Value = DB.FamilySource.Family
-        overwriteParameterValues.Value = True
+        overwriteParameterValues.Value = self._overwriteParameterValues
         return True
 
 

--- a/pyrevitlib/pyrevit/revit/db/create.py
+++ b/pyrevitlib/pyrevit/revit/db/create.py
@@ -30,6 +30,7 @@ PARAM_VALUE_EVALUATORS = {
 class FamilyLoaderOptionsHandler(DB.IFamilyLoadOptions):
     def OnFamilyFound(self, familyInUse, overwriteParameterValues): #pylint: disable=W0613
         """A method called when the family was found in the target document."""
+        overwriteParameterValues.Value = True
         return True
 
     def OnSharedFamilyFound(self,
@@ -37,8 +38,8 @@ class FamilyLoaderOptionsHandler(DB.IFamilyLoadOptions):
                             familyInUse, #pylint: disable=W0613
                             source, #pylint: disable=W0613
                             overwriteParameterValues): #pylint: disable=W0613
-        source = DB.FamilySource.Family
-        overwriteParameterValues = True
+        source.Value = DB.FamilySource.Family
+        overwriteParameterValues.Value = True
         return True
 
 


### PR DESCRIPTION
I ran across this when working on my own plug-in. The DB.Document.LoadFamily method wouldn't reload the family types until I made this change.

Some parameters in this interface are passed by-reference (using the out keyword in the argument list).

These references are changed with their Value attribute. The values set in the current implementation don't stick, counter to the intent of the code.

I also set the overwriteParameterValues, for consistency.

See this IronPython explainer. ([Link](https://ironpython.net/documentation/dotnet/dotnet.html#methods-with-ref-or-out-parameters))

Thank you! We love pyRevit at CORE Design Group.