### PR TITLE
Option to set icon size for toggle_icon and UIpanel's is_beta

### DIFF
--- a/pyrevitlib/pyrevit/loader/uimaker.py
+++ b/pyrevitlib/pyrevit/loader/uimaker.py
@@ -552,7 +552,10 @@ def _produce_ui_panels(ui_maker_params):
     """
     parent_ui_tab = ui_maker_params.parent_ui
     panel = ui_maker_params.component
-
+    
+    if panel.is_beta and not ui_maker_params.create_beta_cmds:
+        return None
+    
     mlogger.debug('Producing ribbon panel: %s', panel)
     try:
         parent_ui_tab.create_ribbon_panel(panel.name, update_if_exists=True)

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -39,6 +39,9 @@ mlogger = logger.get_logger(__name__)
 
 DATAFEXT = 'pym'
 
+ICON_SMALL = 16
+ICON_MEDIUM = 24
+ICON_LARGE = 32
 
 def get_info():
     """Return info on current pyRevit command.
@@ -416,7 +419,7 @@ def get_all_buttons():
     return buttons
 
 
-def toggle_icon(new_state, on_icon_path=None, off_icon_path=None):
+def toggle_icon(new_state, on_icon_path=None, off_icon_path=None, icon_size=ICON_MEDIUM):
     """Set the state of button icon (on or off).
 
     This method expects on.png and off.png in command bundle for on and off
@@ -454,7 +457,7 @@ def toggle_icon(new_state, on_icon_path=None, off_icon_path=None):
                   new_state, icon_path)
 
     for uibutton in uibuttons:
-        uibutton.set_icon(icon_path)
+        uibutton.set_icon(icon_path, icon_size)
 
 
 def exit():     #pylint: disable=W0622


### PR DESCRIPTION
toggle_icon() now allows you to select the icon size, so they don't change when you use them.
Examples:
script.toggle_icon(new_state, icon_size = script.ICON_LARGE)
script.toggle_icon(new_state, icon_size = script.ICON_MEDIUM)
script.toggle_icon(new_state, icon_size = script.ICON_SMALL)

UI Panels can now use "is_beta" in yaml to avoid creating empty panels when all of its buttons are beta buttons.
A cleaner solution without "is_beta" should be made.