### PR TITLE
docs: fix and update docstrings

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ pygount = "*"
 pyyaml = ">=5.4"
 black = "*"
 setuptools = "==65.5.1"
+ruff = "*"
 
 [requires]
 python_version = "3.10"
@@ -24,3 +25,4 @@ allow_prereleases = true
 
 [scripts]
 pyrevit = "python ./dev/pyrevit.py"
+check-docstrings = "ruff check --fix pyrevitlib/pyrevit"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub forks](https://img.shields.io/github/forks/eirannejad/pyRevit.svg?style=for-the-badge)](https://github.com/eirannejad/pyRevit/network)
 [![GitHub stars](https://img.shields.io/github/stars/eirannejad/pyRevit.svg?style=for-the-badge&colorB=red)](https://github.com/eirannejad/pyRevit/stargazers)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg?style=for-the-badge)](http://www.gnu.org/licenses/gpl-3.0)
-[![madewithloveinportland](https://img.shields.io/badge/%3C%2F%3E%20with%20%3C3-Portland%2C%20OR-green.svg?style=for-the-badge)](https://en.wikipedia.org/wiki/Portland,_Oregon)
+[![made with love in portland](https://img.shields.io/badge/%3C%2F%3E%20with%20%3C3-Portland%2C%20OR-green.svg?style=for-the-badge)](https://en.wikipedia.org/wiki/Portland,_Oregon)
 
 &nbsp;
 
@@ -120,12 +120,11 @@ Check the list of [Currently Open](https://github.com/eirannejad/pyRevit/issues)
 
 ## Share Your Coins
 
-**↓** Help making pyRevit financially stronger 
+**↓** Help making pyRevit financially stronger
 
 [Support on Patreon](https://www.notion.so/Support-on-Patreon-cdf92ba547154f7a85d32b526dc5e59b)
 
 [Supporters](https://www.notion.so/Supporters-4f3350243ba24dcd8228df6262723629)
-
 
 # Contributors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+select = ["D"]
+ignore = ["D107", "D105"]
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/pyrevitlib/pyrevit/__init__.py
+++ b/pyrevitlib/pyrevit/__init__.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 import traceback
 import re
 
-import clr  #pylint: disable=E0401
+import clr  # pylint: disable=E0401
 
 from pyrevit import compat
 
@@ -141,7 +141,7 @@ class PyRevitIOError(PyRevitException):
 
 
 class PyRevitCPythonNotSupported(PyRevitException):
-    """Common base class for all pyRevit io-related exceptions."""
+    """Exception for features not supported under CPython."""
     def __init__(self, feature_name):
         super(PyRevitCPythonNotSupported, self).__init__()
         self.feature_name = feature_name
@@ -179,10 +179,7 @@ class _HostApplication(object):
     info on the active screen, active document and ui-document, available
     postable commands, and other functionality.
 
-    Args:
-        host_uiapp (``UIApplication``): Instance of running host.
-
-    Example:
+    Examples:
         >>> hostapp = _HostApplication()
         >>> hostapp.is_newer_than(2017)
     """
@@ -211,7 +208,7 @@ class _HostApplication(object):
 
     @property
     def has_api_context(self):
-        """Determine if host application is in API context"""
+        """Determine if host application is in API context."""
         return self.app.ActiveAddInId is not None
 
     @property
@@ -278,8 +275,13 @@ class _HostApplication(object):
 
     @property
     def pretty_name(self):
-        """str: Pretty name of the host
-        (e.g. 'Autodesk Revit 2019.2 build: 20190808_0900(x64)')
+        """Returns the pretty name of the host.
+
+        Examples:
+            Autodesk Revit 2019.2 build: 20190808_0900(x64)
+
+        Returns:
+            (str): Pretty name of the host
         """
         host_name = self.version_name
         if self.is_newer_than(2017):
@@ -359,6 +361,7 @@ class _HostApplication(object):
 
         Args:
             version (str or int): version to check against.
+            or_equal (bool): Whether to include `version` in the comparison
         """
         if or_equal:
             return int(self.version) >= int(version)
@@ -385,7 +388,7 @@ class _HostApplication(object):
         """Return list of postable commands.
 
         Returns:
-            :obj:`list` of :obj:`_HostAppPostableCommand`
+            (list[_HostAppPostableCommand]): postable commands.
         """
         # if list of postable commands is _not_ already created
         # make the list and store in instance parameter
@@ -408,7 +411,7 @@ class _HostApplication(object):
         return self._postable_cmds
 
     def post_command(self, command_id):
-        """Request Revit to run a command
+        """Request Revit to run a command.
 
         Args:
             command_id (str): command identifier e.g. ID_REVIT_SAVE_AS_TEMPLATE
@@ -435,7 +438,7 @@ class _ExecutorParams(object):
 
     @property   # read-only
     def exec_id(self):
-        """Return execution unique id"""
+        """Return execution unique id."""
         try:
             return __execid__
         except NameError:
@@ -443,7 +446,7 @@ class _ExecutorParams(object):
 
     @property   # read-only
     def exec_timestamp(self):
-        """Return execution timestamp"""
+        """Return execution timestamp."""
         try:
             return __timestamp__
         except NameError:
@@ -451,7 +454,7 @@ class _ExecutorParams(object):
 
     @property   # read-only
     def engine_id(self):
-        """Return engine id"""
+        """Return engine id."""
         try:
             return __cachedengineid__
         except NameError:
@@ -488,25 +491,25 @@ class _ExecutorParams(object):
 
     @property   # read-only
     def output_stream(self):
-        """Return ScriptIO"""
+        """Return ScriptIO."""
         if self.script_runtime:
             return self.script_runtime.OutputStream
 
     @property   # read-only
     def script_data(self):
-        """Return ScriptRuntime.ScriptData"""
+        """Return ScriptRuntime.ScriptData."""
         if self.script_runtime:
             return self.script_runtime.ScriptData
 
     @property   # read-only
     def script_runtime_cfgs(self):
-        """Return ScriptRuntime.ScriptRuntimeConfigs"""
+        """Return ScriptRuntime.ScriptRuntimeConfigs."""
         if self.script_runtime:
             return self.script_runtime.ScriptRuntimeConfigs
 
     @property   # read-only
     def engine_cfgs(self):
-        """Return ScriptRuntime.ScriptRuntimeConfigs"""
+        """Return ScriptRuntime.ScriptRuntimeConfigs."""
         if self.script_runtime:
             return self.script_runtime.EngineConfigs
 
@@ -598,15 +601,13 @@ class _ExecutorParams(object):
 
     @property   # read
     def window_handle(self):
-        """``PyRevitLabs.PyRevit.Runtime.ScriptConsole``:
-                Return output window. handle
-        """
+        """Output window handle."""
         if self.script_runtime:
             return self.script_runtime.OutputWindow
 
     @property
     def command_data(self):
-        """``ExternalCommandData``: Return current command data."""
+        """ExternalCommandData: Return current command data."""
         if self.script_runtime_cfgs:
             return self.script_runtime_cfgs.CommandData
 
@@ -710,16 +711,16 @@ EXEC_PARAMS = _ExecutorParams()
 # -----------------------------------------------------------------------------
 
 class _DocsGetter(object):
-    """Instance to safely get document from HOST_APP instance or EXEC_PARAMS"""
+    """Instance to safely get document from HOST_APP instance or EXEC_PARAMS."""
 
     @property
     def doc(self):
-        """Active document"""
+        """Active document."""
         return HOST_APP.doc or EXEC_PARAMS.event_doc
 
     @property
     def docs(self):
-        """List of active documents"""
+        """List of active documents."""
         return HOST_APP.docs
 
 

--- a/pyrevitlib/pyrevit/api.py
+++ b/pyrevitlib/pyrevit/api.py
@@ -1,6 +1,6 @@
 """Provide access to Revit API.
 
-Example:
+Examples:
     >>> from pyrevit.api import AdWindows
 """
 import os.path as op
@@ -30,16 +30,31 @@ from Autodesk.Revit.DB import DirectContext3D
 
 
 def get_product_serial_number():
-    """Return serial number of running host instance."""
+    """Return serial number of running host instance.
+
+    Returns:
+        (str): Serial number
+    """
     return UIFrameworkServices.InfoCenterService.ProductSerialNumber
 
 
 def is_product_demo():
-    """Determine if product is using demo license"""
+    """Determine if product is using demo license.
+
+    Returns:
+        (bool): True if product is using demo license
+    """
     return get_product_serial_number() == '000-00000000'
 
 
 def is_api_object(data_type):
-    """Check if given object belongs to Revit API"""
+    """Check if given object belongs to Revit API.
+
+    Args:
+        data_type (object): Object to check
+
+    Returns:
+        (bool): True if object belongs to Revit API
+    """
     if hasattr(data_type, 'GetType'):
         return 'Autodesk.Revit.' in data_type.GetType().Namespace

--- a/pyrevitlib/pyrevit/compat.py
+++ b/pyrevitlib/pyrevit/compat.py
@@ -1,6 +1,6 @@
 """python engine compatibility module.
 
-Example:
+Examples:
     >>> from pyrevit.compat import IRONPY277
     >>> from pyrevit.compat import safe_strtype
 """
@@ -42,14 +42,24 @@ if PY2:
 
 
 def urlopen(url):
-    """urlopen wrapper"""
+    """Urlopen wrapper.
+
+    Args:
+        url (str): request url
+    """
     if PY3:
         return urllib.request.urlopen(url)
     return urllib2.urlopen(url)
 
 
 def make_request(url, headers, data):
-    """urlopen wrapper to create and send a request"""
+    """Urlopen wrapper to create and send a request.
+
+    Args:
+        url (str): request url
+        headers (dict[str, str]): headers
+        data (bytes | None): request data
+    """
     if PY3:
         req = urllib.request.Request(url, headers, data)
         urllib.request.urlopen(req).close()

--- a/pyrevitlib/pyrevit/coreutils/__init__.py
+++ b/pyrevitlib/pyrevit/coreutils/__init__.py
@@ -1,6 +1,6 @@
 """Misc Helper functions for pyRevit.
 
-Example:
+Examples:
     >>> from pyrevit import coreutils
     >>> coreutils.cleanup_string('some string')
 """
@@ -53,7 +53,7 @@ UNICODE_NONPRINTABLE_CHARS = [
 class Timer(object):
     """Timer class using python native time module.
 
-    Example:
+    Examples:
         >>> timer = Timer()
         >>> timer.get_time()
         12
@@ -78,7 +78,7 @@ class ScriptFileParser(object):
     Primarily designed to assist pyRevit in determining script configurations
     but can work for any python script.
 
-    Example:
+    Examples:
         >>> finder = ScriptFileParser('/path/to/coreutils/__init__.py')
         >>> finder.docstring()
         ... "Misc Helper functions for pyRevit."
@@ -100,7 +100,7 @@ class ScriptFileParser(object):
                 self.ast_tree = ast.parse(contents)
 
     def extract_node_value(self, node):
-        """Manual extraction of values from node"""
+        """Manual extraction of values from node."""
         if isinstance(node, ast.Assign):
             node_value = node.value
         else:
@@ -136,7 +136,7 @@ class ScriptFileParser(object):
                 default value to be returned if variable does not exist
 
         Returns:
-            any: value of the variable or :obj:`None`
+            (Any): value of the variable or None
         """
         if self.ast_tree:
             try:
@@ -159,7 +159,7 @@ class FileWatcher(object):
     This is a simple utility class to look for changes in a file based on
     its timestamp.
 
-    Example:
+    Examples:
         >>> watcher = FileWatcher('/path/to/file.ext')
         >>> watcher.has_changed
         True
@@ -191,7 +191,7 @@ class SafeDict(dict):
     This is a dictionary subclass to help with string formatting with unknown
     key values.
 
-    Example:
+    Examples:
         >>> string = '{target} {attr} is {color}.'
         >>> safedict = SafeDict({'target': 'Apple',
         ...                      'attr':   'Color'})
@@ -210,7 +210,7 @@ def get_all_subclasses(parent_classes):
         parent_classes (list): list of python classes
 
     Returns:
-        list: list of python subclasses
+        (list): list of python subclasses
     """
     sub_classes = []
     # if super-class, get a list of sub-classes.
@@ -234,7 +234,7 @@ def get_sub_folders(search_folder):
         search_folder (str): folder path
 
     Returns:
-        list: list of subfolder names
+        (list[str]): list of subfolder names
     """
     sub_folders = []
     for sub_folder in os.listdir(search_folder):
@@ -250,10 +250,10 @@ def verify_directory(folder):
         folder (str): path of folder to verify
 
     Returns:
-        str: path of verified folder, equals to provided folder
+        (str): path of verified folder, equals to provided folder
 
     Raises:
-        OSError on folder creation error.
+        OSError: on folder creation error.
     """
     if not op.exists(folder):
         try:
@@ -272,7 +272,7 @@ def join_strings(str_list, separator=DEFAULT_SEPARATOR):
             defaults to DEFAULT_SEPARATOR
 
     Returns:
-        str: joined string
+        (str): joined string
     """
     if str_list:
         if any(not isinstance(x, str) for x in str_list):
@@ -316,8 +316,9 @@ def cleanup_string(input_str, skip=None):
 
     Args:
         input_str (str): input string to be cleaned
+        skip (Container[str]): special characters to keep
 
-    Example:
+    Examples:
         >>> src_str = 'TEST@Some*<value>'
         >>> cleanup_string(src_str)
         "TESTATSomeSTARvalue"
@@ -335,7 +336,7 @@ def get_revit_instance_count():
     """Return number of open host app instances.
 
     Returns:
-        int: number of open host app instances.
+        (int): number of open host app instances.
     """
     return len(list(framework.Process.GetProcessesByName(HOST_APP.proc_name)))
 
@@ -396,12 +397,12 @@ def make_canonical_name(*args):
     """Join arguments with dot creating a unique id.
 
     Args:
-        *args: Variable length argument list of type :obj:`str`
+        *args (str): Variable length argument list
 
     Returns:
-        str: dot separated unique name
+        (str): dot separated unique name
 
-    Example:
+    Examples:
         >>> make_canonical_name('somename', 'someid', 'txt')
         "somename.someid.txt"
     """
@@ -412,12 +413,12 @@ def get_canonical_parts(canonical_string):
     """Splots argument using dot, returning all composing parts.
 
     Args:
-        canonical_string(:obj:`str`): Source string e.g. "Config.SubConfig"
+        canonical_string (str): Source string e.g. "Config.SubConfig"
 
     Returns:
-        list[:obj:`str`]: list of composing parts
+        (list[str]): list of composing parts
 
-    Example:
+    Examples:
         >>> get_canonical_parts("Config.SubConfig")
         ['Config', 'SubConfig']
     """
@@ -442,7 +443,7 @@ def get_str_hash(source_str):
         source_str (str): source str
 
     Returns:
-        str: hash value as string
+        (str): hash value as string
     """
     return hashlib.md5(source_str.encode('utf-8', 'ignore')).hexdigest()
 
@@ -456,9 +457,9 @@ def calculate_dir_hash(dir_path, dir_filter, file_filter):
         file_filter (str): exclude files matching this regex
 
     Returns:
-        str: hash value as string
+        (str): hash value as string
 
-    Example:
+    Examples:
         >>> calculate_dir_hash(source_path, '\.extension', '\.json')
         "1a885a0cae99f53d6088b9f7cee3bf4d"
     """
@@ -486,7 +487,7 @@ def prepare_html_str(input_string):
     Args:
         input_string (str): input html string
 
-    Example:
+    Examples:
         >>> prepare_html_str('<p>Some text</p>')
         "&clt;p&cgt;Some text&clt;/p&cgt;"
     """
@@ -506,7 +507,7 @@ def reverse_html(input_html):
     Args:
         input_html (str): input codified html string
 
-    Example:
+    Examples:
         >>> prepare_html_str('&clt;p&cgt;Some text&clt;/p&cgt;')
         "<p>Some text</p>"
     """
@@ -536,7 +537,7 @@ def can_access_url(url_to_open, timeout=1000):
         timeout (int): timeout in milliseconds
 
     Returns:
-        bool: true if accessible
+        (bool): true if accessible
     """
     try:
         client = framework.WebRequest.Create(url_to_open)
@@ -569,7 +570,7 @@ def check_internet_connection(timeout=1000):
         timeout (int): timeout in milliseconds
 
     Returns:
-        url if internet connection is present, None if no internet.
+        (str): url if internet connection is present, None if no internet.
     """
     solid_urls = ["http://google.com/",
                   "http://github.com/",
@@ -605,10 +606,10 @@ def read_source_file(source_file_path):
         source_file_path (str): target file path
 
     Returns:
-        str: file contents
+        (str): file contents
 
     Raises:
-        :obj:`PyRevitException` on read error
+        PyRevitException: on read error
     """
     try:
         with open(source_file_path, 'r') as code_file:
@@ -659,11 +660,12 @@ def cleanup_filename(file_name, windows_safe=False):
 
     Args:
         file_name (str): file name
+        windows_safe (bool): whether to use windows safe characters
 
     Returns:
-        str: cleaned up file name
+        (str): cleaned up file name
 
-    Example:
+    Examples:
         >>> cleanup_filename('Myfile-(3).txt')
         "Myfile(3).txt"
 
@@ -682,11 +684,13 @@ def _inc_or_dec_string(str_id, shift, refit=False, logger=None):
     Args:
         str_id (str): identifier e.g. A310a
         shift (int): number of steps to change the identifier
+        refit (bool): whether to refit the identifier
+        logger (logging.Logger): logger
 
     Returns:
-        str: modified identifier
+        (str): modified identifier
 
-    Example:
+    Examples:
         >>> _inc_or_dec_string('A319z')
         'A320a'
     """
@@ -783,11 +787,12 @@ def increment_str(input_str, step=1, expand=False):
     Args:
         input_str (str): identifier e.g. A310a
         step (int): number of steps to change the identifier
+        expand (bool): removes leading zeroes and duplicate letters
 
     Returns:
-        str: modified identifier
+        (str): modified identifier
 
-    Example:
+    Examples:
         >>> increment_str('A319z')
         'A320a'
     """
@@ -800,11 +805,12 @@ def decrement_str(input_str, step=1, shrink=False):
     Args:
         input_str (str): identifier e.g. A310a
         step (int): number of steps to change the identifier
+        shrink (bool): removes leading zeroes or duplicate letters 
 
     Returns:
-        str: modified identifier
+        (str): modified identifier
 
-    Example:
+    Examples:
         >>> decrement_str('A310a')
         'A309z'
     """
@@ -812,7 +818,7 @@ def decrement_str(input_str, step=1, shrink=False):
 
 
 def extend_counter(input_str, upper=True, use_zero=False):
-    """Add a new level to identifier. e.g. A310 -> A310A
+    """Add a new level to identifier. e.g. A310 -> A310A.
 
     Args:
         input_str (str): identifier e.g. A310
@@ -820,9 +826,9 @@ def extend_counter(input_str, upper=True, use_zero=False):
         use_zero (bool): start from 0 for numeric extension
 
     Returns:
-        str: extended identifier
+        (str): extended identifier
 
-    Example:
+    Examples:
         >>> extend_counter('A310')
         'A310A'
         >>> extend_counter('A310A', use_zero=True)
@@ -838,10 +844,10 @@ def filter_null_items(src_list):
     """Remove None items in the given list.
 
     Args:
-        src_list (:obj:`list`): list of any items
+        src_list (list[Any]): list of any items
 
     Returns:
-        :obj:`list`: cleaned list
+        (list[Any]): cleaned list
     """
     return list(filter(bool, src_list))
 
@@ -850,12 +856,12 @@ def reverse_dict(input_dict):
     """Reverse the key, value pairs.
 
     Args:
-        input_dict (:obj:`dict`): source ordered dict
+        input_dict (dict): source ordered dict
 
     Returns:
-        :obj:`defaultdict`: reversed dictionary
+        (defaultdict): reversed dictionary
 
-    Example:
+    Examples:
         >>> reverse_dict({1: 2, 3: 4})
         defaultdict(<type 'list'>, {2: [1], 4: [3]})
     """
@@ -869,9 +875,9 @@ def timestamp():
     """Return timestamp for current time.
 
     Returns:
-        str: timestamp in string format
+        (str): timestamp in string format
 
-    Example:
+    Examples:
         >>> timestamp()
         '01003075032506808'
     """
@@ -884,9 +890,9 @@ def current_time():
     Current implementation uses %H:%M:%S to format time.
 
     Returns:
-        str: formatted current time.
+        (str): formatted current time.
 
-    Example:
+    Examples:
         >>> current_time()
         '07:50:53'
     """
@@ -899,9 +905,9 @@ def current_date():
     Current implementation uses %Y-%m-%d to format date.
 
     Returns:
-        str: formatted current date.
+        (str): formatted current date.
 
-    Example:
+    Examples:
         >>> current_date()
         '2018-01-03'
     """
@@ -915,9 +921,9 @@ def is_blank(input_string):
         input_string (str): input string
 
     Returns:
-        bool: True if string is blank
+        (bool): True if string is blank
 
-    Example:
+    Examples:
         >>> is_blank('   ')
         True
     """
@@ -933,9 +939,9 @@ def is_url_valid(url_string):
         url_string (str): URL string
 
     Returns:
-        bool: True if URL is in valid format
+        (bool): True if URL is in valid format
 
-    Example:
+    Examples:
         >>> is_url_valid('https://www.google.com')
         True
     """
@@ -963,9 +969,9 @@ def reformat_string(orig_str, orig_format, new_format):
         new_format (str): New pattern (how to recompose the data)
 
     Returns:
-        str: Reformatted string
+        (str): Reformatted string
 
-    Example:
+    Examples:
         >>> reformat_string('150 - FLOOR/CEILING - WD - 1 HR - FLOOR ASSEMBLY',
                             '{section} - {loc} - {mat} - {rating} - {name}',
                             '{section}:{mat}:{rating} - {name} ({loc})'))
@@ -1010,9 +1016,9 @@ def dletter_to_unc(dletter_path):
         dletter_path (str): drive letter path
 
     Returns:
-        str: UNC path
+        (str): UNC path
 
-    Example:
+    Examples:
         >>> # assuming J: is mapped to //filestore/server/jdrive
         >>> dletter_to_unc('J:/somefile.txt')
         '//filestore/server/jdrive/somefile.txt'
@@ -1031,9 +1037,9 @@ def unc_to_dletter(unc_path):
         unc_path (str): UNC path
 
     Returns:
-        str: drive letter path
+        (str): drive letter path
 
-    Example:
+    Examples:
         >>> # assuming J: is mapped to //filestore/server/jdrive
         >>> unc_to_dletter('//filestore/server/jdrive/somefile.txt')
         'J:/somefile.txt'
@@ -1057,7 +1063,7 @@ def random_alpha():
 def random_hex_color():
     """Return a random color in hex format.
 
-    Example:
+    Examples:
         >>> random_hex_color()
         '#FF0000'
     """
@@ -1069,7 +1075,7 @@ def random_hex_color():
 def random_rgb_color():
     """Return a random color in rgb format.
 
-    Example:
+    Examples:
         >>> random_rgb_color()
         'rgb(255, 0, 0)'
     """
@@ -1081,7 +1087,7 @@ def random_rgb_color():
 def random_rgba_color():
     """Return a random color in rgba format.
 
-    Example:
+    Examples:
         >>> random_rgba_color()
         'rgba(255, 0, 0, 0.5)'
     """
@@ -1103,11 +1109,12 @@ def extract_range(formatted_str, max_range=500):
 
     Args:
         formatted_str (str): string specifying range
+        max_range (int): maximum number of items to create.
 
     Returns:
-        list: list of names in the specified range
+        (list[str]): names in the specified range
 
-    Example:
+    Examples:
         >>> exract_range('A103:A106')
         ['A103', 'A104', 'A105', 'A106']
         >>> exract_range('S203-S206')
@@ -1140,7 +1147,7 @@ def extract_range(formatted_str, max_range=500):
 
 
 def check_encoding_bom(filename, bom_bytes=codecs.BOM_UTF8):
-    """Check if given file contains the given BOM bytes at the start
+    """Check if given file contains the given BOM bytes at the start.
 
     Args:
         filename (str): file path
@@ -1157,7 +1164,7 @@ def has_nonprintable(input_str):
         input_str (str): input string
 
     Returns:
-        bool: True if contains non-printable characters
+        (bool): True if contains non-printable characters
     """
     return any([x in input_str for x in UNICODE_NONPRINTABLE_CHARS])
 
@@ -1168,7 +1175,7 @@ def get_enum_values(enum_type):
 
 
 def get_enum_value(enum_type, value_string):
-    """Return enum value matching given value string (case insensitive)"""
+    """Return enum value matching given value string (case insensitive)."""
     for ftype in get_enum_values(enum_type):
         if str(ftype).lower() == value_string.lower():
             return ftype
@@ -1204,7 +1211,7 @@ def format_hex_rgb(rgb_value):
 
 
 def new_uuid():
-    """Create a new UUID (using dotnet Guid.NewGuid)"""
+    """Create a new UUID (using dotnet Guid.NewGuid)."""
     # RE: https://github.com/eirannejad/pyRevit/issues/413
     # return uuid.uuid1()
     return str(Guid.NewGuid())
@@ -1234,7 +1241,7 @@ def fuzzy_search_ratio(target_string, sfilter, regex=False):
         regex (bool): treat the sfilter as regular expression pattern
 
     Returns:
-        int: integer between 0 to 100, with 100 being the exact match
+        (int): integer between 0 to 100, with 100 being the exact match
     """
     tstring = target_string
 
@@ -1330,9 +1337,9 @@ def get_reg_key(key, subkey):
         subkey (str): subkey path
 
     Returns:
-        PyHKEY: registry key if found, None if not found
+        (PyHKEY): registry key if found, None if not found
 
-    Example:
+    Examples:
         >>> get_reg_key(wr.HKEY_CURRENT_USER, 'Control Panel/International')
         ... <PyHKEY at 0x...>
     """
@@ -1343,12 +1350,12 @@ def get_reg_key(key, subkey):
 
 
 def kill_tasks(task_name):
-    """Kill running tasks matching task_name
+    """Kill running tasks matching task_name.
 
     Args:
         task_name (str): task name
 
-    Example:
+    Examples:
         >>> kill_tasks('Revit.exe')
     """
     os.system("taskkill /f /im %s" % task_name)
@@ -1368,15 +1375,15 @@ def hex2int_long(hex_string):
 
 
 def split_words(input_string):
-    """Splits given string by uppercase characters
+    """Splits given string by uppercase characters.
 
     Args:
         input_string (str): input string
 
     Returns:
-        list[str]: split string
+        (list[str]): split string
 
-    Example:
+    Examples:
         >>> split_words("UIApplication_ApplicationClosing")
         ... ['UIApplication', 'Application', 'Closing']
     """
@@ -1395,10 +1402,10 @@ def split_words(input_string):
 
 
 def get_paper_sizes(printer_name=None):
-    """Get paper sizes defined on this system
+    """Get paper sizes defined on this system.
 
     Returns:
-        list[]: list of papersize instances
+        (list[]): list of papersize instances
     """
     print_settings = framework.Drawing.Printing.PrinterSettings()
     if printer_name:
@@ -1412,5 +1419,5 @@ def get_integer_length(number):
 
 
 def get_my_ip():
-    """Return local ip address of this machine"""
+    """Return local ip address of this machine."""
     return socket.gethostbyname(socket.gethostname())

--- a/pyrevitlib/pyrevit/coreutils/apidocs.py
+++ b/pyrevitlib/pyrevit/coreutils/apidocs.py
@@ -1,4 +1,4 @@
-"""ApiDocs API wrapper"""
+"""ApiDocs API wrapper."""
 import json
 from collections import namedtuple
 
@@ -16,6 +16,11 @@ APIDocsApp = namedtuple('APIDocsApp', ['apptitle', 'appslug', 'versionslug'])
 
 
 def get_apps():
+    """Returns a list of application availaboe on apidocs.
+
+    Returns:
+        (list[APIDocsApp]): applictations documented on apidocs
+    """
     apidoc_apps = []
     for app in json.loads(coreutils.read_url(APIDOCS_INDEX)):
         apidoc_apps.append(
@@ -29,6 +34,17 @@ def get_apps():
 
 
 def _make_uri(asset_type, asset_id, app_name, app_version):
+    """Retirna a URI for the given asset.
+
+    Args:
+        asset_type (str): Asset type
+        asset_id (str): Asset ID
+        app_name (str): Application name
+        app_version (str): Application version
+
+    Returns:
+        (str): URI
+    """
     return APIDOCS_LOOKUP_TEMPLATE.format(
         asset_type=asset_type,
         asset_id=asset_id,
@@ -40,6 +56,16 @@ def _make_uri(asset_type, asset_id, app_name, app_version):
 def make_namespace_uri(namespace,
                        app_name="revit",
                        app_version=str(HOST_APP.version)):
+    """Returns the URI of a namespace.
+
+    Args:
+        namespace (str): name of the namespace
+        app_name (str, optional): name of the application. Defaults to "revit".
+        app_version (str, optional): version of the application. Defaults to str(HOST_APP.version).
+
+    Returns:
+        (str): URI of the namespace
+    """
     return _make_uri(
         asset_type="N",
         asset_id=namespace,
@@ -51,6 +77,16 @@ def make_namespace_uri(namespace,
 def make_type_uri(type_name,
                   app_name="revit",
                   app_version=str(HOST_APP.version)):
+    """Returns the URI of a type.
+
+    Args:
+        type_name (str): name of the type
+        app_name (str, optional): name of the application. Defaults to "revit".
+        app_version (str, optional): version of the application. Defaults to str(HOST_APP.version).
+
+    Returns:
+        (str): URI of the type
+    """
     return _make_uri(
         asset_type="T",
         asset_id=type_name,
@@ -62,6 +98,17 @@ def make_type_uri(type_name,
 def make_event_uri(event_name,
                    app_name="revit",
                    app_version=str(HOST_APP.version)):
+    """Returns the URI of an event.
+
+    Args:
+        event_name (str): name of the event.
+        app_name (str): name of the application. Defaults to "revit".
+        app_version (str): version of the application.
+        
+
+    Returns:
+        (str): URI of the event
+    """
     return _make_uri(
         asset_type="E",
         asset_id=event_name,

--- a/pyrevitlib/pyrevit/coreutils/appdata.py
+++ b/pyrevitlib/pyrevit/coreutils/appdata.py
@@ -4,7 +4,7 @@ Most times, scripts need to save some data to share between different scripts
 that work on a similar topic or between script executions. This module provides
 the necessary and consistent mechanism for creating and maintaining such files.
 
-Example:
+Examples:
     >>> from pyrevit.coreutils import appdata
     >>> appdata.list_data_files()
 """
@@ -132,7 +132,7 @@ def get_universal_data_file(file_id, file_ext, name_only=False):
         name_only (bool): If true, function returns file name only
 
     Returns:
-        str: File name or full file path (depending on name_only)
+        (str): File name or full file path (depending on name_only)
     """
     return _get_app_file(file_id, file_ext,
                          filename_only=name_only, universal=True)
@@ -149,7 +149,7 @@ def get_data_file(file_id, file_ext, name_only=False):
         name_only (bool): If true, function returns file name only
 
     Returns:
-        str: File name or full file path (depending on name_only)
+        (str): File name or full file path (depending on name_only)
     """
     return _get_app_file(file_id, file_ext, filename_only=name_only)
 
@@ -166,7 +166,7 @@ def get_instance_data_file(file_id, file_ext=TEMP_FILE_EXT, name_only=False):
         name_only (bool): If true, function returns file name only
 
     Returns:
-        str: File name or full file path (depending on name_only)
+        (str): File name or full file path (depending on name_only)
     """
     return _get_app_file(file_id, file_ext,
                          filename_only=name_only, stamped=True)
@@ -179,7 +179,7 @@ def is_pyrevit_data_file(file_name):
         file_name (str): file name
 
     Returns:
-        bool: True if file is a pyRevit data file
+        (bool): True if file is a pyRevit data file
     """
     return pyrevit.PYREVIT_FILE_PREFIX in file_name
 
@@ -193,7 +193,7 @@ def is_file_available(file_name, file_ext, universal=False):
         universal (bool): Check against universal data files
 
     Returns:
-        str: file path if file is available
+        (str | bool): file path if file is available
     """
     if universal:
         full_filename = op.join(
@@ -217,7 +217,7 @@ def is_data_file_available(file_id, file_ext):
         file_ext (str): file extension
 
     Returns:
-        str: file path if file is available
+        (str): file path if file is available
     """
     full_filename = _get_app_file(file_id, file_ext)
     if op.exists(full_filename):
@@ -234,7 +234,7 @@ def list_data_files(file_ext, universal=False):
         universal (bool): Check against universal data files
 
     Returns:
-        :obj:`list`: list of files
+        (list[str]): list of files
     """
     return _list_app_files(
         pyrevit.PYREVIT_FILE_PREFIX,
@@ -250,20 +250,20 @@ def list_instance_data_files(file_ext):
         file_ext (str): data files with this extension will be listed only.
 
     Returns:
-        :obj:`list`: list of data files
+        (list[str]): list of data files
 
     """
     return _list_app_files(pyrevit.PYREVIT_FILE_PREFIX_STAMPED, file_ext)
 
 
 def find_data_files(file_ext):
-    """Find data files in all data files directories
+    """Find data files in all data files directories.
 
     Args:
         file_ext (str): data files with this extension will be listed only
 
     Returns:
-        :obj:`list`: list of files
+        (list[str]): list of files
     """
     all_datafiles = set()
     for app_folder in _list_app_folders():
@@ -280,14 +280,14 @@ def find_data_files(file_ext):
 
 
 def find_instance_data_files(file_ext, instance_id):
-    """Find instance data files in all data files directories
+    """Find instance data files in all data files directories.
 
     Args:
         file_ext (str): data files with this extension will be listed only
         instance_id (int): list data files for this instance id only
 
     Returns:
-        :obj:`list`: list of files
+        (list[str]): list of files
     """
     # instance files names are like pyRevit_2018_14422_
     instance_files = set()

--- a/pyrevitlib/pyrevit/coreutils/applocales.py
+++ b/pyrevitlib/pyrevit/coreutils/applocales.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Provide conversion services between python.locale and host languages"""
+"""Provide conversion services between python.locale and host languages."""
 # https://www.science.co.il/language/Locale-codes.php
 from pyrevit import HOST_APP, EXEC_PARAMS
 from pyrevit.api import ApplicationServices
@@ -147,44 +147,79 @@ else:
 
 
 def get_applocale_by_local_code(locale_code):
+    """Return application locale by locale code.
+
+    Args:
+        locale_code (str): locale code
+
+    Returns:
+        (AppLocale): application locale
+    """
     for applocale in APP_LOCALES:
         if locale_code in applocale.locale_codes:
             return applocale
 
 
 def get_applocale_by_lang_type(lang_type):
+    """Return application locale by language type.
+
+    Args:
+        lang_type (ApplicationServices.LanguageType | str): language type
+
+    Returns:
+        (AppLocale): application locale
+    """
     for applocale in APP_LOCALES:
         if lang_type == applocale.lang_type:
             return applocale
 
 
 def get_applocale_by_lang_name(lang_name):
+    """Return application locale by language name.
+
+    Args:
+        lang_name (str): language name
+
+    Returns:
+        (AppLocale): application locale
+    """
     for applocale in APP_LOCALES:
-        if lang_name == applocale.lang_name \
-                or lang_name == str(applocale.lang_type):
+        if lang_name in {applocale.lang_name, str(applocale.lang_type)}:
             return applocale
 
 
 def get_current_applocale():
+    """Return the current locale.
+    
+    This is the user locale, if set, or the host application locale otherwise.
+
+    Returns:
+        (AppLocale): current locale
+    """
     if user_config.user_locale:
         return get_applocale_by_local_code(user_config.user_locale)
     return get_applocale_by_lang_type(HOST_APP.language)
 
 
 def get_host_applocale():
+    """Return host application locale.
+
+    Returns:
+        (AppLocale): host application locale
+    """
     return get_applocale_by_lang_type(HOST_APP.language)
 
 
 def get_locale_string(string_dict):
-    """Returns the correct string from given dict based on host language
+    """Returns the correct string from given dict based on host language.
 
     Args:
-        string_dict (dict[str:str]): dict of strings in various locales
+        string_dict (dict[str, str]): dict of strings in various locales
 
     Returns:
-        str: string in correct locale
+        (str): string in correct locale
 
-    Example:
+    Examples:
         >>> data = {"en_us":"Hello", "chinese_s":"你好"}
         >>> from pyrevit.coreutils import applocales
         >>> # assuming running Revit is Chinese

--- a/pyrevitlib/pyrevit/coreutils/assmutils.py
+++ b/pyrevitlib/pyrevit/coreutils/assmutils.py
@@ -1,3 +1,4 @@
+"""Utilities to load and manage assemblies."""
 import os.path as op
 
 from pyrevit import PyRevitException
@@ -16,7 +17,7 @@ def load_asm(asm_name):
         asm_name (str): assembly name
 
     Returns:
-        returns the loaded assembly, None if not loaded.
+        (Any): the loaded assembly, None if not loaded.
     """
     return framework.AppDomain.CurrentDomain.Load(asm_name)
 
@@ -28,7 +29,7 @@ def load_asm_file(asm_file):
         asm_file (str): assembly file path
 
     Returns:
-        returns the loaded assembly, None if not loaded.
+        (Any): loaded assembly, None if not loaded.
     """
     try:
         return framework.Assembly.LoadFrom(asm_file)
@@ -56,9 +57,9 @@ def find_loaded_asm(asm_info, by_partial_name=False, by_location=False):
         by_location (bool): returns all assemblies matching location
 
     Returns:
-        list: List of all loaded assemblies matching the provided info
-        If only one assembly has been found, it returns the assembly.
-        :obj:`None` will be returned if assembly is not loaded.
+        (list): List of all loaded assemblies matching the provided info
+            If only one assembly has been found, it returns the assembly.
+            None will be returned if assembly is not loaded.
     """
     loaded_asm_list = []
     cleaned_asm_info = \
@@ -86,14 +87,14 @@ def find_type_by_name(assembly, type_name):
     """Find type by name in assembly.
 
     Args:
-        assembly (:obj:`Assembly`): assembly to find the type in
+        assembly (Assembly): assembly to find the type in
         type_name (str): type name
 
     Returns:
-        returns the type if found.
+        (type): type if found.
 
     Raises:
-        :obj:`PyRevitException` if type not found.
+        PyRevitException: if type not found.
     """
     base_class = assembly.GetType(type_name)
     if base_class is not None:

--- a/pyrevitlib/pyrevit/coreutils/charts.py
+++ b/pyrevitlib/pyrevit/coreutils/charts.py
@@ -1,4 +1,4 @@
-"""Charts engine for output window"""
+"""Charts engine for output window."""
 #pylint: disable=C0103
 from json import JSONEncoder
 
@@ -55,7 +55,7 @@ class PyRevitOutputChartDataset(object):
 
         Arguments are expected to be R, G, B, A values.
 
-        Example:
+        Examples:
             >>> dataset_obj.set_color(0xFF, 0x8C, 0x8D, 0.8)
         """
         if len(args) == 4:
@@ -80,9 +80,9 @@ class PyRevitOutputChartData(object):
             dataset_label (str): dataset label
 
         Returns:
-            :obj:`PyRevitOutputChartDataset`: dataset wrapper object
+            (PyRevitOutputChartDataset): dataset wrapper object
 
-        Example:
+        Examples:
             >>> chart.data.new_dataset('set_a')
         """
         new_dataset = PyRevitOutputChartDataset(dataset_label)
@@ -94,7 +94,7 @@ class PyRevitOutputChart(object):
     """Chart wrapper object for output window.
 
     Attributes:
-        output (:obj:`pyrevit.output.PyRevitOutputWindow`):
+        output (pyrevit.output.PyRevitOutputWindow):
             output window wrapper object
         chart_type (str): chart type name
     
@@ -210,7 +210,7 @@ class PyRevitOutputChart(object):
         Args:
             html_style (str): inline html css styling string
 
-        Example:
+        Examples:
             >>> chart.set_style('height:150px')
         """
         self._style = html_style

--- a/pyrevitlib/pyrevit/coreutils/colors.py
+++ b/pyrevitlib/pyrevit/coreutils/colors.py
@@ -1,8 +1,10 @@
 #pylint: disable=C0302
-"""Provide RGB color constants and a colors dictionary with
-elements formatted: COLORS[colorname] = CONSTANT
+"""Colors constants.
 
-Example:
+Provide RGB color constants and a colors dictionary with
+elements formatted: COLORS[colorname] = CONSTANT.
+
+Examples:
     >>> from pyrevit.coreutils import colors
     >>> colors.COLORS['black']
     ... <RGB #000000>
@@ -34,12 +36,12 @@ class RGB(object):
 
     @property
     def hex_color(self):
-        """Return color in hex format"""
+        """Return color in hex format."""
         return '#{:02X}{:02X}{:02X}'.format(self.red, self.green, self.blue)
 
     @property
     def luminance(self):
-        """Return color luminance (preceived)"""
+        """Return color luminance (preceived)."""
         return 0.299*self.red + 0.587*self.green + 0.114*self.blue
 
     @property

--- a/pyrevitlib/pyrevit/coreutils/configparser.py
+++ b/pyrevitlib/pyrevit/coreutils/configparser.py
@@ -87,7 +87,7 @@ class PyRevitConfigSectionParser(object):
 
     @property
     def subheader(self):
-        """Section sub-header e.g. Section.SubSection"""
+        """Section sub-header e.g. Section.SubSection."""
         return coreutils.get_canonical_parts(self.header)[-1]
 
     def has_option(self, option_name):
@@ -165,7 +165,11 @@ class PyRevitConfigParser(object):
                 .format(section_name))
 
     def get_config_file_hash(self):
-        """Get calculated unique hash for this config."""
+        """Get calculated unique hash for this config.
+
+        Returns:
+            (str): hash of the config.
+        """
         with codecs.open(self._cfg_file_path, 'r', 'utf-8') as cfg_file:
             cfg_hash = coreutils.get_str_hash(cfg_file.read())
 

--- a/pyrevitlib/pyrevit/coreutils/envvars.py
+++ b/pyrevitlib/pyrevit/coreutils/envvars.py
@@ -18,7 +18,7 @@ pyRevit uses environment variables extensively at its core and making changes
 to the core environment variables (starting with ``PYREVIT_``) through
 scripts is strongly prohibited.
 
-Example:
+Examples:
     >>> from pyrevit.coreutils import envvars
     >>> envvars.set_pyrevit_env_var('MY_SCRIPT_STATUS', True)
     >>> envvars.set_pyrevit_env_var('MY_SCRIPT_CONFIG', {'someconfig': True})
@@ -92,7 +92,7 @@ def get_pyrevit_env_var(param_name):
         param_name (str): name of environment variable
 
     Returns:
-        object: any object stored as the environment variable value
+        (object): any object stored as the environment variable value
     """
     # This function returns None if it can not find the parameter.
     # Thus value of None should not be used for params

--- a/pyrevitlib/pyrevit/coreutils/git.py
+++ b/pyrevitlib/pyrevit/coreutils/git.py
@@ -1,9 +1,7 @@
-"""
-Description:
-LibGit2Sharp wrapper module for pyRevit.
+"""LibGit2Sharp wrapper module for pyRevit.
 
 Documentation:
-https://github.com/libgit2/libgit2sharp/wiki
+    https://github.com/libgit2/libgit2sharp/wiki
 """
 
 import importlib
@@ -152,7 +150,7 @@ def get_repo(repo_dir):
         repo_dir (str): full path of git repo directory
 
     Returns:
-        :obj:`RepoInfo`: repo object
+        (RepoInfo): repo object
     """
     repo = libgit.Repository(repo_dir)
     return RepoInfo(repo)
@@ -162,10 +160,10 @@ def git_pull(repo_info):
     """Pull the current head of given repo.
 
     Args:
-        repo_info (:obj:`RepoInfo`): target repo object
+        repo_info (RepoInfo): target repo object
 
     Returns:
-        :obj:`RepoInfo`: repo object with updated head
+        (RepoInfo): repo object with updated head
     """
     repo = repo_info.repo
     try:
@@ -188,10 +186,10 @@ def git_fetch(repo_info):
     """Fetch current branch of given repo.
 
     Args:
-        repo_info (:obj:`RepoInfo`): target repo object
+        repo_info (RepoInfo): target repo object
 
     Returns:
-        :obj:`RepoInfo`: repo object with updated head
+        (RepoInfo): repo object with updated head
     """
     repo = repo_info.repo
     try:
@@ -214,7 +212,7 @@ def git_fetch(repo_info):
 
 
 def git_clone(repo_url, clone_dir, username=None, password=None):
-    """Clone git repository to given location
+    """Clone git repository to given location.
 
     Args:
         repo_url (str): repo .git url
@@ -240,10 +238,7 @@ def compare_branch_heads(repo_info):
     """Compare local and remote branch heads and return ???
 
     Args:
-        repo_info (:obj:`RepoInfo`): target repo object
-
-    Returns:
-        type: desc
+        repo_info (RepoInfo): target repo object
     """
     # FIXME: need return type. possibly simplify
     repo = repo_info.repo
@@ -277,10 +272,10 @@ def get_all_new_commits(repo_info):
     """Fetch and return new commits ahead of current head.
 
     Args:
-        repo_info (:obj:`RepoInfo`): target repo object
+        repo_info (RepoInfo): target repo object
 
     Returns:
-        OrderedDict[str:str]: ordered dict of commit hash:message
+        (OrderedDict[str, str]): ordered dict of commit hash:message
     """
     repo = repo_info.repo
     current_commit = repo_info.last_commit_hash

--- a/pyrevitlib/pyrevit/coreutils/logger.py
+++ b/pyrevitlib/pyrevit/coreutils/logger.py
@@ -102,12 +102,7 @@ class DispatchingFormatter(object):
 
 
 class LoggerWrapper(logging.Logger):
-    """Custom logging object.
-
-    Args:
-        val (type): desc
-        val (type): desc
-    """
+    """Custom logging object."""
     def __init__(self, *args):
         logging.Logger.__init__(self, *args)
         self._has_errors = False
@@ -130,7 +125,7 @@ class LoggerWrapper(logging.Logger):
                             exc_info=exc_info, extra=extra)
 
     def callHandlers(self, record):
-        """Override logging.Logger.callHandlers"""
+        """Override logging.Logger.callHandlers."""
         for hdlr in self.handlers:
             # stream-handler only records based on current level
             if isinstance(hdlr, logging.StreamHandler) \
@@ -142,7 +137,7 @@ class LoggerWrapper(logging.Logger):
                 hdlr.handle(record)
 
     def isEnabledFor(self, level):
-        """Override logging.Logger.isEnabledFor"""
+        """Override logging.Logger.isEnabledFor."""
         # update current logging level and file logging state
         self._filelogstate = \
             envvars.get_pyrevit_env_var(envvars.FILELOGGING_ENVVAR)
@@ -208,6 +203,12 @@ class LoggerWrapper(logging.Logger):
         return envvars.get_pyrevit_env_var(envvars.LOGGING_LEVEL_ENVVAR)
 
     def log_parse_except(self, parsed_file, parse_ex):
+        """Logs a file parsing exception.
+
+        Args:
+            parsed_file (str): File path that failed the parsing
+            parse_ex (Exception): Parsing exception
+        """
         err_msg = '<strong>Error while parsing file:</strong>\n{file}\n' \
                   '<strong>Error type:</strong> {type}\n' \
                   '<strong>Error Message:</strong> {errmsg}\n' \
@@ -223,16 +224,36 @@ class LoggerWrapper(logging.Logger):
         self.error(coreutils.prepare_html_str(err_msg))
 
     def success(self, message, *args, **kws):
+        """Log a success message.
+
+        Args:
+            message (str): success message
+            *args (Any): extra agruments passed to the log function
+            **kws (Any): extra agruments passed to the log function
+        """
         if self.isEnabledFor(SUCCESS_LOG_LEVEL):
             # Yes, logger takes its '*args' as 'args'.
-            self._log(SUCCESS_LOG_LEVEL, message, args, **kws) 
+            self._log(SUCCESS_LOG_LEVEL, message, args, **kws)
 
     def deprecate(self, message, *args, **kws):
+        """Log a deprecation message.
+
+        Args:
+            message (str): deprecation message
+            *args (Any): extra agruments passed to the log function
+            **kws (Any): extra agruments passed to the log function
+        """
         if self.isEnabledFor(DEPRECATE_LOG_LEVEL):
             # Yes, logger takes its '*args' as 'args'.
             self._log(DEPRECATE_LOG_LEVEL, message, args, **kws)
 
     def dev_log(self, source, message=''):
+        """Appends a message to a log file.
+
+        Args:
+            source (str): source of the message
+            message (str): message to log
+        """
         devlog_fname = \
             '{}.log'.format(EXEC_PARAMS.command_uniqueid or self.name)
         with open(op.join(USER_DESKTOP, devlog_fname), 'a') as devlog_file:
@@ -267,7 +288,7 @@ def get_stdout_hndlr():
     """Return stdout logging handler object.
 
     Returns:
-        logging.StreamHandler:
+        (logging.StreamHandler):
             configured instance of python's native stream handler
     """
     global stdout_hndlr     #pylint: disable=W0603
@@ -279,7 +300,7 @@ def get_file_hndlr():
     """Return file logging handler object.
 
     Returns:
-        logging.FileHandler:
+        (logging.FileHandler):
             configured instance of python's native stream handler
     """
     global file_hndlr       #pylint: disable=W0603
@@ -311,12 +332,11 @@ def get_logger(logger_name):
 
     Args:
         logger_name (str): logger name
-        val (type): desc
 
     Returns:
-        :obj:`LoggerWrapper`: logger object wrapper python's native logger
+        (LoggerWrapper): logger object wrapper python's native logger
 
-    Example:
+    Examples:
         >>> get_logger('my command')
         ... <LoggerWrapper ...>
     """

--- a/pyrevitlib/pyrevit/coreutils/markdown/__init__.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/__init__.py
@@ -1,6 +1,4 @@
-"""
-Python Markdown
-===============
+"""Python Markdown.
 
 Python Markdown converts Markdown to HTML and can be used as a library or
 called from the command line.
@@ -78,39 +76,42 @@ class Markdown(object):
     }
 
     def __init__(self, *args, **kwargs):
+        """Creates a new Markdown instance.
+
+        Args:
+            *args (Any): positional args
+            **kwargs (Any): keyword args
+
+        Keyword Args:
+            extensions (list[Extension | str]): A list of extensions.
+                If they are of type string, the module mdx_name.py will be loaded.
+                If they are a subclass of markdown.Extension, they will be used
+                as-is.
+            extension_configs (dict[str, Any]): Configuration settings for extensions.
+            output_format (str): Format of output. Supported formats are:
+                * "xhtml1": Outputs XHTML 1.x. Default.
+                * "xhtml5": Outputs XHTML style tags of HTML 5
+                * "xhtml": Outputs latest supported version of XHTML
+                  (currently XHTML 1.1).
+                * "html4": Outputs HTML 4
+                * "html5": Outputs HTML style tags of HTML 5
+                * "html": Outputs latest supported version of HTML
+                  (currently HTML 4).
+                Note that it is suggested that the more specific formats ("xhtml1"
+                and "html4") be used as "xhtml" or "html" may change in the future
+                if it makes sense at that time.
+            safe_mode (str): Deprecated! Disallow raw html.
+                One of "remove", "replace" or "escape".
+            html_replacement_text (str): Deprecated! Text used when safe_mode
+                is set to "replace".
+            tab_length (int): Length of tabs in the source. Default: 4
+            enable_attributes (bool): Enable the conversion of attributes.
+                Default: True
+            smart_emphasis (bool): Treat `_connected_words_` intelligently
+                Default: True
+            lazy_ol (bool): Ignore number of first item of ordered lists.
+                Default: True
         """
-        Creates a new Markdown instance.
-
-        Keyword arguments:
-
-        * extensions: A list of extensions.
-           If they are of type string, the module mdx_name.py will be loaded.
-           If they are a subclass of markdown.Extension, they will be used
-           as-is.
-        * extension_configs: Configuration settings for extensions.
-        * output_format: Format of output. Supported formats are:
-            * "xhtml1": Outputs XHTML 1.x. Default.
-            * "xhtml5": Outputs XHTML style tags of HTML 5
-            * "xhtml": Outputs latest supported version of XHTML
-              (currently XHTML 1.1).
-            * "html4": Outputs HTML 4
-            * "html5": Outputs HTML style tags of HTML 5
-            * "html": Outputs latest supported version of HTML
-              (currently HTML 4).
-            Note that it is suggested that the more specific formats ("xhtml1"
-            and "html4") be used as "xhtml" or "html" may change in the future
-            if it makes sense at that time.
-        * safe_mode: Deprecated! Disallow raw html. One of "remove", "replace"
-          or "escape".
-        * html_replacement_text: Deprecated! Text used when safe_mode is set
-          to "replace".
-        * tab_length: Length of tabs in the source. Default: 4
-        * enable_attributes: Enable the conversion of attributes. Default: True
-        * smart_emphasis: Treat `_connected_words_` intelligently Default: True
-        * lazy_ol: Ignore number of first item of ordered lists. Default: True
-
-        """
-
         # For backward compatibility, loop through old positional args
         pos = ['extensions', 'extension_configs', 'safe_mode', 'output_format']
         for c, arg in enumerate(args):
@@ -163,7 +164,7 @@ class Markdown(object):
         self.reset()
 
     def build_parser(self):
-        """ Build the parser from the various parts. """
+        """Build the parser from the various parts."""
         self.preprocessors = build_preprocessors(self)
         self.parser = build_block_parser(self)
         self.inlinePatterns = build_inlinepatterns(self)
@@ -172,14 +173,12 @@ class Markdown(object):
         return self
 
     def registerExtensions(self, extensions, configs):
-        """
-        Register extensions with this instance of Markdown.
+        """Register extensions with this instance of Markdown.
 
-        Keyword arguments:
-
-        * extensions: A list of extensions, which can either
-           be strings or objects.  See the docstring on Markdown.
-        * configs: A dictionary mapping module names to config options.
+        Args:
+            extensions (list[Extension]): extensions strings or objects.
+                See the docstring on Markdown.
+            configs (dict[str, Any]): A dictionary mapping module names to config options.
 
         """
         for ext in extensions:
@@ -205,7 +204,6 @@ class Markdown(object):
         following format: "extname(key1=value1,key2=value2)"
 
         """
-
         configs = dict(configs)
 
         # Parse extensions config params (ignore the order)
@@ -299,14 +297,12 @@ class Markdown(object):
                 raise
 
     def registerExtension(self, extension):
-        """ This gets called by the extension """
+        """This gets called by the extension."""
         self.registeredExtensions.append(extension)
         return self
 
     def reset(self):
-        """
-        Resets all state variables so that we can start with a new text.
-        """
+        """Resets all state variables so that we can start with a new text."""
         self.htmlStash.reset()
         self.references.clear()
 
@@ -317,7 +313,7 @@ class Markdown(object):
         return self
 
     def set_output_format(self, format):
-        """ Set the output format for the class instance. """
+        """Set the output format for the class instance."""
         self.output_format = format.lower()
         try:
             self.serializer = self.output_formats[self.output_format]
@@ -332,12 +328,10 @@ class Markdown(object):
         return self
 
     def convert(self, source):
-        """
-        Convert markdown to serialized XHTML or HTML.
+        """Convert markdown to serialized XHTML or HTML.
 
-        Keyword arguments:
-
-        * source: Source text as a Unicode string.
+        Args:
+            source (str): Source text as a Unicode string.
 
         Markdown processing takes place in five steps:
 
@@ -350,9 +344,7 @@ class Markdown(object):
         4. Some post-processors are run against the text after the ElementTree
            has been serialized into text.
         5. The output is written to a string.
-
         """
-
         # Fixup the source text
         if not source.strip():
             return ''  # a blank unicode string
@@ -414,14 +406,11 @@ class Markdown(object):
         takes place in Python-Markdown.  (All other code is Unicode-in /
         Unicode-out.)
 
-        Keyword arguments:
-
-        * input: File object or path. Reads from stdin if `None`.
-        * output: File object or path. Writes to stdout if `None`.
-        * encoding: Encoding of input and output files. Defaults to utf-8.
-
+        Args:
+            input (str | None): File object or path. Reads from stdin if `None`.
+            output (str | None): File object or path. Writes to stdout if `None`.
+            encoding (str): Encoding of input and output files. Defaults to utf-8.
         """
-
         encoding = encoding or "utf-8"
 
         # Read the source
@@ -484,12 +473,13 @@ def markdown(text, *args, **kwargs):
     basic use case.  It initializes an instance of Markdown, loads the
     necessary extensions and runs the parser on the given text.
 
-    Keyword arguments:
+    Args:
+        text (str): Markdown formatted text as Unicode or ASCII string.
+        *args (Any): Any arguments accepted by the Markdown class.
+        **kwargs (Any): Any arguments accepted by the Markdown class.
 
-    * text: Markdown formatted text as Unicode or ASCII string.
-    * Any arguments accepted by the Markdown class.
-
-    Returns: An HTML document as a string.
+    Returns:
+        (str): An HTML document as a string.
 
     """
     md = Markdown(*args, **kwargs)
@@ -502,12 +492,12 @@ def markdownFromFile(*args, **kwargs):
     This is a shortcut function which initializes an instance of Markdown,
     and calls the convertFile method rather than convert.
 
-    Keyword arguments:
-
-    * input: a file name or readable object.
-    * output: a file name or writable object.
-    * encoding: Encoding of input and output.
-    * Any arguments accepted by the Markdown class.
+    Args:
+        *args (Any): Any arguments accepted by the Markdown class.
+            input (str): a file name or readable object.
+            output (str): a file name or writable object.
+            encoding (str): Encoding of input and output.
+        **kwargs (Any): Any arguments accepted by the Markdown class.
 
     """
     # For backward compatibility loop through positional args

--- a/pyrevitlib/pyrevit/coreutils/markdown/__main__.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/__main__.py
@@ -1,8 +1,4 @@
-"""
-COMMAND-LINE SPECIFIC STUFF
-=============================================================================
-
-"""
+"""COMMAND-LINE SPECIFIC STUFF."""
 
 import sys
 import optparse
@@ -21,9 +17,7 @@ logger = logging.getLogger('MARKDOWN')
 
 
 def parse_options(args=None, values=None):
-    """
-    Define and parse `optparse` options for command-line usage.
-    """
+    """Define and parse `optparse` options for command-line usage."""
     usage = """%prog [options] [INPUTFILE]
        (STDIN is assumed if no INPUTFILE is given)"""
     desc = "A Python implementation of John Gruber's Markdown. " \
@@ -111,7 +105,6 @@ def parse_options(args=None, values=None):
 
 def run():  # pragma: no cover
     """Run Markdown from the command line."""
-
     # Parse options and adjust logging level if necessary
     options, logging_level = parse_options()
     if not options:

--- a/pyrevitlib/pyrevit/coreutils/markdown/__version__.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/__version__.py
@@ -1,6 +1,4 @@
-#
-# markdown/__version__.py
-#
+"""Markdown version."""
 # version_info should conform to PEP 386
 # (major, minor, micro, alpha/beta/rc/final, #)
 # (1, 1, 2, 'alpha', 0) => "1.1.2.dev"
@@ -9,7 +7,7 @@ version_info = (2, 6, 8, 'final', 0)
 
 
 def _get_version():
-    " Returns a PEP 386-compliant version number from version_info. "
+    """Returns a PEP 386-compliant version number from version_info."""
     assert len(version_info) == 5
     assert version_info[3] in ('alpha', 'beta', 'rc', 'final')
 

--- a/pyrevitlib/pyrevit/coreutils/markdown/blockparser.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/blockparser.py
@@ -1,3 +1,4 @@
+"""Markdown blocks parser."""
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -6,7 +7,7 @@ from . import util
 
 
 class State(list):
-    """ Track the current and nested state of the parser.
+    """Track the current and nested state of the parser.
 
     This utility class is used to track the state of the BlockParser and
     support multiple levels if nesting. It's just a simple API wrapped around
@@ -24,15 +25,15 @@ class State(list):
     """
 
     def set(self, state):
-        """ Set a new state. """
+        """Set a new state."""
         self.append(state)
 
     def reset(self):
-        """ Step back one step in nested state. """
+        """Step back one step in nested state."""
         self.pop()
 
     def isstate(self, state):
-        """ Test that top (current) level is of given state. """
+        """Test that top (current) level is of given state."""
         if len(self):
             return self[-1] == state
         else:
@@ -40,7 +41,7 @@ class State(list):
 
 
 class BlockParser:
-    """ Parse Markdown blocks into an ElementTree object.
+    """Parse Markdown blocks into an ElementTree object.
 
     A wrapper class that stitches the various BlockProcessors together,
     looping through them and creating an ElementTree object.
@@ -52,7 +53,7 @@ class BlockParser:
         self.markdown = markdown
 
     def parseDocument(self, lines):
-        """ Parse a markdown document into an ElementTree.
+        """Parse a markdown document into an ElementTree.
 
         Given a list of lines, an ElementTree object (not just a parent
         Element) is created and the root element is passed to the parser
@@ -67,7 +68,7 @@ class BlockParser:
         return util.etree.ElementTree(self.root)
 
     def parseChunk(self, parent, text):
-        """ Parse a chunk of markdown text and attach to given etree node.
+        """Parse a chunk of markdown text and attach to given etree node.
 
         While the ``text`` argument is generally assumed to contain multiple
         blocks which will be split on blank lines, it could contain only one
@@ -81,7 +82,7 @@ class BlockParser:
         self.parseBlocks(parent, text.split('\n\n'))
 
     def parseBlocks(self, parent, blocks):
-        """ Process blocks of markdown text and attach to given etree node.
+        """Process blocks of markdown text and attach to given etree node.
 
         Given a list of ``blocks``, each blockprocessor is stepped through
         until there are no blocks left. While an extension could potentially

--- a/pyrevitlib/pyrevit/coreutils/markdown/blockprocessors.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/blockprocessors.py
@@ -1,6 +1,4 @@
-"""
-CORE MARKDOWN BLOCKPARSER
-===========================================================================
+"""CORE MARKDOWN BLOCKPARSER.
 
 This parser handles basic parsing of Markdown blocks.  It doesn't concern
 itself with inline elements such as **bold** or *italics*, but rather just
@@ -25,7 +23,7 @@ logger = logging.getLogger('MARKDOWN')
 
 
 def build_block_parser(md_instance, **kwargs):
-    """ Build the default block parser used by Markdown. """
+    """Build the default block parser used by Markdown."""
     parser = BlockParser(md_instance)
     parser.blockprocessors['empty'] = EmptyBlockProcessor(parser)
     parser.blockprocessors['indent'] = ListIndentProcessor(parser)
@@ -41,7 +39,7 @@ def build_block_parser(md_instance, **kwargs):
 
 
 class BlockProcessor(object):
-    """ Base class for block processors.
+    """Base class for block processors.
 
     Each subclass will provide the methods below to work with the source and
     tree. Each processor will need to define it's own ``test`` and ``run``
@@ -49,6 +47,8 @@ class BlockProcessor(object):
     whether the current block should be processed by this processor. If the
     test passes, the parser will call the processors ``run`` method.
 
+    Args:
+        parser (BlockParser): BlockParser instance
     """
 
     def __init__(self, parser):
@@ -56,14 +56,14 @@ class BlockProcessor(object):
         self.tab_length = parser.markdown.tab_length
 
     def lastChild(self, parent):
-        """ Return the last child of an etree element. """
+        """Return the last child of an etree element."""
         if len(parent):
             return parent[-1]
         else:
             return None
 
     def detab(self, text):
-        """ Remove a tab from the front of each line of the given text. """
+        """Remove a tab from the front of each line of the given text."""
         newtext = []
         lines = text.split('\n')
         for line in lines:
@@ -76,7 +76,7 @@ class BlockProcessor(object):
         return '\n'.join(newtext), '\n'.join(lines[len(newtext):])
 
     def looseDetab(self, text, level=1):
-        """ Remove a tab from front of lines but allowing dedented lines. """
+        """Remove a tab from front of lines but allowing dedented lines."""
         lines = text.split('\n')
         for i in range(len(lines)):
             if lines[i].startswith(' '*self.tab_length*level):
@@ -84,7 +84,7 @@ class BlockProcessor(object):
         return '\n'.join(lines)
 
     def test(self, parent, block):
-        """ Test for block type. Must be overridden by subclasses.
+        """Test for block type. Must be overridden by subclasses.
 
         As the parser loops through processors, it will call the ``test``
         method on each to determine if the given block of text is of that
@@ -95,16 +95,15 @@ class BlockProcessor(object):
         depending on the parent of the block (i.e. inside a list), the parent
         etree element is also provided and may be used as part of the test.
 
-        Keywords:
-
-        * ``parent``: A etree element which will be the parent of the block.
-        * ``block``: A block of text from the source which has been split at
-            blank lines.
+        Args:
+            parent (Element): A etree element which will be the parent of the block.
+            block (list[Element]): A block of text from the source
+                which has been split at blank lines.
         """
         pass  # pragma: no cover
 
     def run(self, parent, blocks):
-        """ Run processor. Must be overridden by subclasses.
+        """Run processor. Must be overridden by subclasses.
 
         When the parser determines the appropriate type of a block, the parser
         will call the corresponding processor's ``run`` method. This method
@@ -120,18 +119,17 @@ class BlockProcessor(object):
         to the parent, and should remove (``pop``) or add (``insert``) items to
         the list of blocks.
 
-        Keywords:
-
-        * ``parent``: A etree element which is the parent of the current block.
-        * ``blocks``: A list of all remaining blocks of the document.
+        Keyword Args:
+            parent (Element): A etree element which is the parent of the current block.
+            blocks (list[Element]): A list of all remaining blocks of the document.
         """
         pass  # pragma: no cover
 
 
 class ListIndentProcessor(BlockProcessor):
-    """ Process children of list items.
+    """Process children of list items.
 
-    Example:
+    Examples:
         * a list item
             process this part
 
@@ -190,12 +188,12 @@ class ListIndentProcessor(BlockProcessor):
         self.parser.state.reset()
 
     def create_item(self, parent, block):
-        """ Create a new li and parse the block with it as the parent. """
+        """Create a new li and parse the block with it as the parent."""
         li = util.etree.SubElement(parent, 'li')
         self.parser.parseBlocks(li, [block])
 
     def get_level(self, parent, block):
-        """ Get level of indent based on list level. """
+        """Get level of indent based on list level."""
         # Get indent level
         m = self.INDENT_RE.match(block)
         if m:
@@ -224,7 +222,7 @@ class ListIndentProcessor(BlockProcessor):
 
 
 class CodeBlockProcessor(BlockProcessor):
-    """ Process code blocks. """
+    """Process code blocks."""
 
     def test(self, parent, block):
         return block.startswith(' '*self.tab_length)
@@ -257,6 +255,7 @@ class CodeBlockProcessor(BlockProcessor):
 
 
 class BlockQuoteProcessor(BlockProcessor):
+    """Blockquote processor."""
 
     RE = re.compile(r'(^|\n)[ ]{0,3}>[ ]?(.*)')
 
@@ -288,7 +287,7 @@ class BlockQuoteProcessor(BlockProcessor):
         self.parser.state.reset()
 
     def clean(self, line):
-        """ Remove ``>`` from beginning of a line. """
+        """Remove ``>`` from beginning of a line."""
         m = self.RE.match(line)
         if line.strip() == ">":
             return ""
@@ -299,7 +298,7 @@ class BlockQuoteProcessor(BlockProcessor):
 
 
 class OListProcessor(BlockProcessor):
-    """ Process ordered list blocks. """
+    """Process ordered list blocks."""
 
     TAG = 'ol'
     # The integer (python string) with which the lists starts (default=1)
@@ -384,7 +383,7 @@ class OListProcessor(BlockProcessor):
         self.parser.state.reset()
 
     def get_items(self, block):
-        """ Break a block into list items. """
+        """Break a block into list items."""
         items = []
         for line in block.split('\n'):
             m = self.CHILD_RE.match(line)
@@ -411,7 +410,7 @@ class OListProcessor(BlockProcessor):
 
 
 class UListProcessor(OListProcessor):
-    """ Process unordered list blocks. """
+    """Process unordered list blocks."""
 
     TAG = 'ul'
 
@@ -422,7 +421,7 @@ class UListProcessor(OListProcessor):
 
 
 class HashHeaderProcessor(BlockProcessor):
-    """ Process Hash Headers. """
+    """Process Hash Headers."""
 
     # Detect a header at start of any line in block
     RE = re.compile(r'(^|\n)(?P<level>#{1,6})(?P<header>.*?)#*(\n|$)')
@@ -453,7 +452,7 @@ class HashHeaderProcessor(BlockProcessor):
 
 
 class SetextHeaderProcessor(BlockProcessor):
-    """ Process Setext-style Headers. """
+    """Process Setext-style Headers."""
 
     # Detect Setext-style header. Must be first 2 lines of block.
     RE = re.compile(r'^.*?\n[=-]+[ ]*(\n|$)', re.MULTILINE)
@@ -476,7 +475,7 @@ class SetextHeaderProcessor(BlockProcessor):
 
 
 class HRProcessor(BlockProcessor):
-    """ Process Horizontal Rules. """
+    """Process Horizontal Rules."""
 
     RE = r'^[ ]{0,3}((-+[ ]{0,2}){3,}|(_+[ ]{0,2}){3,}|(\*+[ ]{0,2}){3,})[ ]*'
     # Detect hr on any line of a block.
@@ -511,7 +510,7 @@ class HRProcessor(BlockProcessor):
 
 
 class EmptyBlockProcessor(BlockProcessor):
-    """ Process blocks that are empty or start with an empty line. """
+    """Process blocks that are empty or start with an empty line."""
 
     def test(self, parent, block):
         return not block or block.startswith('\n')
@@ -538,7 +537,7 @@ class EmptyBlockProcessor(BlockProcessor):
 
 
 class ParagraphProcessor(BlockProcessor):
-    """ Process Paragraph blocks. """
+    """Process Paragraph blocks."""
 
     def test(self, parent, block):
         return True

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/__init__.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/__init__.py
@@ -1,7 +1,4 @@
-"""
-Extensions
------------------------------------------------------------------------------
-"""
+"""Markdown Extensions."""
 
 from __future__ import unicode_literals
 from ..util import parseBoolValue
@@ -9,7 +6,7 @@ import warnings
 
 
 class Extension(object):
-    """ Base class for extensions to subclass. """
+    """Base class for extensions to subclass."""
 
     # Default config -- to be overriden by a subclass
     # Must be of the following format:
@@ -21,8 +18,7 @@ class Extension(object):
     config = {}
 
     def __init__(self, *args, **kwargs):
-        """ Initiate Extension and set up configs. """
-
+        """Initiate Extension and set up configs."""
         # check for configs arg for backward compat.
         # (there only ever used to be one so we use arg[0])
         if len(args):
@@ -51,22 +47,22 @@ class Extension(object):
         self.setConfigs(kwargs)
 
     def getConfig(self, key, default=''):
-        """ Return a setting for the given key or an empty string. """
+        """Return a setting for the given key or an empty string."""
         if key in self.config:
             return self.config[key][0]
         else:
             return default
 
     def getConfigs(self):
-        """ Return all configs settings as a dict. """
+        """Return all configs settings as a dict."""
         return dict([(key, self.getConfig(key)) for key in self.config.keys()])
 
     def getConfigInfo(self):
-        """ Return all config descriptions as a list of tuples. """
+        """Return all config descriptions as a list of tuples."""
         return [(key, self.config[key][1]) for key in self.config.keys()]
 
     def setConfig(self, key, value):
-        """ Set a config setting for `key` with the given `value`. """
+        """Set a config setting for `key` with the given `value`."""
         if isinstance(self.config[key][0], bool):
             value = parseBoolValue(value)
         if self.config[key][0] is None:
@@ -74,7 +70,7 @@ class Extension(object):
         self.config[key][0] = value
 
     def setConfigs(self, items):
-        """ Set multiple config settings given a dict or list of tuples. """
+        """Set multiple config settings given a dict or list of tuples."""
         if hasattr(items, 'items'):
             # it's a dict
             items = items.items()
@@ -82,16 +78,13 @@ class Extension(object):
             self.setConfig(key, value)
 
     def extendMarkdown(self, md, md_globals):
-        """
-        Add the various proccesors and patterns to the Markdown Instance.
+        """Add the various proccesors and patterns to the Markdown Instance.
 
         This method must be overriden by every extension.
 
-        Keyword arguments:
-
-        * md: The Markdown instance.
-
-        * md_globals: Global variables in the markdown module namespace.
+        Args:
+            md (Markdown): The Markdown instance.
+            md_globals (list[Any]): Global variables in the markdown module namespace.
 
         """
         raise NotImplementedError(

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/abbr.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/abbr.py
@@ -1,6 +1,4 @@
-'''
-Abbreviation Extension for Python-Markdown
-==========================================
+"""Abbreviation Extension for Python-Markdown.
 
 This extension adds abbreviation handling to Python-Markdown.
 
@@ -13,9 +11,7 @@ Oringinal code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/) and
 All changes Copyright 2008-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
-'''
-
+"""
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
@@ -29,22 +25,21 @@ ABBR_REF_RE = re.compile(r'[*]\[(?P<abbr>[^\]]*)\][ ]?:\s*(?P<title>.*)')
 
 
 class AbbrExtension(Extension):
-    """ Abbreviation Extension for Python-Markdown. """
+    """Abbreviation Extension for Python-Markdown."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Insert AbbrPreprocessor before ReferencePreprocessor. """
+        """Insert AbbrPreprocessor before ReferencePreprocessor."""
         md.preprocessors.add('abbr', AbbrPreprocessor(md), '<reference')
 
 
 class AbbrPreprocessor(Preprocessor):
-    """ Abbreviation Preprocessor - parse text for abbr references. """
+    """Abbreviation Preprocessor - parse text for abbr references."""
 
     def run(self, lines):
-        '''
-        Find and remove all Abbreviation references from the text.
-        Each reference is set as a new AbbrPattern in the markdown instance.
+        """Find and remove all Abbreviation references from the text.
 
-        '''
+        Each reference is set as a new AbbrPattern in the markdown instance.
+        """
         new_text = []
         for line in lines:
             m = ABBR_REF_RE.match(line)
@@ -58,15 +53,14 @@ class AbbrPreprocessor(Preprocessor):
         return new_text
 
     def _generate_pattern(self, text):
-        '''
-        Given a string, returns an regex pattern to match that string.
+        """Given a string, returns an regex pattern to match that string.
 
         'HTML' -> r'(?P<abbr>[H][T][M][L])'
 
         Note: we force each char as a literal match (in brackets) as we don't
         know what they will be beforehand.
 
-        '''
+        """
         chars = list(text)
         for i in range(len(chars)):
             chars[i] = r'[%s]' % chars[i]
@@ -74,7 +68,7 @@ class AbbrPreprocessor(Preprocessor):
 
 
 class AbbrPattern(Pattern):
-    """ Abbreviation inline pattern. """
+    """Abbreviation inline pattern."""
 
     def __init__(self, pattern, title):
         super(AbbrPattern, self).__init__(pattern)

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/admonition.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/admonition.py
@@ -1,6 +1,4 @@
-"""
-Admonition extension for Python-Markdown
-========================================
+"""Admonition extension for Python-Markdown.
 
 Adds rST-style admonitions. Inspired by [rST][] feature with the same name.
 
@@ -14,7 +12,6 @@ Original code Copyright [Tiago Serafim](http://www.tiagoserafim.com/).
 All changes Copyright The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -26,10 +23,10 @@ import re
 
 
 class AdmonitionExtension(Extension):
-    """ Admonition extension for Python-Markdown. """
+    """Admonition extension for Python-Markdown."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Add Admonition to Markdown instance. """
+        """Add Admonition to Markdown instance."""
         md.registerExtension(self)
 
         md.parser.blockprocessors.add('admonition',
@@ -38,6 +35,7 @@ class AdmonitionExtension(Extension):
 
 
 class AdmonitionProcessor(BlockProcessor):
+    """Admonition processor."""
 
     CLASSNAME = 'admonition'
     CLASSNAME_TITLE = 'admonition-title'

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/attr_list.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/attr_list.py
@@ -1,6 +1,4 @@
-"""
-Attribute List Extension for Python-Markdown
-============================================
+"""Attribute List Extension for Python-Markdown.
 
 Adds attribute list syntax. Inspired by
 [maruku](http://maruku.rubyforge.org/proposal.html#attribute_lists)'s
@@ -14,7 +12,6 @@ Original code Copyright 2011 [Waylan Limberg](http://achinghead.com/).
 All changes Copyright 2011-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -63,7 +60,7 @@ _scanner = Scanner([
 
 
 def get_attrs(str):
-    """ Parse attribute list and return a list of attribute tuples. """
+    """Parse attribute list and return a list of attribute tuples."""
     return _scanner.scan(str)[0]
 
 
@@ -72,7 +69,7 @@ def isheader(elem):
 
 
 class AttrListTreeprocessor(Treeprocessor):
-
+    """Attribute List Tree processor."""
     BASE_RE = r'\{\:?([^\}\n]*)\}'
     HEADER_RE = re.compile(r'[ ]+%s[ ]*$' % BASE_RE)
     BLOCK_RE = re.compile(r'\n[ ]*%s[ ]*$' % BASE_RE)
@@ -146,7 +143,7 @@ class AttrListTreeprocessor(Treeprocessor):
                         elem.tail = elem.tail[m.end():]
 
     def assign_attrs(self, elem, attrs):
-        """ Assign attrs to element. """
+        """Assign attrs to element."""
         for k, v in get_attrs(attrs):
             if k == '.':
                 # add to class
@@ -160,14 +157,15 @@ class AttrListTreeprocessor(Treeprocessor):
                 elem.set(self.sanitize_name(k), v)
 
     def sanitize_name(self, name):
-        """
-        Sanitize name as 'an XML Name, minus the ":"'.
-        See http://www.w3.org/TR/REC-xml-names/#NT-NCName
+        """Sanitize name as 'an XML Name, minus the ":"'.
+        
+        See http://www.w3.org/TR/REC-xml-names/#NT-NCName.
         """
         return self.NAME_RE.sub('_', name)
 
 
 class AttrListExtension(Extension):
+    """Attribute List Extension."""
     def extendMarkdown(self, md, md_globals):
         md.treeprocessors.add(
             'attr_list', AttrListTreeprocessor(md), '>prettify'

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/codehilite.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/codehilite.py
@@ -1,6 +1,4 @@
-"""
-CodeHilite Extension for Python-Markdown
-========================================
+"""CodeHilite Extension for Python-Markdown.
 
 Adds code/syntax highlighting to standard Python-Markdown code blocks.
 
@@ -12,7 +10,6 @@ Original code Copyright 2006-2008 [Waylan Limberg](http://achinghead.com/).
 All changes Copyright 2008-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -46,8 +43,7 @@ def parse_hl_lines(expr):
 
 # ------------------ The Main CodeHilite Class ----------------------
 class CodeHilite(object):
-    """
-    Determine language of source code, and pass it into pygments hilighter.
+    """Determine language of source code, and pass it into pygments hilighter.
 
     Basic Usage:
         >>> code = CodeHilite(src = 'some text')
@@ -88,16 +84,16 @@ class CodeHilite(object):
         self.use_pygments = use_pygments
 
     def hilite(self):
-        """
+        """Highlites the code.
+
         Pass code to the [Pygments](http://pygments.pocoo.org/) highliter with
         optional line numbers. The output should then be styled with css to
         your liking. No styles are applied by default - only styling hooks
         (i.e.: <span class="k">).
 
-        returns : A string of html.
-
+        Returns:
+            (str): html text of the highlighted code.
         """
-
         self.src = self.src.strip('\n')
 
         if self.lang is None:
@@ -139,7 +135,8 @@ class CodeHilite(object):
                    (self.css_class, class_str, txt)
 
     def _parseHeader(self):
-        """
+        """Parse the code block header.
+
         Determines language of a code block from shebang line and whether said
         line should be removed or left in place. If the sheband line contains a
         path (even a single /) then it is assumed to be a real shebang line and
@@ -155,7 +152,6 @@ class CodeHilite(object):
 
             :::python hl_lines="1 3"
         """
-
         import re
 
         # split text into lines
@@ -198,10 +194,10 @@ class CodeHilite(object):
 
 
 class HiliteTreeprocessor(Treeprocessor):
-    """ Hilight source code in code blocks. """
+    """Hilight source code in code blocks."""
 
     def run(self, root):
-        """ Find code blocks and store in htmlStash. """
+        """Find code blocks and store in htmlStash."""
         blocks = root.iter('pre')
         for block in blocks:
             if len(block) == 1 and block[0].tag == 'code':
@@ -226,7 +222,7 @@ class HiliteTreeprocessor(Treeprocessor):
 
 
 class CodeHiliteExtension(Extension):
-    """ Add source code hilighting to markdown codeblocks. """
+    """Add source code hilighting to markdown codeblocks."""
 
     def __init__(self, *args, **kwargs):
         # define default configs
@@ -253,7 +249,7 @@ class CodeHiliteExtension(Extension):
         super(CodeHiliteExtension, self).__init__(*args, **kwargs)
 
     def extendMarkdown(self, md, md_globals):
-        """ Add HilitePostprocessor to Markdown instance. """
+        """Add HilitePostprocessor to Markdown instance."""
         hiliter = HiliteTreeprocessor(md)
         hiliter.config = self.getConfigs()
         md.treeprocessors.add("hilite", hiliter, "<inline")

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/def_list.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/def_list.py
@@ -1,6 +1,4 @@
-"""
-Definition List Extension for Python-Markdown
-=============================================
+"""Definition List Extension for Python-Markdown.
 
 Adds parsing of Definition Lists to Python-Markdown.
 
@@ -12,7 +10,6 @@ Original code Copyright 2008 [Waylan Limberg](http://achinghead.com)
 All changes Copyright 2008-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -24,7 +21,7 @@ import re
 
 
 class DefListProcessor(BlockProcessor):
-    """ Process Definition Lists. """
+    """Process Definition Lists."""
 
     RE = re.compile(r'(^|\n)[ ]{0,3}:[ ]{1,3}(.*?)(\n|$)')
     NO_INDENT_RE = re.compile(r'^[ ]{0,3}[^ :]')
@@ -87,22 +84,22 @@ class DefListProcessor(BlockProcessor):
 
 
 class DefListIndentProcessor(ListIndentProcessor):
-    """ Process indented children of definition list items. """
+    """Process indented children of definition list items."""
 
     ITEM_TYPES = ['dd']
     LIST_TYPES = ['dl']
 
     def create_item(self, parent, block):
-        """ Create a new dd and parse the block with it as the parent. """
+        """Create a new dd and parse the block with it as the parent."""
         dd = etree.SubElement(parent, 'dd')
         self.parser.parseBlocks(dd, [block])
 
 
 class DefListExtension(Extension):
-    """ Add definition lists to Markdown. """
+    """Add definition lists to Markdown."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Add an instance of DefListProcessor to BlockParser. """
+        """Add an instance of DefListProcessor to BlockParser."""
         md.parser.blockprocessors.add('defindent',
                                       DefListIndentProcessor(md.parser),
                                       '>indent')

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/extra.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/extra.py
@@ -1,6 +1,4 @@
-"""
-Python-Markdown Extra Extension
-===============================
+"""Python-Markdown Extra Extension.
 
 A compilation of various Python-Markdown extensions that imitates
 [PHP Markdown Extra](http://michelf.com/projects/php-markdown/extra/).
@@ -26,7 +24,6 @@ for documentation.
 Copyright The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -50,15 +47,15 @@ extensions = [
 
 
 class ExtraExtension(Extension):
-    """ Add various extensions to Markdown class."""
+    """Add various extensions to Markdown class."""
 
     def __init__(self, *args, **kwargs):
-        """ config is a dumb holder which gets passed to actual ext later. """
+        """Config is a dumb holder which gets passed to actual ext later."""
         self.config = kwargs.pop('configs', {})
         self.config.update(kwargs)
 
     def extendMarkdown(self, md, md_globals):
-        """ Register extension instances. """
+        """Register extension instances."""
         md.registerExtensions(extensions, self.config)
         if not md.safeMode:
             # Turn on processing of markdown text within raw html

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/fenced_code.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/fenced_code.py
@@ -1,6 +1,4 @@
-"""
-Fenced Code Extension for Python Markdown
-=========================================
+"""Fenced Code Extension for Python Markdown.
 
 This extension adds Fenced Code Blocks to Python-Markdown.
 
@@ -24,9 +22,10 @@ import re
 
 
 class FencedCodeExtension(Extension):
+    """Fenced code extension."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Add FencedBlockPreprocessor to the Markdown instance. """
+        """Add FencedBlockPreprocessor to the Markdown instance."""
         md.registerExtension(self)
 
         md.preprocessors.add('fenced_code_block',
@@ -35,6 +34,7 @@ class FencedCodeExtension(Extension):
 
 
 class FencedBlockPreprocessor(Preprocessor):
+    """Fenced code block preprocessor."""
     FENCED_BLOCK_RE = re.compile(r'''
 (?P<fence>^(?:~{3,}|`{3,}))[ ]*         # Opening ``` or ~~~
 (\{?\.?(?P<lang>[\w#.+-]*))?[ ]*        # Optional {, and lang
@@ -53,8 +53,7 @@ class FencedBlockPreprocessor(Preprocessor):
         self.codehilite_conf = {}
 
     def run(self, lines):
-        """ Match and store Fenced Code Blocks in the HtmlStash. """
-
+        """Match and store Fenced Code Blocks in the HtmlStash."""
         # Check for code hilite extension
         if not self.checked_for_codehilite:
             for ext in self.markdown.registeredExtensions:
@@ -101,7 +100,7 @@ class FencedBlockPreprocessor(Preprocessor):
         return text.split("\n")
 
     def _escape(self, txt):
-        """ basic html escaping """
+        """Basic html escaping."""
         txt = txt.replace('&', '&amp;')
         txt = txt.replace('<', '&lt;')
         txt = txt.replace('>', '&gt;')

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/footnotes.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/footnotes.py
@@ -1,6 +1,4 @@
-"""
-Footnotes Extension for Python-Markdown
-=======================================
+"""Footnotes Extension for Python-Markdown.
 
 Adds footnote handling to Python-Markdown.
 
@@ -10,7 +8,6 @@ for documentation.
 Copyright The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -35,11 +32,10 @@ RE_REF_ID = re.compile(r'(fnref)(\d+)')
 
 
 class FootnoteExtension(Extension):
-    """ Footnote Extension. """
+    """Footnote Extension."""
 
     def __init__(self, *args, **kwargs):
-        """ Setup configs. """
-
+        """Setup configs."""
         self.config = {
             'PLACE_MARKER':
                 ["///Footnotes Go Here///",
@@ -63,7 +59,7 @@ class FootnoteExtension(Extension):
         self.reset()
 
     def extendMarkdown(self, md, md_globals):
-        """ Add pieces to Markdown. """
+        """Add pieces to Markdown."""
         md.registerExtension(self)
         self.parser = md.parser
         self.md = md
@@ -97,14 +93,14 @@ class FootnoteExtension(Extension):
         )
 
     def reset(self):
-        """ Clear footnotes on reset, and prepare for distinct document. """
+        """Clear footnotes on reset, and prepare for distinct document."""
         self.footnotes = OrderedDict()
         self.unique_prefix += 1
         self.found_refs = {}
         self.used_refs = set()
 
     def unique_ref(self, reference, found=False):
-        """ Get a unique reference if there are duplicates. """
+        """Get a unique reference if there are duplicates."""
         if not found:
             return reference
 
@@ -125,7 +121,7 @@ class FootnoteExtension(Extension):
         return reference
 
     def findFootnotesPlaceholder(self, root):
-        """ Return ElementTree Element that contains Footnote placeholder. """
+        """Return ElementTree Element that contains Footnote placeholder."""
         def finder(element):
             for child in element:
                 if child.text:
@@ -143,7 +139,7 @@ class FootnoteExtension(Extension):
         return res
 
     def setFootnote(self, id, text):
-        """ Store a footnote for later retrieval. """
+        """Store a footnote for later retrieval."""
         self.footnotes[id] = text
 
     def get_separator(self):
@@ -152,22 +148,21 @@ class FootnoteExtension(Extension):
         return ':'
 
     def makeFootnoteId(self, id):
-        """ Return footnote link id. """
+        """Return footnote link id."""
         if self.getConfig("UNIQUE_IDS"):
             return 'fn%s%d-%s' % (self.get_separator(), self.unique_prefix, id)
         else:
             return 'fn%s%s' % (self.get_separator(), id)
 
     def makeFootnoteRefId(self, id, found=False):
-        """ Return footnote back-link id. """
+        """Return footnote back-link id."""
         if self.getConfig("UNIQUE_IDS"):
             return self.unique_ref('fnref%s%d-%s' % (self.get_separator(), self.unique_prefix, id), found)
         else:
             return self.unique_ref('fnref%s%s' % (self.get_separator(), id), found)
 
     def makeFootnotesDiv(self, root):
-        """ Return div of footnotes as et Element. """
-
+        """Return div of footnotes as et Element."""
         if not list(self.footnotes.keys()):
             return None
 
@@ -211,14 +206,13 @@ class FootnoteExtension(Extension):
 
 
 class FootnotePreprocessor(Preprocessor):
-    """ Find all footnote references and store for later use. """
+    """Find all footnote references and store for later use."""
 
     def __init__(self, footnotes):
         self.footnotes = footnotes
 
     def run(self, lines):
-        """
-        Loop through lines and find, set, and remove footnote definitions.
+        """Loop through lines and find, set, and remove footnote definitions.
 
         Keywords:
 
@@ -245,13 +239,13 @@ class FootnotePreprocessor(Preprocessor):
         return newlines
 
     def detectTabbed(self, lines):
-        """ Find indented text and remove indent before further proccesing.
+        """Find indented text and remove indent before further proccesing.
 
-        Keyword arguments:
+        Args:
+            lines (list[str]): text lines
 
-        * lines: an array of strings
-
-        Returns: a list of post processed items and the index of last line.
+        Returns:
+            (tuple[list, int]): post processed items and the index of last line.
 
         """
         items = []
@@ -303,7 +297,7 @@ class FootnotePreprocessor(Preprocessor):
 
 
 class FootnotePattern(Pattern):
-    """ InlinePattern for footnote markers in a document's body text. """
+    """InlinePattern for footnote markers in a document's body text."""
 
     def __init__(self, pattern, footnotes):
         super(FootnotePattern, self).__init__(pattern)
@@ -326,13 +320,13 @@ class FootnotePattern(Pattern):
 
 
 class FootnotePostTreeprocessor(Treeprocessor):
-    """ Ammend footnote div with duplicates. """
+    """Ammend footnote div with duplicates."""
 
     def __init__(self, footnotes):
         self.footnotes = footnotes
 
     def add_duplicates(self, li, duplicates):
-        """ Adjust current li and add the duplicates: fnref2, fnref3, etc. """
+        """Adjust current li and add the duplicates: fnref2, fnref3, etc."""
         for link in li.iter('a'):
             # Find the link that needs to be duplicated.
             if link.attrib.get('class', '') == 'footnote-backref':
@@ -352,13 +346,13 @@ class FootnotePostTreeprocessor(Treeprocessor):
                 break
 
     def get_num_duplicates(self, li):
-        """ Get the number of duplicate refs of the footnote. """
+        """Get the number of duplicate refs of the footnote."""
         fn, rest = li.attrib.get('id', '').split(self.footnotes.get_separator(), 1)
         link_id = '%sref%s%s' % (fn, self.footnotes.get_separator(), rest)
         return self.footnotes.found_refs.get(link_id, 0)
 
     def handle_duplicates(self, parent):
-        """ Find duplicate footnotes and format and add the duplicates. """
+        """Find duplicate footnotes and format and add the duplicates."""
         for li in list(parent):
             # Check number of duplicates footnotes and insert
             # additional links if needed.
@@ -367,7 +361,7 @@ class FootnotePostTreeprocessor(Treeprocessor):
                 self.add_duplicates(li, count)
 
     def run(self, root):
-        """ Crawl the footnote div and add missing duplicate footnotes. """
+        """Crawl the footnote div and add missing duplicate footnotes."""
         self.offset = 0
         for div in root.iter('div'):
             if div.attrib.get('class', '') == 'footnote':
@@ -379,7 +373,7 @@ class FootnotePostTreeprocessor(Treeprocessor):
 
 
 class FootnoteTreeprocessor(Treeprocessor):
-    """ Build and append footnote div to end of document. """
+    """Build and append footnote div to end of document."""
 
     def __init__(self, footnotes):
         self.footnotes = footnotes
@@ -402,7 +396,7 @@ class FootnoteTreeprocessor(Treeprocessor):
 
 
 class FootnotePostprocessor(Postprocessor):
-    """ Replace placeholders with html entities. """
+    """Replace placeholders with html entities."""
     def __init__(self, footnotes):
         self.footnotes = footnotes
 
@@ -414,5 +408,5 @@ class FootnotePostprocessor(Postprocessor):
 
 
 def makeExtension(*args, **kwargs):
-    """ Return an instance of the FootnoteExtension """
+    """Return an instance of the FootnoteExtension."""
     return FootnoteExtension(*args, **kwargs)

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/headerid.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/headerid.py
@@ -1,6 +1,4 @@
-"""
-HeaderID Extension for Python-Markdown
-======================================
+"""HeaderID Extension for Python-Markdown.
 
 Auto-generate id attributes for HTML headers.
 
@@ -12,7 +10,6 @@ Original code Copyright 2007-2011 [Waylan Limberg](http://achinghead.com/).
 All changes Copyright 2011-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -25,7 +22,7 @@ import warnings
 
 
 class HeaderIdTreeprocessor(Treeprocessor):
-    """ Assign IDs to headers. """
+    """Assign IDs to headers."""
 
     IDs = set()
 
@@ -49,7 +46,7 @@ class HeaderIdTreeprocessor(Treeprocessor):
                     elem.tag = 'h%d' % level
 
     def _get_meta(self):
-        """ Return meta data suported by this ext as a tuple """
+        """Return meta data suported by this ext as a tuple."""
         level = int(self.config['level']) - 1
         force = parseBoolValue(self.config['forceid'])
         if hasattr(self.md, 'Meta'):
@@ -61,6 +58,7 @@ class HeaderIdTreeprocessor(Treeprocessor):
 
 
 class HeaderIdExtension(Extension):
+    """Header ID extension."""
     def __init__(self, *args, **kwargs):
         # set defaults
         self.config = {

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/meta.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/meta.py
@@ -1,6 +1,4 @@
-"""
-Meta Data Extension for Python-Markdown
-=======================================
+"""Meta Data Extension for Python-Markdown.
 
 This extension adds Meta Data handling to markdown.
 
@@ -12,7 +10,6 @@ Original code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com).
 All changes Copyright 2008-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -32,20 +29,20 @@ END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
 
 
 class MetaExtension (Extension):
-    """ Meta-Data extension for Python-Markdown. """
+    """Meta-Data extension for Python-Markdown."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Add MetaPreprocessor to Markdown instance. """
+        """Add MetaPreprocessor to Markdown instance."""
         md.preprocessors.add("meta",
                              MetaPreprocessor(md),
                              ">normalize_whitespace")
 
 
 class MetaPreprocessor(Preprocessor):
-    """ Get Meta-Data. """
+    """Get Meta-Data."""
 
     def run(self, lines):
-        """ Parse Meta-Data and store in Markdown.Meta. """
+        """Parse Meta-Data and store in Markdown.Meta."""
         meta = {}
         key = None
         if lines and BEGIN_RE.match(lines[0]):

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/nl2br.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/nl2br.py
@@ -1,6 +1,4 @@
-"""
-NL2BR Extension
-===============
+"""NL2BR Extension.
 
 A Python-Markdown extension to treat newlines as hard breaks; like
 GitHub-flavored Markdown does.
@@ -13,7 +11,6 @@ Oringinal code Copyright 2011 [Brian Neal](http://deathofagremmie.com/)
 All changes Copyright 2011-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -25,6 +22,7 @@ BR_RE = r'\n'
 
 
 class Nl2BrExtension(Extension):
+    """Newline to br extension."""
 
     def extendMarkdown(self, md, md_globals):
         br_tag = SubstituteTagPattern(BR_RE, 'br')

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/sane_lists.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/sane_lists.py
@@ -1,6 +1,4 @@
-"""
-Sane List Extension for Python-Markdown
-=======================================
+"""Sane List Extension for Python-Markdown.
 
 Modify the behavior of Lists in Python-Markdown to act in a sane manor.
 
@@ -12,7 +10,6 @@ Original code Copyright 2011 [Waylan Limberg](http://achinghead.com)
 All changes Copyright 2011-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -23,6 +20,7 @@ import re
 
 
 class SaneOListProcessor(OListProcessor):
+    """Sane ordered list processor."""
 
     SIBLING_TAGS = ['ol']
 
@@ -33,6 +31,7 @@ class SaneOListProcessor(OListProcessor):
 
 
 class SaneUListProcessor(UListProcessor):
+    """Sane unordered list processor."""
 
     SIBLING_TAGS = ['ul']
 
@@ -43,10 +42,10 @@ class SaneUListProcessor(UListProcessor):
 
 
 class SaneListExtension(Extension):
-    """ Add sane lists to Markdown. """
+    """Add sane lists to Markdown."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Override existing Processors. """
+        """Override existing Processors."""
         md.parser.blockprocessors['olist'] = SaneOListProcessor(md.parser)
         md.parser.blockprocessors['ulist'] = SaneUListProcessor(md.parser)
 

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/smart_strong.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/smart_strong.py
@@ -1,6 +1,4 @@
-'''
-Smart_Strong Extension for Python-Markdown
-==========================================
+"""Smart_Strong Extension for Python-Markdown.
 
 This extention adds smarter handling of double underscores within words.
 
@@ -12,8 +10,7 @@ Original code Copyright 2011 [Waylan Limberg](http://achinghead.com)
 All changes Copyright 2011-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
-'''
+"""
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
@@ -25,10 +22,10 @@ STRONG_RE = r'(\*{2})(.+?)\2'
 
 
 class SmartEmphasisExtension(Extension):
-    """ Add smart_emphasis extension to Markdown class."""
+    """Add smart_emphasis extension to Markdown class."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Modify inline patterns. """
+        """Modify inline patterns."""
         md.inlinePatterns['strong'] = SimpleTagPattern(STRONG_RE, 'strong')
         md.inlinePatterns.add(
             'strong2',

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/smarty.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/smarty.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
-Smarty extension for Python-Markdown
-====================================
+"""Smarty extension for Python-Markdown.
 
 Adds conversion of ASCII dashes, quotes and ellipses to their HTML
 entity equivalents.
@@ -77,8 +75,7 @@ smartypants.py license:
    theory of liability, whether in contract, strict liability, or tort
    (including negligence or otherwise) arising in any way out of the use
    of this software, even if advised of the possibility of such damage.
-
-'''
+"""
 
 
 from __future__ import unicode_literals
@@ -151,8 +148,9 @@ HTML_STRICT_RE = HTML_RE + r'(?!\>)'
 
 
 class SubstituteTextPattern(HtmlPattern):
+    """Text pattern substitution handler."""
     def __init__(self, pattern, replace, markdown_instance):
-        """ Replaces matches with some text. """
+        """Replaces matches with some text."""
         HtmlPattern.__init__(self, pattern)
         self.replace = replace
         self.markdown = markdown_instance
@@ -168,6 +166,7 @@ class SubstituteTextPattern(HtmlPattern):
 
 
 class SmartyExtension(Extension):
+    """Smarty Extension."""
     def __init__(self, *args, **kwargs):
         self.config = {
             'smart_quotes': [True, 'Educate quotes'],

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/tables.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/tables.py
@@ -1,6 +1,4 @@
-"""
-Tables Extension for Python-Markdown
-====================================
+"""Tables Extension for Python-Markdown.
 
 Added parsing of tables to Python-Markdown.
 
@@ -12,7 +10,6 @@ Original code Copyright 2009 [Waylan Limberg](http://achinghead.com)
 All changes Copyright 2008-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -24,7 +21,7 @@ import re
 
 
 class TableProcessor(BlockProcessor):
-    """ Process Tables. """
+    """Process Tables."""
 
     RE_CODE_PIPES = re.compile(r'(?:(\\\\)|(\\`+)|(`+)|(\\\|)|(\|))')
     RE_END_BORDER = re.compile(r'(?<!\\)(?:\\\\)*\|$')
@@ -35,8 +32,7 @@ class TableProcessor(BlockProcessor):
         super(TableProcessor, self).__init__(parser)
 
     def test(self, parent, block):
-        """
-        Ensure first two rows (column header and separator row) are valid table rows.
+        """Ensure first two rows (column header and separator row) are valid table rows.
 
         Keep border check and separator row do avoid repeating the work.
         """
@@ -55,7 +51,7 @@ class TableProcessor(BlockProcessor):
         return is_table
 
     def run(self, parent, blocks):
-        """ Parse a table block and build table. """
+        """Parse a table block and build table."""
         block = blocks.pop(0).split('\n')
         header = block[0].strip()
         rows = [] if len(block) < 3 else block[2:]
@@ -82,7 +78,7 @@ class TableProcessor(BlockProcessor):
             self._build_row(row.strip(), tbody, align)
 
     def _build_row(self, row, parent, align):
-        """ Given a row of text, build table cells. """
+        """Given a row of text, build table cells."""
         tr = etree.SubElement(parent, 'tr')
         tag = 'td'
         if parent.tag == 'thead':
@@ -100,7 +96,7 @@ class TableProcessor(BlockProcessor):
                 c.set('align', a)
 
     def _split_row(self, row):
-        """ split a row of text into list of cells. """
+        """Split a row of text into list of cells."""
         if self.border:
             if row.startswith('|'):
                 row = row[1:]
@@ -108,7 +104,7 @@ class TableProcessor(BlockProcessor):
         return self._split(row)
 
     def _split(self, row):
-        """ split a row of text with some code into a list of cells. """
+        """Split a row of text with some code into a list of cells."""
         elements = []
         pipes = []
         tics = []
@@ -181,10 +177,10 @@ class TableProcessor(BlockProcessor):
 
 
 class TableExtension(Extension):
-    """ Add tables to Markdown. """
+    """Add tables to Markdown."""
 
     def extendMarkdown(self, md, md_globals):
-        """ Add an instance of TableProcessor to BlockParser. """
+        """Add an instance of TableProcessor to BlockParser."""
         if '|' not in md.ESCAPED_CHARS:
             md.ESCAPED_CHARS.append('|')
         md.parser.blockprocessors.add('table',

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/toc.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/toc.py
@@ -1,16 +1,13 @@
-"""
-Table of Contents Extension for Python-Markdown
-===============================================
+"""Table of Contents Extension for Python-Markdown.
 
 See <https://pythonhosted.org/Markdown/extensions/toc.html>
 for documentation.
 
-Oringinal code Copyright 2008 [Jack Miller](http://codezen.org)
+Original code Copyright 2008 [Jack Miller](http://codezen.org)
 
 All changes Copyright 2008-2014 The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
 """
 
 from __future__ import absolute_import
@@ -23,7 +20,7 @@ import unicodedata
 
 
 def slugify(value, separator):
-    """ Slugify a string, to make it URL friendly. """
+    """Slugify a string, to make it URL friendly."""
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
     value = re.sub('[^\w\s-]', '', value.decode('ascii')).strip().lower()
     return re.sub('[%s\s]+' % separator, separator, value)
@@ -33,7 +30,7 @@ IDCOUNT_RE = re.compile(r'^(.*)_([0-9]+)$')
 
 
 def unique(id, ids):
-    """ Ensure id is unique in set of ids. Append '_1', '_2'... if not """
+    """Ensure id is unique in set of ids. Append '_1', '_2'... if not."""
     while id in ids or not id:
         m = IDCOUNT_RE.match(id)
         if m:
@@ -45,9 +42,9 @@ def unique(id, ids):
 
 
 def stashedHTML2text(text, md):
-    """ Extract raw HTML from stash, reduce to plain text and swap with placeholder. """
+    """Extract raw HTML from stash, reduce to plain text and swap with placeholder."""
     def _html_sub(m):
-        """ Substitute raw html with plain text. """
+        """Substitute raw html with plain text."""
         try:
             raw, safe = md.htmlStash.rawHtmlBlocks[int(m.group(1))]
         except (IndexError, TypeError):  # pragma: no cover
@@ -62,16 +59,17 @@ def stashedHTML2text(text, md):
 
 def nest_toc_tokens(toc_list):
     """Given an unsorted list with errors and skips, return a nested one.
-    [{'level': 1}, {'level': 2}]
-    =>
-    [{'level': 1, 'children': [{'level': 2, 'children': []}]}]
 
-    A wrong list is also converted:
-    [{'level': 2}, {'level': 1}]
-    =>
-    [{'level': 2, 'children': []}, {'level': 1, 'children': []}]
+    Examples:
+        [{'level': 1}, {'level': 2}]
+        =>
+        [{'level': 1, 'children': [{'level': 2, 'children': []}]}].
+
+        A wrong list is also converted:
+        [{'level': 2}, {'level': 1}]
+        =>
+        [{'level': 2, 'children': []}, {'level': 1, 'children': []}]
     """
-
     ordered_list = []
     if len(toc_list):
         # Initialize everything by processing the first entry
@@ -124,6 +122,7 @@ def nest_toc_tokens(toc_list):
 
 
 class TocTreeprocessor(Treeprocessor):
+    """TOC Tree processor."""
     def __init__(self, md, config):
         super(TocTreeprocessor, self).__init__(md)
 
@@ -140,13 +139,13 @@ class TocTreeprocessor(Treeprocessor):
         self.header_rgx = re.compile("[Hh][123456]")
 
     def iterparent(self, root):
-        ''' Iterator wrapper to get parent and child all at once. '''
+        """Iterator wrapper to get parent and child all at once."""
         for parent in root.iter():
             for child in parent:
                 yield parent, child
 
     def replace_marker(self, root, elem):
-        ''' Replace marker with elem. '''
+        """Replace marker with elem."""
         for (p, c) in self.iterparent(root):
             text = ''.join(c.itertext()).strip()
             if not text:
@@ -166,7 +165,7 @@ class TocTreeprocessor(Treeprocessor):
                         break
 
     def set_level(self, elem):
-        ''' Adjust header level according to base level. '''
+        """Adjust header level according to base level."""
         level = int(elem.tag[-1]) + self.base_level
         if level > 6:
             level = 6
@@ -195,7 +194,7 @@ class TocTreeprocessor(Treeprocessor):
         c.append(permalink)
 
     def build_toc_div(self, toc_list):
-        """ Return a string div given a toc list. """
+        """Return a string div given a toc list."""
         div = etree.Element("div")
         div.attrib["class"] = "toc"
 
@@ -264,6 +263,7 @@ class TocTreeprocessor(Treeprocessor):
 
 
 class TocExtension(Extension):
+    """TOC Markdown extension."""
 
     TreeProcessorClass = TocTreeprocessor
 

--- a/pyrevitlib/pyrevit/coreutils/markdown/extensions/wikilinks.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/extensions/wikilinks.py
@@ -1,6 +1,4 @@
-'''
-WikiLinks Extension for Python-Markdown
-======================================
+"""WikiLinks Extension for Python-Markdown.
 
 Converts [[WikiLinks]] to relative links.
 
@@ -12,9 +10,7 @@ Original code Copyright [Waylan Limberg](http://achinghead.com/).
 All changes Copyright The Python Markdown Project
 
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
-
-'''
-
+"""
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
@@ -24,12 +20,13 @@ import re
 
 
 def build_url(label, base, end):
-    """ Build a url from the label, a base, and an end. """
+    """Build a url from the label, a base, and an end."""
     clean_label = re.sub(r'([ ]+_)|(_[ ]+)|([ ]+)', '_', label)
     return '%s%s%s' % (base, clean_label, end)
 
 
 class WikiLinkExtension(Extension):
+    """WikiLinks markdown extension."""
 
     def __init__(self, *args, **kwargs):
         self.config = {
@@ -52,6 +49,7 @@ class WikiLinkExtension(Extension):
 
 
 class WikiLinks(Pattern):
+    """WikiLinks parser."""
     def __init__(self, pattern, config):
         super(WikiLinks, self).__init__(pattern)
         self.config = config
@@ -71,7 +69,7 @@ class WikiLinks(Pattern):
         return a
 
     def _getMeta(self):
-        """ Return meta data or config data. """
+        """Return meta data or config data."""
         base_url = self.config['base_url']
         end_url = self.config['end_url']
         html_class = self.config['html_class']

--- a/pyrevitlib/pyrevit/coreutils/markdown/inlinepatterns.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/inlinepatterns.py
@@ -1,6 +1,4 @@
-"""
-INLINE PATTERNS
-=============================================================================
+"""INLINE PATTERNS.
 
 Inline patterns such as *emphasis* are handled by means of auxiliary
 objects, one per pattern.  Pattern objects must be instances of classes
@@ -60,7 +58,7 @@ except ImportError:  # pragma: no cover
 
 
 def build_inlinepatterns(md_instance, **kwargs):
-    """ Build the default set of inline patterns for Markdown. """
+    """Build the default set of inline patterns for Markdown."""
     inlinePatterns = odict.OrderedDict()
     inlinePatterns["backtick"] = BacktickPattern(BACKTICK_RE)
     inlinePatterns["escape"] = EscapePattern(ESCAPE_RE, md_instance)
@@ -190,16 +188,14 @@ The pattern classes
 
 
 class Pattern(object):
-    """Base class that inline patterns subclass. """
+    """Base class that inline patterns subclass."""
 
     def __init__(self, pattern, markdown_instance=None):
-        """
-        Create an instant of an inline pattern.
+        """Create an instant of an inline pattern.
 
-        Keyword arguments:
-
-        * pattern: A regular expression that matches a pattern
-
+        Args:
+            pattern (str): A regular expression that matches a pattern
+            markdown_instance (markdown.Markdown): Instance of Markdown
         """
         self.pattern = pattern
         self.compiled_re = re.compile("^(.*?)%s(.*)$" % pattern,
@@ -211,7 +207,7 @@ class Pattern(object):
             self.markdown = markdown_instance
 
     def getCompiledRegExp(self):
-        """ Return a compiled regular expression. """
+        """Return a compiled regular expression."""
         return self.compiled_re
 
     def handleMatch(self, m):
@@ -219,26 +215,24 @@ class Pattern(object):
 
         Subclasses should override this method.
 
-        Keyword arguments:
-
-        * m: A re match object containing a match of the pattern.
-
+        Args:
+            m (re.match): A re match object containing a match of the pattern.
         """
         pass  # pragma: no cover
 
     def type(self):
-        """ Return class name, to define pattern type """
+        """Return class name, to define pattern type."""
         return self.__class__.__name__
 
     def unescape(self, text):
-        """ Return unescaped text given text with an inline placeholder. """
+        """Return unescaped text given text with an inline placeholder."""
         try:
             stash = self.markdown.treeprocessors['inline'].stashed_nodes
         except KeyError:  # pragma: no cover
             return text
 
         def itertext(el):  # pragma: no cover
-            ' Reimplement Element.itertext for older python versions '
+            """Reimplement Element.itertext for older python versions."""
             tag = el.tag
             if not isinstance(tag, util.string_type) and tag is not None:
                 return
@@ -263,13 +257,13 @@ class Pattern(object):
 
 
 class SimpleTextPattern(Pattern):
-    """ Return a simple text of group(2) of a Pattern. """
+    """Return a simple text of group(2) of a Pattern."""
     def handleMatch(self, m):
         return m.group(2)
 
 
 class EscapePattern(Pattern):
-    """ Return an escaped character. """
+    """Return an escaped character."""
 
     def handleMatch(self, m):
         char = m.group(2)
@@ -280,11 +274,7 @@ class EscapePattern(Pattern):
 
 
 class SimpleTagPattern(Pattern):
-    """
-    Return element of type `tag` with a text attribute of group(3)
-    of a Pattern.
-
-    """
+    """Return a `tag` element with a text attribute of group(3) of a Pattern."""
     def __init__(self, pattern, tag):
         Pattern.__init__(self, pattern)
         self.tag = tag
@@ -296,13 +286,13 @@ class SimpleTagPattern(Pattern):
 
 
 class SubstituteTagPattern(SimpleTagPattern):
-    """ Return an element of type `tag` with no children. """
+    """Return an element of type `tag` with no children."""
     def handleMatch(self, m):
         return util.etree.Element(self.tag)
 
 
 class BacktickPattern(Pattern):
-    """ Return a `<code>` element containing the matching text. """
+    """Return a `<code>` element containing the matching text."""
     def __init__(self, pattern):
         Pattern.__init__(self, pattern)
         self.ESCAPED_BSLASH = '%s%s%s' % (util.STX, ord('\\'), util.ETX)
@@ -334,14 +324,14 @@ class DoubleTagPattern(SimpleTagPattern):
 
 
 class HtmlPattern(Pattern):
-    """ Store raw inline html and return a placeholder. """
+    """Store raw inline html and return a placeholder."""
     def handleMatch(self, m):
         rawhtml = self.unescape(m.group(2))
         place_holder = self.markdown.htmlStash.store(rawhtml)
         return place_holder
 
     def unescape(self, text):
-        """ Return unescaped text given text with an inline placeholder. """
+        """Return unescaped text given text with an inline placeholder."""
         try:
             stash = self.markdown.treeprocessors['inline'].stashed_nodes
         except KeyError:  # pragma: no cover
@@ -360,7 +350,7 @@ class HtmlPattern(Pattern):
 
 
 class LinkPattern(Pattern):
-    """ Return a link element from the given match. """
+    """Return a link element from the given match."""
     def handleMatch(self, m):
         el = util.etree.Element("a")
         el.text = m.group(2)
@@ -380,8 +370,7 @@ class LinkPattern(Pattern):
         return el
 
     def sanitize_url(self, url):
-        """
-        Sanitize a url against xss attacks in "safe_mode".
+        """Sanitize a url against xss attacks in "safe_mode".
 
         Rather than specifically blacklisting `javascript:alert("XSS")` and all
         its aliases (see <http://ha.ckers.org/xss.html>), we whitelist known
@@ -427,7 +416,7 @@ class LinkPattern(Pattern):
 
 
 class ImagePattern(LinkPattern):
-    """ Return a img element from the given match. """
+    """Return a img element from the given match."""
     def handleMatch(self, m):
         el = util.etree.Element("img")
         src_parts = m.group(9).split()
@@ -451,7 +440,7 @@ class ImagePattern(LinkPattern):
 
 
 class ReferencePattern(LinkPattern):
-    """ Match to a stored reference and return link element. """
+    """Match to a stored reference and return link element."""
 
     NEWLINE_CLEANUP_RE = re.compile(r'[ ]?\n', re.MULTILINE)
 
@@ -486,7 +475,7 @@ class ReferencePattern(LinkPattern):
 
 
 class ImageReferencePattern(ReferencePattern):
-    """ Match to a stored reference and return img element. """
+    """Match to a stored reference and return img element."""
     def makeTag(self, href, title, text):
         el = util.etree.Element("img")
         el.set("src", self.sanitize_url(href))
@@ -501,7 +490,7 @@ class ImageReferencePattern(ReferencePattern):
 
 
 class AutolinkPattern(Pattern):
-    """ Return a link Element given an autolink (`<http://example/com>`). """
+    """Return a link Element given an autolink (`<http://example/com>`)."""
     def handleMatch(self, m):
         el = util.etree.Element("a")
         el.set('href', self.unescape(m.group(2)))
@@ -510,9 +499,7 @@ class AutolinkPattern(Pattern):
 
 
 class AutomailPattern(Pattern):
-    """
-    Return a mailto link Element given an automail link (`<foo@example.com>`).
-    """
+    """Return a mailto link Element given an automail link (`<foo@example.com>`)."""
     def handleMatch(self, m):
         el = util.etree.Element('a')
         email = self.unescape(m.group(2))

--- a/pyrevitlib/pyrevit/coreutils/markdown/odict.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/odict.py
@@ -1,3 +1,4 @@
+"""Ordered dictionary."""
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from . import util
@@ -5,11 +6,9 @@ from copy import deepcopy
 
 
 class OrderedDict(dict):
-    """
-    A dictionary that keeps its keys in the order in which they're inserted.
+    """A dictionary that keeps its keys in the order in which they're inserted.
 
     Copied from Django's SortedDict with some modifications.
-
     """
     def __new__(cls, *args, **kwargs):
         instance = super(OrderedDict, cls).__new__(cls, *args, **kwargs)
@@ -129,10 +128,7 @@ class OrderedDict(dict):
         return self.__class__(self)
 
     def __repr__(self):
-        """
-        Replaces the normal dict.__repr__ with a version that returns the keys
-        in their Ordered order.
-        """
+        """Returns the keys in their Ordered order."""
         return '{%s}' % ', '.join(
             ['%r: %r' % (k, v) for k, v in self._iteritems()]
         )
@@ -142,14 +138,14 @@ class OrderedDict(dict):
         self.keyOrder = []
 
     def index(self, key):
-        """ Return the index of a given key. """
+        """Return the index of a given key."""
         try:
             return self.keyOrder.index(key)
         except ValueError:
             raise ValueError("Element '%s' was not found in OrderedDict" % key)
 
     def index_for_location(self, location):
-        """ Return index or None for a given location. """
+        """Return index or None for a given location."""
         if location == '_begin':
             i = 0
         elif location == '_end':
@@ -168,7 +164,7 @@ class OrderedDict(dict):
         return i
 
     def add(self, key, value, location):
-        """ Insert by key location. """
+        """Insert by key location."""
         i = self.index_for_location(location)
         if i is not None:
             self.insert(i, key, value)
@@ -176,7 +172,7 @@ class OrderedDict(dict):
             self.__setitem__(key, value)
 
     def link(self, key, location):
-        """ Change location of an existing item. """
+        """Change location of an existing item."""
         n = self.keyOrder.index(key)
         del self.keyOrder[n]
         try:

--- a/pyrevitlib/pyrevit/coreutils/markdown/postprocessors.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/postprocessors.py
@@ -1,11 +1,8 @@
-"""
-POST-PROCESSORS
-=============================================================================
+"""POST-PROCESSORS.
 
 Markdown also allows post-processors, which are similar to preprocessors in
 that they need to implement a "run" method. However, they are run after core
 processing.
-
 """
 
 from __future__ import absolute_import
@@ -19,7 +16,7 @@ from . import util
 
 
 def build_postprocessors(md_instance, **kwargs):
-    """ Build the default postprocessors for Markdown. """
+    """Build the default postprocessors for Markdown."""
     postprocessors = odict.OrderedDict()
     postprocessors["raw_html"] = RawHtmlPostprocessor(md_instance)
     postprocessors["amp_substitute"] = AndSubstitutePostprocessor()
@@ -28,8 +25,7 @@ def build_postprocessors(md_instance, **kwargs):
 
 
 class Postprocessor(util.Processor):
-    """
-    Postprocessors are run after the ElementTree it converted back into text.
+    """Postprocessors are run after the ElementTree it converted back into text.
 
     Each Postprocessor implements a "run" method that takes a pointer to a
     text string, modifies it as necessary and returns a text string.
@@ -39,20 +35,20 @@ class Postprocessor(util.Processor):
     """
 
     def run(self, text):
-        """
+        """Main postprocessor method.
+
         Subclasses of Postprocessor should implement a `run` method, which
         takes the html document as a single text string and returns a
         (possibly modified) string.
-
         """
         pass  # pragma: no cover
 
 
 class RawHtmlPostprocessor(Postprocessor):
-    """ Restore raw html to the document. """
+    """Restore raw html to the document."""
 
     def run(self, text):
-        """ Iterate over html stash and restore "safe" html. """
+        """Iterate over html stash and restore "safe" html."""
         replacements = OrderedDict()
         for i in range(self.markdown.htmlStash.html_counter):
             html, safe = self.markdown.htmlStash.rawHtmlBlocks[i]
@@ -77,7 +73,7 @@ class RawHtmlPostprocessor(Postprocessor):
         return text
 
     def escape(self, html):
-        """ Basic html escaping """
+        """Basic html escaping."""
         html = html.replace('&', '&amp;')
         html = html.replace('<', '&lt;')
         html = html.replace('>', '&gt;')
@@ -94,7 +90,7 @@ class RawHtmlPostprocessor(Postprocessor):
 
 
 class AndSubstitutePostprocessor(Postprocessor):
-    """ Restore valid entities """
+    """Restore valid entities."""
 
     def run(self, text):
         text = text.replace(util.AMP_SUBSTITUTE, "&")
@@ -102,7 +98,7 @@ class AndSubstitutePostprocessor(Postprocessor):
 
 
 class UnescapePostprocessor(Postprocessor):
-    """ Restore escaped chars """
+    """Restore escaped chars."""
 
     RE = re.compile('%s(\d+)%s' % (util.STX, util.ETX))
 

--- a/pyrevitlib/pyrevit/coreutils/markdown/preprocessors.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/preprocessors.py
@@ -1,6 +1,4 @@
-"""
-PRE-PROCESSORS
-=============================================================================
+"""PRE-PROCESSORS.
 
 Preprocessors work on source text before we start doing anything too
 complicated.
@@ -16,7 +14,7 @@ from . import util
 
 
 def build_preprocessors(md_instance, **kwargs):
-    """ Build the default set of preprocessors used by Markdown. """
+    """Build the default set of preprocessors used by Markdown."""
     preprocessors = odict.OrderedDict()
     preprocessors['normalize_whitespace'] = NormalizeWhitespace(md_instance)
     if md_instance.safeMode != 'escape':
@@ -26,18 +24,17 @@ def build_preprocessors(md_instance, **kwargs):
 
 
 class Preprocessor(util.Processor):
-    """
-    Preprocessors are run after the text is broken into lines.
+    """Preprocessors are run after the text is broken into lines.
 
     Each preprocessor implements a "run" method that takes a pointer to a
     list of lines of the document, modifies it as necessary and returns
     either the same pointer or a pointer to a new list.
 
     Preprocessors must extend markdown.Preprocessor.
-
     """
     def run(self, lines):
-        """
+        """Main preprocessor task.
+
         Each subclass of Preprocessor should override the `run` method, which
         takes the document as a list of strings split by newlines and returns
         the (possibly modified) list of lines.
@@ -47,7 +44,7 @@ class Preprocessor(util.Processor):
 
 
 class NormalizeWhitespace(Preprocessor):
-    """ Normalize whitespace for consistant parsing. """
+    """Normalize whitespace for consistant parsing."""
 
     def run(self, lines):
         source = '\n'.join(lines)
@@ -146,7 +143,8 @@ class HtmlBlockPreprocessor(Preprocessor):
         return (tag in ['hr', 'hr/'])
 
     def _stringindex_to_listindex(self, stringindex, items):
-        """
+        """Return the index of the item matching the cumulative string index.
+
         Same effect as concatenating the strings in items,
         finding the character to which stringindex refers in that string,
         and returning the index of the item in which that character resides.
@@ -325,7 +323,7 @@ class HtmlBlockPreprocessor(Preprocessor):
 
 
 class ReferencePreprocessor(Preprocessor):
-    """ Remove reference definitions from text and store for later use. """
+    """Remove reference definitions from text and store for later use."""
 
     TITLE = r'[ ]*(\"(.*)\"|\'(.*)\'|\((.*)\))[ ]*'
     RE = re.compile(

--- a/pyrevitlib/pyrevit/coreutils/markdown/serializers.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/serializers.py
@@ -1,41 +1,39 @@
-# markdown/searializers.py
-#
-# Add x/html serialization to Elementree
-# Taken from ElementTree 1.3 preview with slight modifications
-#
-# Copyright (c) 1999-2007 by Fredrik Lundh.  All rights reserved.
-#
-# fredrik@pythonware.com
-# http://www.pythonware.com
-#
-# --------------------------------------------------------------------
-# The ElementTree toolkit is
-#
-# Copyright (c) 1999-2007 by Fredrik Lundh
-#
-# By obtaining, using, and/or copying this software and/or its
-# associated documentation, you agree that you have read, understood,
-# and will comply with the following terms and conditions:
-#
-# Permission to use, copy, modify, and distribute this software and
-# its associated documentation for any purpose and without fee is
-# hereby granted, provided that the above copyright notice appears in
-# all copies, and that both that copyright notice and this permission
-# notice appear in supporting documentation, and that the name of
-# Secret Labs AB or the author not be used in advertising or publicity
-# pertaining to distribution of the software without specific, written
-# prior permission.
-#
-# SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
-# TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANT-
-# ABILITY AND FITNESS.  IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR
-# BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
-# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
-# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
-# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
-# OF THIS SOFTWARE.
-# --------------------------------------------------------------------
+"""Add x/html serialization to Elementree.
 
+Taken from ElementTree 1.3 preview with slight modifications
+
+Copyright (c) 1999-2007 by Fredrik Lundh.  All rights reserved.
+
+fredrik@pythonware.com
+http://www.pythonware.com
+
+--------------------------------------------------------------------
+The ElementTree toolkit is
+
+Copyright (c) 1999-2007 by Fredrik Lundh
+
+By obtaining, using, and/or copying this software and/or its
+associated documentation, you agree that you have read, understood,
+and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and
+its associated documentation for any purpose and without fee is
+hereby granted, provided that the above copyright notice appears in
+all copies, and that both that copyright notice and this permission
+notice appear in supporting documentation, and that the name of
+Secret Labs AB or the author not be used in advertising or publicity
+pertaining to distribution of the software without specific, written
+prior permission.
+
+SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
+TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANT-
+ABILITY AND FITNESS.  IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR
+BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+OF THIS SOFTWARE.
+"""
 
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/pyrevitlib/pyrevit/coreutils/markdown/treeprocessors.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/treeprocessors.py
@@ -1,3 +1,4 @@
+"""Markdown Treeprocessors."""
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -7,7 +8,7 @@ from . import util
 
 
 def build_treeprocessors(md_instance, **kwargs):
-    """ Build the default treeprocessors for Markdown. """
+    """Build the default treeprocessors for Markdown."""
     treeprocessors = odict.OrderedDict()
     treeprocessors["inline"] = InlineProcessor(md_instance)
     treeprocessors["prettify"] = PrettifyTreeprocessor(md_instance)
@@ -15,15 +16,14 @@ def build_treeprocessors(md_instance, **kwargs):
 
 
 def isString(s):
-    """ Check if it's string """
+    """Check if it's string."""
     if not isinstance(s, util.AtomicString):
         return isinstance(s, util.string_type)
     return False
 
 
 class Treeprocessor(util.Processor):
-    """
-    Treeprocessors are run on the ElementTree object before serialization.
+    """Treeprocessors are run on the ElementTree object before serialization.
 
     Each Treeprocessor implements a "run" method that takes a pointer to an
     ElementTree, modifies it as necessary and returns an ElementTree
@@ -33,7 +33,8 @@ class Treeprocessor(util.Processor):
 
     """
     def run(self, root):
-        """
+        """Main treeprocessor method.
+
         Subclasses of Treeprocessor should implement a `run` method, which
         takes a root ElementTree. This method can return another ElementTree
         object, and the existing root ElementTree will be replaced, or it can
@@ -43,9 +44,7 @@ class Treeprocessor(util.Processor):
 
 
 class InlineProcessor(Treeprocessor):
-    """
-    A Treeprocessor that traverses a tree, applying inline patterns.
-    """
+    """A Treeprocessor that traverses a tree, applying inline patterns."""
 
     def __init__(self, md):
         self.__placeholder_prefix = util.INLINE_PLACEHOLDER_PREFIX
@@ -57,22 +56,20 @@ class InlineProcessor(Treeprocessor):
         self.inlinePatterns = md.inlinePatterns
 
     def __makePlaceholder(self, type):
-        """ Generate a placeholder """
+        """Generate a placeholder."""
         id = "%04d" % len(self.stashed_nodes)
         hash = util.INLINE_PLACEHOLDER % id
         return hash, id
 
     def __findPlaceholder(self, data, index):
-        """
-        Extract id from data string, start from index
+        """Extract id from data string, start from index.
 
-        Keyword arguments:
+        Args:
+            data (str): text
+            index (int): index from which we start search
 
-        * data: string
-        * index: index, from which we start search
-
-        Returns: placeholder id and string index, after the found placeholder.
-
+        Returns:
+            (str, int): placeholder id and index after the found placeholder.
         """
         m = self.__placeholder_re.search(data, index)
         if m:
@@ -81,23 +78,20 @@ class InlineProcessor(Treeprocessor):
             return None, index + 1
 
     def __stashNode(self, node, type):
-        """ Add node to stash """
+        """Add node to stash."""
         placeholder, id = self.__makePlaceholder(type)
         self.stashed_nodes[id] = node
         return placeholder
 
     def __handleInline(self, data, patternIndex=0):
-        """
-        Process string with inline patterns and replace it
-        with placeholders
+        """Replace placeholders of texts with inline patterns.
 
-        Keyword arguments:
+        Args:
+            data (str): A line of Markdown text
+            patternIndex (int): The index of the inlinePattern to start with
 
-        * data: A line of Markdown text
-        * patternIndex: The index of the inlinePattern to start with
-
-        Returns: String with placeholders.
-
+        Returns:
+            (str): Text with placeholders.
         """
         if not isinstance(data, util.AtomicString):
             startIndex = 0
@@ -110,18 +104,12 @@ class InlineProcessor(Treeprocessor):
         return data
 
     def __processElementText(self, node, subnode, isText=True):
-        """
-        Process placeholders in Element.text or Element.tail
-        of Elements popped from self.stashed_nodes.
+        """Process text placeholders of stashed nodes.
 
-        Keywords arguments:
-
-        * node: parent node
-        * subnode: processing node
-        * isText: bool variable, True - it's text, False - it's tail
-
-        Returns: None
-
+        Args:
+            node (Element): parent node
+            subnode (Element): processing node
+            isText (bool): True - it's text, False - it's tail
         """
         if isText:
             text = subnode.text
@@ -142,16 +130,15 @@ class InlineProcessor(Treeprocessor):
             node.insert(pos, newChild)
 
     def __processPlaceholders(self, data, parent, isText=True):
-        """
-        Process string with placeholders and generate ElementTree tree.
+        """Process string with placeholders and generate ElementTree tree.
 
-        Keyword arguments:
+        Args:
+            data (str): text with placeholders instead of ElementTree elements.
+            parent (Element): Element which contains processing inline data
+            isText (bool): True - it's text, False - it's tail
 
-        * data: string with placeholders instead of ElementTree elements.
-        * parent: Element, which contains processing inline data
-
-        Returns: list with ElementTree elements with applied inline patterns.
-
+        Returns:
+            (list[ElementTree]): elements with applied inline patterns.
         """
         def linkText(text):
             if text:
@@ -217,19 +204,19 @@ class InlineProcessor(Treeprocessor):
         return result
 
     def __applyPattern(self, pattern, data, patternIndex, startIndex=0):
-        """
+        """Add the pattern to stashed_nodes if the line fits the pattern.
+
         Check if the line fits the pattern, create the necessary
         elements, add it to stashed_nodes.
 
-        Keyword arguments:
+        Args:
+            data (str): the text to be processed
+            pattern (str): the pattern to be checked
+            patternIndex (int): index of current pattern
+            startIndex (int): string index, from which we start searching
 
-        * data: the text to be processed
-        * pattern: the pattern to be checked
-        * patternIndex: index of current pattern
-        * startIndex: string index, from which we start searching
-
-        Returns: String with placeholders instead of ElementTree elements.
-
+        Returns:
+            (str): text with placeholders instead of ElementTree elements.
         """
         match = pattern.getCompiledRegExp().match(data[startIndex:])
         leftData = data[:startIndex]
@@ -272,12 +259,11 @@ class InlineProcessor(Treeprocessor):
 
             node.text = markdown.AtomicString("This will not be processed.")
 
-        Arguments:
+        Args:
+            tree (ElementTree): Markdown tree.
 
-        * tree: ElementTree object, representing Markdown tree.
-
-        Returns: ElementTree object with applied inline patterns.
-
+        Returns:
+            (ElementTree): Tree with applied inline patterns.
         """
         self.stashed_nodes = {}
 
@@ -335,11 +321,10 @@ class InlineProcessor(Treeprocessor):
 
 
 class PrettifyTreeprocessor(Treeprocessor):
-    """ Add linebreaks to the html document. """
+    """Add linebreaks to the html document."""
 
     def _prettifyETree(self, elem):
-        """ Recursively add linebreaks to ElementTree children. """
-
+        """Recursively add linebreaks to ElementTree children."""
         i = "\n"
         if util.isBlockLevel(elem.tag) and elem.tag not in ['code', 'pre']:
             if (not elem.text or not elem.text.strip()) \
@@ -354,8 +339,7 @@ class PrettifyTreeprocessor(Treeprocessor):
             elem.tail = i
 
     def run(self, root):
-        """ Add linebreaks to ElementTree root object. """
-
+        """Add linebreaks to ElementTree root object."""
         self._prettifyETree(root)
         # Do <br />'s seperately as they are often in the middle of
         # inline content and missed by _prettifyETree.

--- a/pyrevitlib/pyrevit/coreutils/markdown/util.py
+++ b/pyrevitlib/pyrevit/coreutils/markdown/util.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Markdown utils."""
 from __future__ import unicode_literals
 import re
 import sys
@@ -93,10 +94,23 @@ def isBlockLevel(tag):
 
 
 def parseBoolValue(value, fail_on_errors=True, preserve_none=False):
-    """Parses a string representing bool value. If parsing was successful,
-       returns True or False. If preserve_none=True, returns True, False,
-       or None. If parsing was not successful, raises  ValueError, or, if
-       fail_on_errors=False, returns None."""
+    """Parses a string representing bool value.
+    
+    If parsing was successful, returns True or False.
+    If preserve_none=True, returns True, False, or None.
+    If parsing was not successful, raises ValueError, or, if
+    fail_on_errors=False, returns None.
+    
+
+    Args:
+        value (str): String to parse.
+        fail_on_errors (bool): If True, raises ValueError.
+        preserve_none (bool): If True and value is None, returns None.
+        
+
+    Returns:
+        (bool): boolean value
+    """
     if not isinstance(value, string_type):
         if preserve_none and value is None:
             return value
@@ -123,37 +137,34 @@ class AtomicString(unicode):
 
 
 class Processor(object):
+    """Base class for Markdown processors."""
     def __init__(self, markdown_instance=None):
         if markdown_instance:
             self.markdown = markdown_instance
 
 
 class HtmlStash(object):
-    """
-    This class is used for stashing HTML objects that we extract
-    in the beginning and replace with place-holders.
-    """
+    """HTML objects stash."""
 
     def __init__(self):
-        """ Create a HtmlStash. """
+        """Create a HtmlStash."""
         self.html_counter = 0  # for counting inline html segments
         self.rawHtmlBlocks = []
         self.tag_counter = 0
         self.tag_data = []  # list of dictionaries in the order tags appear
 
     def store(self, html, safe=False):
-        """
-        Saves an HTML segment for later reinsertion.  Returns a
-        placeholder string that needs to be inserted into the
+        """Saves an HTML segment for later reinsertion.
+
+        Returns a placeholder string that needs to be inserted into the
         document.
 
-        Keyword arguments:
+        Args:
+            html (str): an html segment
+            safe (bool): label an html segment as safe for safemode
 
-        * html: an html segment
-        * safe: label an html segment as safe for safemode
-
-        Returns : a placeholder string
-
+        Returns:
+            (str): a placeholder string
         """
         self.rawHtmlBlocks.append((html, safe))
         placeholder = self.get_placeholder(self.html_counter)

--- a/pyrevitlib/pyrevit/coreutils/mathnet.py
+++ b/pyrevitlib/pyrevit/coreutils/mathnet.py
@@ -2,7 +2,7 @@
 
 See https://www.mathdotnet.com for documentation.
 
-Example:
+Examples:
     >>> from pyrevit.coreutils.mathnet import MathNet
 """
 #pylint: disable=W0703,C0302,C0103

--- a/pyrevitlib/pyrevit/coreutils/moduleutils.py
+++ b/pyrevitlib/pyrevit/coreutils/moduleutils.py
@@ -16,7 +16,7 @@ def copy_func(func, func_name, doc_string=None, arg_list=None):
         arg_list (list): list of default values for function arguments
 
     Returns:
-        object: new python function objects
+        (object): new python function objects
     """
     new_func = types.FunctionType(func.func_code, func.func_globals,
                                   func_name, tuple(arg_list), func.func_closure)
@@ -25,7 +25,7 @@ def copy_func(func, func_name, doc_string=None, arg_list=None):
 
 
 def mark(prop_name):
-    """Decorator function to add a marker property to the given type"""
+    """Decorator function to add a marker property to the given type."""
     def setter_decorator(type_obj):
         setattr(type_obj, prop_name, True)
         return type_obj
@@ -33,7 +33,7 @@ def mark(prop_name):
 
 
 def collect_marked(module_obj, prop_name):
-    """Collect module objects that are marked with given property"""
+    """Collect module objects that are marked with given property."""
     marked_objs = []
     for member in inspect.getmembers(module_obj):
         _, type_obj = member
@@ -44,12 +44,12 @@ def collect_marked(module_obj, prop_name):
 
 
 def has_argument(function_obj, arg_name):
-    """Check if given function object has argument matching arg_name"""
+    """Check if given function object has argument matching arg_name."""
     return arg_name in inspect.getargspec(function_obj)[0] #pylint: disable=deprecated-method
 
 
 def has_any_arguments(function_obj, arg_name_list):
-    """Check if given function object has any of given arguments"""
+    """Check if given function object has any of given arguments."""
     args = inspect.getargspec(function_obj)[0] #pylint: disable=deprecated-method
     if arg_name_list:
         return any(x in args for x in arg_name_list)
@@ -57,7 +57,7 @@ def has_any_arguments(function_obj, arg_name_list):
 
 
 def filter_kwargs(function_obj, kwargs):
-    """Filter given arguments dict for function_obj arguments"""
+    """Filter given arguments dict for function_obj arguments."""
     filtered_kwargs = {}
     for arg_name in inspect.getargspec(function_obj)[0]: #pylint: disable=deprecated-method
         filtered_kwargs[arg_name] = kwargs.get(arg_name, None)

--- a/pyrevitlib/pyrevit/coreutils/pyutils.py
+++ b/pyrevitlib/pyrevit/coreutils/pyutils.py
@@ -1,6 +1,6 @@
 """Helper functions for python.
 
-Example:
+Examples:
     >>> from pyrevit.coreutils import pyutils
     >>> pyutils.safe_cast('string', int, 0)
 """
@@ -21,7 +21,7 @@ class DefaultOrderedDict(OrderedDict):
     This is similar to defaultdict and maintains the order of items added
     to it so in that regards it functions similar to OrderedDict.
 
-    Example:
+    Examples:
         >>> from pyrevit.coreutils import pyutils
         >>> od = pyutils.DefaultOrderedDict(list)
         >>> od['A'] = [1, 2, 3]
@@ -86,9 +86,9 @@ def pairwise(iterable, step=2):
         step (int): number of steps to move when making pairs
 
     Returns:
-        iterable: list of pairs
+        (Iterable[Any]): list of pairs
 
-    Example:
+    Examples:
         >>> pairwise([1, 2, 3, 4, 5])
         [(1, 2), (3, 4)]    # 5 can not be paired
         >>> pairwise([1, 2, 3, 4, 5, 6])
@@ -116,7 +116,7 @@ def safe_cast(val, to_type, default=None):
         to_type (type): target type
         default (any): value to rerun on conversion exception
 
-    Example:
+    Examples:
         >>> safe_cast('name', int, default=0)
         0
     """
@@ -133,9 +133,9 @@ def isnumber(token):
         token (str): string value
 
     Returns:
-        bool: True of token is int or float
+        (bool): True of token is int or float
 
-    Example:
+    Examples:
         >>> isnumber('12.3')
         True
     """
@@ -170,9 +170,9 @@ def merge(d1, d2):
         d2 (dict): dict to be merge into d1
 
     Returns:
-        dict: updated d1
+        (dict[Any, Any]): updated d1
 
-    Example:
+    Examples:
         >>> d1 = {1: 1, 2: "B"    , 3: {1:"A", 2:"B"}, 4: "b"  , 5: ["a", "b"]}
         >>> d2 = {1: 1, 2: {1:"A"}, 3: {1:"S", 3:"C"}, 4: ["a"], 5: ["c"]}
         >>> merge(d1, d2)
@@ -217,7 +217,7 @@ def merge(d1, d2):
 
 
 def almost_equal(a, b, rnd=5):
-    """Check if two numerical values almost equal
+    """Check if two numerical values almost equal.
 
     Args:
         a (float): value a
@@ -225,6 +225,6 @@ def almost_equal(a, b, rnd=5):
         rnd (int, optional): n digits after comma. Defaults to 5.
 
     Returns:
-        bool: True if almost equal
+        (bool): True if almost equal
     """
     return a == b or int(a*10**rnd) == int(b*10**rnd)

--- a/pyrevitlib/pyrevit/coreutils/ribbon.py
+++ b/pyrevitlib/pyrevit/coreutils/ribbon.py
@@ -61,7 +61,7 @@ def load_bitmapimage(image_file):
         image_file (str): image file path
 
     Returns:
-        Imaging.BitmapImage: bitmap image object
+        (Imaging.BitmapImage): bitmap image object
     """
     bitmap = Imaging.BitmapImage()
     bitmap.BeginInit()
@@ -135,7 +135,7 @@ class ButtonIcons(object):
             icon_size (int): icon size (width or height)
 
         Returns:
-            Imaging.BitmapSource: object containing image data at given size
+            (Imaging.BitmapSource): object containing image data at given size
         """
         mlogger.debug('Creating %sx%s bitmap from: %s',
                       icon_size, icon_size, self.icon_file_path)
@@ -177,7 +177,7 @@ class ButtonIcons(object):
         """Resamples image and creates bitmap for size :obj:`ICON_SMALL`.
 
         Returns:
-            Imaging.BitmapSource: object containing image data at given size
+            (Imaging.BitmapSource): object containing image data at given size
         """
         return self.create_bitmap(ICON_SMALL)
 
@@ -186,7 +186,7 @@ class ButtonIcons(object):
         """Resamples image and creates bitmap for size :obj:`ICON_MEDIUM`.
 
         Returns:
-            Imaging.BitmapSource: object containing image data at given size
+            (Imaging.BitmapSource): object containing image data at given size
         """
         return self.create_bitmap(ICON_MEDIUM)
 
@@ -195,7 +195,7 @@ class ButtonIcons(object):
         """Resamples image and creates bitmap for size :obj:`ICON_LARGE`.
 
         Returns:
-            Imaging.BitmapSource: object containing image data at given size
+            (Imaging.BitmapSource): object containing image data at given size
         """
         return self.create_bitmap(ICON_LARGE)
 
@@ -333,7 +333,7 @@ class GenericPyRevitUIContainer(object):
             state (bool): flag state to filter children
 
         Returns:
-            list[*]: list of filtered child objects
+            (list[*]): list of filtered child objects
         """
         # FIXME: return type
         flagged_cmps = []
@@ -382,7 +382,6 @@ class GenericPyRevitUIContainer(object):
 
         Args:
             pyrvt_cmp_name (str): target component name
-            val (type): desc
         """
         return pyrvt_cmp_name in self._sub_pyrvt_components.keys()
 
@@ -393,7 +392,7 @@ class GenericPyRevitUIContainer(object):
             child_name (str): target component name
 
         Returns:
-            *: component object if found, otherwise None
+            (Any): component object if found, otherwise None
         """
         for sub_cmp in self._sub_pyrvt_components.values():
             if child_name == sub_cmp.name:
@@ -435,7 +434,7 @@ class GenericPyRevitUIContainer(object):
         return self.get_flagged_children(state=False)
 
     def reorder_before(self, item_name, ritem_name):
-        """Reorder and place item_name before ritem_name
+        """Reorder and place item_name before ritem_name.
 
         Args:
             item_name (str): name of component to be moved
@@ -472,7 +471,7 @@ class GenericPyRevitUIContainer(object):
                 apiobj.Panels.Move(litem_idx, 0)
 
     def reorder_after(self, item_name, ritem_name):
-        """Reorder and place item_name after ritem_name
+        """Reorder and place item_name after ritem_name.
 
         Args:
             item_name (str): name of component to be moved
@@ -569,7 +568,7 @@ class RevitNativeRibbonGroupItem(GenericRevitNativeUIContainer):
             name (str): name of button item to find
 
         Returns:
-            :obj:`RevitNativeRibbonButton`: button object if found
+            (RevitNativeRibbonButton): button object if found
         """
         return super(RevitNativeRibbonGroupItem, self)._get_component(name)
 
@@ -631,7 +630,7 @@ class RevitNativeRibbonPanel(GenericRevitNativeUIContainer):
             item_name (str): name of panel item to find
 
         Returns:
-            object:
+            (object):
                 panel item if found, could be :obj:`RevitNativeRibbonButton`
                 or :obj:`RevitNativeRibbonGroupItem`
         """
@@ -665,7 +664,7 @@ class RevitNativeRibbonTab(GenericRevitNativeUIContainer):
             panel_name (str): name of panel to find
 
         Returns:
-            :obj:`RevitNativeRibbonPanel`: panel if found
+            (RevitNativeRibbonPanel): panel if found
         """
         return super(RevitNativeRibbonTab, self)._get_component(panel_name)
 
@@ -1691,13 +1690,13 @@ def get_current_ui(all_native=False):
 
     Returned class provides min required functionality for user interaction
 
-    Example:
+    Examples:
         >>> current_ui = pyrevit.session.current_ui()
         >>> this_script = pyrevit.session.get_this_command()
         >>> current_ui.update_button_icon(this_script, new_icon)
 
     Returns:
-        :obj:`_PyRevitUI`: wrapper around active ribbon gui
+        (_PyRevitUI): wrapper around active ribbon gui
     """
     return _PyRevitUI(all_native=all_native)
 
@@ -1709,7 +1708,7 @@ def get_uibutton(command_unique_name):
         command_unique_name (str): unique id of pyRevit command
 
     Returns:
-        :obj:`_PyRevitRibbonButton`: ui button wrapper object
+        (_PyRevitRibbonButton): ui button wrapper object
     """
     # FIXME: verify return type
     pyrvt_tabs = get_current_ui().get_pyrevit_tabs()

--- a/pyrevitlib/pyrevit/coreutils/yaml.py
+++ b/pyrevitlib/pyrevit/coreutils/yaml.py
@@ -30,7 +30,7 @@ def load(yaml_file):
         yaml_file (str): file path to yaml file
 
     Returns:
-        obj`YamlDotNet.RepresentationModel.YamlMappingNode`: yaml node
+        (YamlDotNet.RepresentationModel.YamlMappingNode): yaml node
     """
     if PY3:
         with open(yaml_file, 'r', encoding="utf8") as yamlfile:
@@ -55,7 +55,7 @@ def load_as_dict(yaml_file):
         yaml_file (str): file path to yaml file
 
     Returns:
-        obj`dict`: dictionary representing yaml data
+        (dict[str, Any]): dictionary representing yaml data
     """
     return _convert_yamldotnet_to_dict(load(yaml_file))
 

--- a/pyrevitlib/pyrevit/engine.py
+++ b/pyrevitlib/pyrevit/engine.py
@@ -1,4 +1,4 @@
-"""Access loading engine properties"""
+"""Access loading engine properties."""
 #pylint: disable=W0703,C0302,C0103,W0614,E0401,W0611,C0413,ungrouped-imports
 import os.path as op
 import clr

--- a/pyrevitlib/pyrevit/extensions/__init__.py
+++ b/pyrevitlib/pyrevit/extensions/__init__.py
@@ -8,16 +8,19 @@ UI_EXTENSION_POSTFIX = '.extension'
 
 
 class UIExtensionType:
+    """UI extension type."""
     ID = 'extension'
     POSTFIX = '.extension'
 
 
 class LIBExtensionType:
+    """Library extension type."""
     ID = 'lib'
     POSTFIX = '.lib'
 
 
 class ExtensionTypes:
+    """Extension types."""
     UI_EXTENSION = UIExtensionType
     LIB_EXTENSION = LIBExtensionType
 

--- a/pyrevitlib/pyrevit/extensions/components.py
+++ b/pyrevitlib/pyrevit/extensions/components.py
@@ -30,10 +30,12 @@ EXT_HASH_VERSION_KEY = 'pyrvt_version'
 # Commands, or Command groups
 # ------------------------------------------------------------------------------
 class NoButton(GenericUICommand):
+    """This is not a button."""
     type_id = exts.NOGUI_COMMAND_POSTFIX
 
 
 class NoScriptButton(GenericUICommand):
+    """Base for buttons that doesn't run a script."""
     def __init__(self, cmp_path=None, needs_commandclass=False):
         # using classname otherwise exceptions in superclasses won't show
         GenericUICommand.__init__(self, cmp_path=cmp_path, needs_script=False)
@@ -88,6 +90,7 @@ class NoScriptButton(GenericUICommand):
 
 
 class LinkButton(NoScriptButton):
+    """Link button."""
     type_id = exts.LINK_BUTTON_POSTFIX
 
     def __init__(self, cmp_path=None):
@@ -108,6 +111,7 @@ class LinkButton(NoScriptButton):
 
 
 class InvokeButton(NoScriptButton):
+    """Invoke button."""
     type_id = exts.INVOKE_BUTTON_POSTFIX
 
     def __init__(self, cmp_path=None):
@@ -116,18 +120,22 @@ class InvokeButton(NoScriptButton):
 
 
 class PushButton(GenericUICommand):
+    """Push button."""
     type_id = exts.PUSH_BUTTON_POSTFIX
 
 
 class PanelPushButton(GenericUICommand):
+    """Panel push button."""
     type_id = exts.PANEL_PUSH_BUTTON_POSTFIX
 
 
 class SmartButton(GenericUICommand):
+    """Smart button."""
     type_id = exts.SMART_BUTTON_POSTFIX
 
 
 class ContentButton(GenericUICommand):
+    """Content Button."""
     type_id = exts.CONTENT_BUTTON_POSTFIX
 
     def __init__(self, cmp_path=None):
@@ -171,6 +179,7 @@ class ContentButton(GenericUICommand):
 
 
 class URLButton(GenericUICommand):
+    """URL button."""
     type_id = exts.URL_BUTTON_POSTFIX
 
     def __init__(self, cmp_path=None):
@@ -197,9 +206,12 @@ class URLButton(GenericUICommand):
         return self.target_url or ""
 
 
-# Command groups only include commands. these classes can include
-# GenericUICommand as sub components
 class GenericUICommandGroup(GenericUIContainer):
+    """Generic UI command group.
+
+    Command groups only include commands.
+    These classes can include GenericUICommand as sub components.
+    """
     allowed_sub_cmps = [GenericUICommand, NoScriptButton]
 
     @property
@@ -221,19 +233,25 @@ class GenericUICommandGroup(GenericUIContainer):
 
 
 class PullDownButtonGroup(GenericUICommandGroup):
+    """Pulldown button group."""
     type_id = exts.PULLDOWN_BUTTON_POSTFIX
 
 
 class SplitPushButtonGroup(GenericUICommandGroup):
+    """Split push button group."""
     type_id = exts.SPLITPUSH_BUTTON_POSTFIX
 
 
 class SplitButtonGroup(GenericUICommandGroup):
+    """Split button group."""
     type_id = exts.SPLIT_BUTTON_POSTFIX
 
 
-# Stacks include GenericUICommand, or GenericUICommandGroup
 class GenericStack(GenericUIContainer):
+    """Generic UI stack.
+
+    Stacks include GenericUICommand, or GenericUICommandGroup.
+    """
     type_id = exts.STACK_BUTTON_POSTFIX
 
     allowed_sub_cmps = \
@@ -255,12 +273,15 @@ class GenericStack(GenericUIContainer):
 
 
 class StackButtonGroup(GenericStack):
+    """Stack buttons group."""
     type_id = exts.STACK_BUTTON_POSTFIX
 
 
-
-# Panels include GenericStack, GenericUICommand, or GenericUICommandGroup
 class Panel(GenericUIContainer):
+    """Panel container.
+
+    Panels include GenericStack, GenericUICommand, or GenericUICommandGroup
+    """
     type_id = exts.PANEL_POSTFIX
     allowed_sub_cmps = \
         [GenericStack, GenericUICommandGroup, GenericUICommand, NoScriptButton]
@@ -315,8 +336,8 @@ class Panel(GenericUIContainer):
                     return True
 
 
-# Tabs include Panels
 class Tab(GenericUIContainer):
+    """Tab container for Panels."""
     type_id = exts.TAB_POSTFIX
     allowed_sub_cmps = [Panel]
 
@@ -327,9 +348,8 @@ class Tab(GenericUIContainer):
         return False
 
 
-# UI Tools extension class
-# ------------------------------------------------------------------------------
 class Extension(GenericUIContainer):
+    """UI Tools extension."""
     type_id = exts.ExtensionTypes.UI_EXTENSION.POSTFIX
     allowed_sub_cmps = [Tab]
 
@@ -459,9 +479,8 @@ class Extension(GenericUIContainer):
         return [op.join(self.checks_path, x) for x in check_scripts]
 
 
-# library extension class
-# ------------------------------------------------------------------------------
 class LibraryExtension(GenericComponent):
+    """Library extension."""
     type_id = exts.ExtensionTypes.LIB_EXTENSION.POSTFIX
 
     def __init__(self, cmp_path=None):

--- a/pyrevitlib/pyrevit/extensions/extensionmgr.py
+++ b/pyrevitlib/pyrevit/extensions/extensionmgr.py
@@ -1,7 +1,7 @@
-"""
-The extension module is in charge of finding, parsing, and caching extensions.
+"""Find, parse and cache extensions.
+
 There are two types of extensions: UI Extensions (components.Extension) and
-Library Extensions (components.LibraryExtension)
+Library Extensions (components.LibraryExtension).
 
 This module, finds the ui extensions installed and parses their directory for
 tools or loads them from cache. It also finds the library extensions and adds
@@ -109,14 +109,13 @@ def _parse_or_cache(ext_info):
 
 
 def get_command_from_path(comp_path):
-    """
-    Returns a pyRevit command object from the given bundle directory.
+    """Returns a pyRevit command object from the given bundle directory.
 
     Args:
         comp_path (str): Full directory address of the command bundle
 
     Returns:
-        genericcomps.GenericUICommand: A subclass of pyRevit command object.
+        (genericcomps.GenericUICommand): A subclass of pyRevit command object.
     """
     cmds = parse_comp_dir(comp_path, GenericUICommand)
     if cmds:
@@ -126,12 +125,10 @@ def get_command_from_path(comp_path):
 
 
 def get_thirdparty_extension_data():
-    """
-    Returns a list of all UI and Library extensions (not parsed) that
-    are installed and active.
+    """Returns all installed and active UI and Library extensions (not parsed).
 
     Returns:
-        list: list of components.Extension or components.LibraryExtension
+        (list): list of components.Extension or components.LibraryExtension
     """
     # FIXME: reorganzie this code to use one single method to collect
     # extension data for both lib and ui
@@ -149,15 +146,13 @@ def get_thirdparty_extension_data():
 
 
 def get_installed_lib_extensions(root_dir):
-    """
-    Returns a list of all Library extensions (not parsed)
-    under the given directory that are installed and active.
+    """Returns all the installed and active Library extensions (not parsed).
 
     Args:
         root_dir (str): Extensions directory address
 
     Returns:
-        list: list of components.LibraryExtension objects
+        (list[LibraryExtension]): list of components.LibraryExtension objects
     """
     lib_ext_list = \
         [lib_ext for lib_ext in parse_dir_for_ext_type(root_dir,
@@ -166,13 +161,13 @@ def get_installed_lib_extensions(root_dir):
 
 
 def get_installed_ui_extensions():
-    """
-    Returns a list of all UI extensions (fully parsed) under the given
-    directory. This will also process the Library extensions and will add
+    """Returns all UI extensions (fully parsed) under the given directory.
+
+    This will also process the Library extensions and will add
     their path to the syspath of the UI extensions.
 
     Returns:
-        list: list of components.Extension objects
+        (list[Extension]): list of components.Extension objects
     """
     ui_ext_list = []
     lib_ext_list = []

--- a/pyrevitlib/pyrevit/extensions/genericcomps.py
+++ b/pyrevitlib/pyrevit/extensions/genericcomps.py
@@ -27,10 +27,12 @@ NAME_KEY = 'name'
 
 
 class TypedComponent(object):
+    """Component with a type id."""
     type_id = None
 
 
 class CachableComponent(TypedComponent):
+    """Cacheable Component."""
     def get_cache_data(self):
         cache_dict = self.__dict__.copy()
         if hasattr(self, TYPE_ID_KEY):
@@ -43,18 +45,21 @@ class CachableComponent(TypedComponent):
 
 
 class LayoutDirective(CachableComponent):
+    """Layout directive."""
     def __init__(self, directive_type=None, target=None):
         self.directive_type = directive_type
         self.target = target
 
 
 class LayoutItem(CachableComponent):
+    """Layout item."""
     def __init__(self, name=None, directive=None):
         self.name = name
         self.directive = directive
 
 
 class GenericComponent(CachableComponent):
+    """Generic component object."""
     def __init__(self):
         self.name = None
 
@@ -67,6 +72,7 @@ class GenericComponent(CachableComponent):
 
 
 class GenericUIComponent(GenericComponent):
+    """Generic UI component."""
     def __init__(self, cmp_path=None):
         # using classname otherwise exceptions in superclasses won't show
         GenericComponent.__init__(self)
@@ -100,13 +106,16 @@ class GenericUIComponent(GenericComponent):
 
     @classmethod
     def make_unique_name(cls, cmp_path):
-        """Creates a unique name for the command. This is used to uniquely
-        identify this command and also to create the class in
-        pyRevit dll assembly. Current method create a unique name based on
-        the command full directory address.
-        Example:
+        """Creates a unique name for the command.
+
+        This is used to uniquely identify this command
+        and also to create the class in pyRevit dll assembly.
+        Current method create a unique name based on the command
+        full directory address.
+
+        Examples:
             for 'pyRevit.extension/pyRevit.tab/Edit.panel/Flip doors.pushbutton'
-            unique name would be: 'pyrevit-pyrevit-edit-flipdoors'
+            unique name would be: 'pyrevit-pyrevit-edit-flipdoors'.
         """
         pieces = []
         inside_ext = False
@@ -329,8 +338,8 @@ class GenericUIComponent(GenericComponent):
                 self._resolve_liquid_tag(param_name, key, value)
 
 
-# superclass for all UI group items (tab, panel, button groups, stacks)
 class GenericUIContainer(GenericUIComponent):
+    """Superclass for all UI group items (tab, panel, button groups, stacks)."""
     allowed_sub_cmps = []
 
     def __init__(self, cmp_path=None):
@@ -497,6 +506,7 @@ class GenericUIContainer(GenericUIComponent):
 # can not contain other elements
 class GenericUICommand(GenericUIComponent):
     """Superclass for all single commands.
+
     The information provided by these classes will be used to create a
     push button under Revit UI. However, pyRevit expands the capabilities of
     push button beyond what is provided by Revit UI. (e.g. Toggle button

--- a/pyrevitlib/pyrevit/extensions/parser.py
+++ b/pyrevitlib/pyrevit/extensions/parser.py
@@ -30,17 +30,15 @@ def _get_discovered_comps(comp_path, cmp_types_list):
 def _create_subcomponents(search_dir,
                           cmp_types_list,
                           create_from_search_dir=False):
-    """
-    Parses the provided directory and returns a list of objects of the
-    types in cmp_types_list.
+    """Returns the objects in search_dir of the types in cmp_types_list.
 
     Arguments:
-        search_dir: directory to parse
+        search_dir (str): directory to parse
         cmp_types_list: This methods checks the subfolders in search_dir
-                              against the _get_component types provided
-        in this list.
+            against the _get_component types provided in this list.
+        create_from_search_dir: whether to create the _get_component objects
 
-    Example:
+    Examples:
         _create_subcomponents(search_dir,
                               [LinkButton, PushButton, or ToggleButton])
         this method creates LinkButton, PushButton, or ToggleButton for
@@ -76,13 +74,14 @@ def _get_subcomponents_classes(parent_classes):
 
 
 def _parse_for_components(component):
-    """Recursively parses _get_component.directory for components of type
-    _get_component.allowed_sub_cmps. This method uses get_all_subclasses() to
-    get a list of all subclasses of _get_component.allowed_sub_cmps type.
+    """Recursively parses the component directory for allowed components type.
+
+    This method uses get_all_subclasses() to get a list of all subclasses
+    of _get_component.allowed_sub_cmps type.
     This ensures that if any new type of component_class is added later,
     this method does not need to be updated as the new sub-class will be
     listed by .__subclasses__() method of the parent class and this method
-    will check the directory for its .type_id
+    will check the directory for its .type_id.
     """
     for new_cmp in _create_subcomponents(
             component.directory,
@@ -105,9 +104,9 @@ def parse_comp_dir(comp_path, comp_class):
 
 
 def get_parsed_extension(extension):
-    """
-    Parses package directory and creates and adds components to the package
-    object. Each package object is the root to a tree of components that exists
+    """Creates and adds the extensions components to the package.
+
+    Each package object is the root to a tree of components that exists
     under that package. (e.g. tabs, buttons, ...) sub components of package
     can be accessed by iterating the _get_component.
     See _basecomponents for types.
@@ -117,11 +116,15 @@ def get_parsed_extension(extension):
 
 
 def parse_dir_for_ext_type(root_dir, parent_cmp_type):
-    """
-    Parses root_dir and return a list of objects of type parent_cmp_type
-    for installed extensions. The package objects won't be parsed at this level.
+    """Return the objects of type parent_cmp_type of the extensions in root_dir.
+
+    The package objects won't be parsed at this level.
     This is useful for collecting basic info on an extension type
     for cache cheching or updating extensions using their directory paths.
+
+    Args:
+        root_dir (str): directory to parse
+        parent_cmp_type (type): type of objects to return
     """
     # making sure the provided directory exists.
     # This is mainly for the user defined package directories

--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -1,6 +1,6 @@
 """Reusable WPF forms for pyRevit.
 
-Example:
+Examples:
     >>> from pyrevit.forms import WPFWindow
 """
 #pylint: disable=consider-using-f-string,wrong-import-position
@@ -80,7 +80,7 @@ Attributes:
 
 # https://gui-at.blogspot.com/2009/11/inotifypropertychanged-in-ironpython.html
 class reactive(property):
-    """Decorator for WPF bound properties"""
+    """Decorator for WPF bound properties."""
     def __init__(self, getter):
         def newgetter(ui_control):
             try:
@@ -103,7 +103,7 @@ class reactive(property):
 
 
 class Reactive(ComponentModel.INotifyPropertyChanged):
-    """WPF property updator base mixin"""
+    """WPF property updator base mixin."""
     PropertyChanged, _propertyChangedCaller = pyevent.make_event()
 
     def add_PropertyChanged(self, value):
@@ -119,6 +119,7 @@ class Reactive(ComponentModel.INotifyPropertyChanged):
 
 
 class WindowToggler(object):
+    """Context manager to toggle window visibility."""
     def __init__(self, window):
         self._window = window
 
@@ -138,7 +139,7 @@ class WPFWindow(framework.Windows.Window):
         handle_esc (bool): handle Escape button and close the window
         set_owner (bool): set the owner of window to host app window
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> layout = '<Window ' \
         >>>          'xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" ' \
@@ -153,7 +154,6 @@ class WPFWindow(framework.Windows.Window):
 
     def __init__(self, xaml_source, literal_string=False, handle_esc=True, set_owner=True):
         """Initialize WPF window and resources."""
-
         # load xaml
         self.load_xaml(
             xaml_source,
@@ -216,8 +216,10 @@ class WPFWindow(framework.Windows.Window):
         return xaml_file
 
     def merge_resource_dict(self, xaml_source):
-        """Reads ResourceDictionary from given xaml file and merged into
-        resource dictionary of this window
+        """Merge a ResourceDictionary xaml file with this window.
+
+        Args:
+            xaml_source (str): xaml file with the resource dictionary
         """
         lang_dictionary = ResourceDictionary()
         lang_dictionary.Source = Uri(xaml_source, UriKind.Absolute)
@@ -297,7 +299,7 @@ class WPFWindow(framework.Windows.Window):
         """Set source file for image element.
 
         Args:
-            element_name (System.Windows.Controls.Image): xaml image element
+            wpf_element (System.Windows.Controls.Image): xaml image element
             image_file (str): image file path
         """
         if not op.exists(image_file):
@@ -313,7 +315,7 @@ class WPFWindow(framework.Windows.Window):
         """Set source file for image element.
 
         Args:
-            element_name (System.Windows.Controls.Image): xaml image element
+            wpf_element (System.Windows.Controls.Image): xaml image element
             image_file (str): image file path
         """
         WPFWindow.set_image_source_file(wpf_element, image_file)
@@ -340,7 +342,7 @@ class WPFWindow(framework.Windows.Window):
 
     @property
     def pyrevit_version(self):
-        """Active pyRevit formatted version e.g. '4.9-beta'"""
+        """Active pyRevit formatted version e.g. '4.9-beta'."""
         return 'pyRevit {}'.format(
             versionmgr.get_pyrevit_version().get_formatted()
             )
@@ -350,7 +352,7 @@ class WPFWindow(framework.Windows.Window):
         """Collapse elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be collaped
+            *wpf_elements (list[UIElement]): WPF framework elements to be collaped
         """
         for wpfel in wpf_elements:
             wpfel.Visibility = WPF_COLLAPSED
@@ -360,7 +362,7 @@ class WPFWindow(framework.Windows.Window):
         """Show collapsed elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be set to visible.
+            *wpf_elements (list[UIElement]): WPF framework elements to be set to visible.
         """
         for wpfel in wpf_elements:
             wpfel.Visibility = WPF_VISIBLE
@@ -370,7 +372,7 @@ class WPFWindow(framework.Windows.Window):
         """Toggle visibility of elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be toggled.
+            *wpf_elements (list[UIElement]): WPF framework elements to be toggled.
         """
         for wpfel in wpf_elements:
             if wpfel.Visibility == WPF_VISIBLE:
@@ -383,7 +385,7 @@ class WPFWindow(framework.Windows.Window):
         """Enable elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be enabled
+            *wpf_elements (list[UIElement]): WPF framework elements to be enabled
         """
         for wpfel in wpf_elements:
             wpfel.IsEnabled = False
@@ -393,13 +395,13 @@ class WPFWindow(framework.Windows.Window):
         """Enable elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be enabled
+            *wpf_elements (list[UIElement]): WPF framework elements to be enabled
         """
         for wpfel in wpf_elements:
             wpfel.IsEnabled = True
 
     def handle_url_click(self, sender, args): #pylint: disable=unused-argument
-        """Callback for handling click on package website url"""
+        """Callback for handling click on package website url."""
         return webbrowser.open_new_tab(sender.NavigateUri.AbsoluteUri)
 
 
@@ -409,7 +411,7 @@ class WPFPanel(framework.Windows.Controls.Page):
     panel_id (str) must be set on the type to dockable panel uuid
     panel_source (str): xaml source filepath
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> class MyPanel(forms.WPFPanel):
         ...     panel_id = "181e05a4-28f6-4311-8a9f-d2aa528c8755"
@@ -445,7 +447,7 @@ class WPFPanel(framework.Windows.Controls.Page):
         """Set source file for image element.
 
         Args:
-            element_name (System.Windows.Controls.Image): xaml image element
+            wpf_element (System.Windows.Controls.Image): xaml image element
             image_file (str): image file path
         """
         WPFWindow.set_image_source_file(wpf_element, image_file)
@@ -455,7 +457,7 @@ class WPFPanel(framework.Windows.Controls.Page):
         """Collapse elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be collaped
+            *wpf_elements (list[UIElement]): WPF framework elements to be collaped
         """
         WPFPanel.hide_element(*wpf_elements)
 
@@ -464,7 +466,7 @@ class WPFPanel(framework.Windows.Controls.Page):
         """Show collapsed elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be set to visible.
+            *wpf_elements (list[UIElement]): WPF framework elements to be set to visible.
         """
         WPFPanel.show_element(*wpf_elements)
 
@@ -473,7 +475,7 @@ class WPFPanel(framework.Windows.Controls.Page):
         """Toggle visibility of elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be toggled.
+            *wpf_elements (list[UIElement]): WPF framework elements to be toggled.
         """
         WPFPanel.toggle_element(*wpf_elements)
 
@@ -482,7 +484,7 @@ class WPFPanel(framework.Windows.Controls.Page):
         """Enable elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be enabled
+            *wpf_elements (list[UIElement]): WPF framework elements to be enabled
         """
         WPFPanel.disable_element(*wpf_elements)
 
@@ -491,17 +493,17 @@ class WPFPanel(framework.Windows.Controls.Page):
         """Enable elements.
 
         Args:
-            *wpf_elements: WPF framework elements to be enabled
+            *wpf_elements (list): WPF framework elements to be enabled
         """
         WPFPanel.enable_element(*wpf_elements)
 
     def handle_url_click(self, sender, args): #pylint: disable=unused-argument
-        """Callback for handling click on package website url"""
+        """Callback for handling click on package website url."""
         return webbrowser.open_new_tab(sender.NavigateUri.AbsoluteUri)
 
 
 class _WPFPanelProvider(UI.IDockablePaneProvider):
-    """Internal Panel provider for panels"""
+    """Internal Panel provider for panels."""
 
     def __init__(self, panel_type, default_visible=True):
         self._panel_type = panel_type
@@ -509,7 +511,7 @@ class _WPFPanelProvider(UI.IDockablePaneProvider):
         self.panel = self._panel_type()
 
     def SetupDockablePane(self, data):
-        """Setup forms.WPFPanel set on this instance"""
+        """Setup forms.WPFPanel set on this instance."""
         # TODO: need to implement panel data
         # https://apidocs.co/apps/revit/2021.1/98157ec2-ab26-6ab7-2933-d1b4160ba2b8.htm
         data.FrameworkElement = self.panel
@@ -517,7 +519,7 @@ class _WPFPanelProvider(UI.IDockablePaneProvider):
 
 
 def is_registered_dockable_panel(panel_type):
-    """Check if dockable panel is already registered
+    """Check if dockable panel is already registered.
 
     Args:
         panel_type (forms.WPFPanel): dockable panel type
@@ -528,7 +530,7 @@ def is_registered_dockable_panel(panel_type):
 
 
 def register_dockable_panel(panel_type, default_visible=True):
-    """Register dockable panel
+    """Register dockable panel.
 
     Args:
         panel_type (forms.WPFPanel): dockable panel type
@@ -553,7 +555,7 @@ def register_dockable_panel(panel_type, default_visible=True):
 
 
 def open_dockable_panel(panel_type_or_id):
-    """Open previously registered dockable panel
+    """Open previously registered dockable panel.
 
     Args:
         panel_type_or_id (forms.WPFPanel, str): panel type or id
@@ -562,7 +564,7 @@ def open_dockable_panel(panel_type_or_id):
 
 
 def close_dockable_panel(panel_type_or_id):
-    """Close previously registered dockable panel
+    """Close previously registered dockable panel.
 
     Args:
         panel_type_or_id (forms.WPFPanel, str): panel type or id
@@ -571,10 +573,11 @@ def close_dockable_panel(panel_type_or_id):
 
 
 def toggle_dockable_panel(panel_type_or_id, state):
-    """Toggle previously registered dockable panel
+    """Toggle previously registered dockable panel.
 
     Args:
-        panel_type_or_id (forms.WPFPanel, str): panel type or id
+        panel_type_or_id (forms.WPFPanel | str): panel type or id
+        state (bool): True to show the panel, False to hide it.
     """
     dpanel_id = None
     if isinstance(panel_type_or_id, str):
@@ -607,7 +610,7 @@ class TemplateUserInputWindow(WPFWindow):
         title (str): window title
         width (int): window width
         height (int): window height
-        **kwargs: other arguments to be passed to :func:`_setup`
+        **kwargs (Any): other arguments to be passed to :func:`_setup`
     """
 
     xaml_source = 'BaseWindow.xaml'
@@ -667,6 +670,7 @@ class TemplateListItem(Reactive):
         Args:
             orig_item (any): Object to wrap (must have name property
                              or be convertable to string with str()
+            checked (bool): Initial state. Defaults to False
             checkable (bool): Use checkbox for items
             name_attr (str): Get this attribute of wrapped object as name
         """
@@ -705,7 +709,7 @@ class TemplateListItem(Reactive):
 
     @reactive
     def checked(self):
-        """Id checked"""
+        """Id checked."""
         return self.state
 
     @checked.setter
@@ -727,7 +731,7 @@ class SelectFromList(TemplateUserInputWindow):
     """Standard form to select from a list of items.
 
     Any object can be passed in a list to the ``context`` argument. This class
-    wraps the objects passed to context, in :obj:`TemplateListItem`.
+    wraps the objects passed to context, in `TemplateListItem`.
     This class provides the necessary mechanism to make this form work both
     for selecting items from a list, and from a list of checkboxes. See the
     list of arguments below for additional options and features.
@@ -742,6 +746,8 @@ class SelectFromList(TemplateUserInputWindow):
         title (str, optional): window title. see super class for defaults.
         width (int, optional): window width. see super class for defaults.
         height (int, optional): window height. see super class for defaults.
+
+    Keyword Args:
         button_name (str, optional):
             name of select button. defaults to 'Select'
         name_attr (str, optional):
@@ -763,7 +769,7 @@ class SelectFromList(TemplateUserInputWindow):
         default_group (str): name of defautl group to be selected
 
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> items = ['item1', 'item2', 'item3']
         >>> forms.SelectFromList.show(items, button_name='Select Item')
@@ -1067,7 +1073,7 @@ class SelectFromList(TemplateUserInputWindow):
                 getattr(self.list_lb.SelectedItem, 'description', '')
 
     def toggle_regex(self, sender, args):
-        """Activate regex in search"""
+        """Activate regex in search."""
         self.regexToggle_b.Content = \
             self.Resources['regexIcon'] if self.use_regex \
                 else self.Resources['filterIcon']
@@ -1084,7 +1090,7 @@ class SelectFromList(TemplateUserInputWindow):
 class CommandSwitchWindow(TemplateUserInputWindow):
     """Standard form to select from a list of command options.
 
-    Args:
+    Keyword Args:
         context (list[str]): list of command options to choose from
         switches (list[str]): list of on/off switches
         message (str): window title message
@@ -1092,13 +1098,11 @@ class CommandSwitchWindow(TemplateUserInputWindow):
         recognize_access_key (bool): recognize '_' as mark of access key
 
     Returns:
-        str: name of selected option
+        (str | tuple[str, dict]): name of selected option.
+            if ``switches`` option is used, returns a tuple
+            of selection option name and dict of switches
 
-    Returns:
-        tuple(str, dict): if ``switches`` option is used, returns a tuple
-        of selection option name and dict of switches
-
-    Example:
+    Examples:
         This is an example with series of command options:
 
         >>> from pyrevit import forms
@@ -1246,10 +1250,7 @@ class CommandSwitchWindow(TemplateUserInputWindow):
 class GetValueWindow(TemplateUserInputWindow):
     """Standard form to get simple values from user.
 
-    Args:
-
-
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> items = ['item1', 'item2', 'item3']
         >>> forms.SelectFromList.show(items, button_name='Select Item')
@@ -1342,7 +1343,7 @@ class TemplatePromptBar(WPFWindow):
 
     Args:
         height (int): window height
-        **kwargs: other arguments to be passed to :func:`_setup`
+        **kwargs (Any): other arguments to be passed to :func:`_setup`
     """
 
     xaml_source = 'TemplatePromptBar.xaml'
@@ -1416,10 +1417,10 @@ class TemplatePromptBar(WPFWindow):
 class WarningBar(TemplatePromptBar):
     """Show warning bar at the top of Revit window.
 
-    Args:
+    Keyword Args:
         title (string): warning bar text
 
-    Example:
+    Examples:
         >>> with WarningBar(title='my warning'):
         ...    # do stuff
     """
@@ -1433,13 +1434,13 @@ class WarningBar(TemplatePromptBar):
 class ProgressBar(TemplatePromptBar):
     """Show progress bar at the top of Revit window.
 
-    Args:
-        title (string): progress bar text, defaults to 0/100 progress format
+    Keyword Args:
+        title (string): progress bar text, defaults to 0/100 progress format 
         indeterminate (bool): create indeterminate progress bar
         cancellable (bool): add cancel button to progress bar
         step (int): update progress intervals
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> count = 1
         >>> with forms.ProgressBar(title='my command progress message') as pb:
@@ -1598,16 +1599,18 @@ class SearchPrompt(WPFWindow):
 
     Args:
         search_db (list): list of possible search targets
-        search_tip (str): text to show in grayscale when search box is empty
-        switches (str): list of switches
         width (int): width of search prompt window
         height (int): height of search prompt window
 
-    Returns:
-        str, dict: matched strings, and dict of switches if provided
-        str: matched string if switches are not provided.
+    Keyword Args:
+        search_tip (str): text to show in grayscale when search box is empty
+        switches (str): list of switches
 
-    Example:
+    Returns:
+        (tuple[str, dict] | str): matched string if switches are not provided,
+            matched strings, and dict of switches otherwise.
+
+    Examples:
         >>> from pyrevit import forms
         >>> # assume search input of '/switch1 target1'
         >>> matched_str, args, switches = forms.SearchPrompt.show(
@@ -1954,7 +1957,7 @@ def select_revisions(title='Select Revision',
         title (str, optional): list window title
         button_name (str, optional): list window button caption
         width (int, optional): width of list window
-        multiselect (bool, optional):
+        multiple (bool, optional):
             allow multi-selection (uses check boxes). defaults to True
         filterfunc (function):
             filter function to be applied to context items.
@@ -1962,9 +1965,9 @@ def select_revisions(title='Select Revision',
             source document for revisions; defaults to active document
 
     Returns:
-        list[DB.Revision]: list of selected revisions
+        (list[DB.Revision]): list of selected revisions
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_revisions()
         ... [<Autodesk.Revit.DB.Revision object>,
@@ -2013,12 +2016,15 @@ def select_sheets(title='Select Sheets',
             filter function to be applied to context items.
         doc (DB.Document, optional):
             source document for sheets; defaults to active document
+        include_placeholder (bool, optional): include a placeholder.
+            Defaults to True
         use_selection (bool, optional):
             ask if user wants to use currently selected sheets.
-    Returns:
-        list[DB.ViewSheet]: list of selected sheets
 
-    Example:
+    Returns:
+        (list[DB.ViewSheet]): list of selected sheets
+
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_sheets()
         ... [<Autodesk.Revit.DB.ViewSheet object>,
@@ -2109,10 +2115,11 @@ def select_views(title='Select Views',
             source document for views; defaults to active document
         use_selection (bool, optional):
             ask if user wants to use currently selected views.
-    Returns:
-        list[DB.View]: list of selected views
 
-    Example:
+    Returns:
+        (list[DB.View]): list of selected views
+
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_views()
         ... [<Autodesk.Revit.DB.View object>,
@@ -2176,10 +2183,11 @@ def select_levels(title='Select Levels',
             source document for levels; defaults to active document
         use_selection (bool, optional):
             ask if user wants to use currently selected levels.
-    Returns:
-        list[DB.Level]: list of selected levels
 
-    Example:
+    Returns:
+        (list[DB.Level]): list of selected levels
+
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_levels()
         ... [<Autodesk.Revit.DB.Level object>,
@@ -2237,7 +2245,7 @@ def select_viewtemplates(title='Select View Templates',
         title (str, optional): list window title
         button_name (str, optional): list window button caption
         width (int, optional): width of list window
-        multiselect (bool, optional):
+        multiple (bool, optional):
             allow multi-selection (uses check boxes). defaults to True
         filterfunc (function):
             filter function to be applied to context items.
@@ -2245,9 +2253,9 @@ def select_viewtemplates(title='Select View Templates',
             source document for views; defaults to active document
 
     Returns:
-        list[DB.View]: list of selected view templates
+        (list[DB.View]): list of selected view templates
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_viewtemplates()
         ... [<Autodesk.Revit.DB.View object>,
@@ -2284,7 +2292,7 @@ def select_schedules(title='Select Schedules',
         title (str, optional): list window title
         button_name (str, optional): list window button caption
         width (int, optional): width of list window
-        multiselect (bool, optional):
+        multiple (bool, optional):
             allow multi-selection (uses check boxes). defaults to True
         filterfunc (function):
             filter function to be applied to context items.
@@ -2292,9 +2300,9 @@ def select_schedules(title='Select Schedules',
             source document for views; defaults to active document
 
     Returns:
-        list[DB.ViewSchedule]: list of selected schedules
+        (list[DB.ViewSchedule]): list of selected schedules
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_schedules()
         ... [<Autodesk.Revit.DB.ViewSchedule object>,
@@ -2332,15 +2340,16 @@ def select_open_docs(title='Select Open Documents',
         title (str, optional): list window title
         button_name (str, optional): list window button caption
         width (int, optional): width of list window
-        multiselect (bool, optional):
+        multiple (bool, optional):
             allow multi-selection (uses check boxes). defaults to True
+        check_more_than_one (bool, optional): 
         filterfunc (function):
             filter function to be applied to context items.
 
     Returns:
-        list[DB.Document]: list of selected documents
+        (list[DB.Document]): list of selected documents
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_open_docs()
         ... [<Autodesk.Revit.DB.Document object>,
@@ -2381,17 +2390,17 @@ def select_titleblocks(title='Select Titleblock',
         button_name (str, optional): list window button caption
         no_tb_option (str, optional): name of option for no title block
         width (int, optional): width of list window
-        multiselect (bool, optional):
-            allow multi-selection (uses check boxes). defaults to True
+        multiple (bool, optional):
+            allow multi-selection (uses check boxes). defaults to False
         filterfunc (function):
             filter function to be applied to context items.
         doc (DB.Document, optional):
             source document for titleblocks; defaults to active document
 
     Returns:
-        DB.ElementId: selected titleblock id.
+        (DB.ElementId): selected titleblock id.
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_titleblocks()
         ... <Autodesk.Revit.DB.ElementId object>
@@ -2427,9 +2436,9 @@ def select_swatch(title='Select Color Swatch', button_name='Select'):
         button_name (str, optional): swatch list window button caption
 
     Returns:
-        pyrevit.coreutils.colors.RGB: rgb color
+        (pyrevit.coreutils.colors.RGB): rgb color
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_swatch(title="Select Text Color")
         ... <RGB #CD8800>
@@ -2459,9 +2468,9 @@ def select_image(images, title='Select Image', button_name='Select'):
         button_name (str, optional): swatch list window button caption
 
     Returns:
-        str : path of the selected image
+        (str): path of the selected image
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.select_image(['C:/path/to/image1.png',
                                 'C:/path/to/image2.png'],
@@ -2512,7 +2521,7 @@ def select_parameters(src_element,
         src_element (DB.Element): source element
         title (str, optional): list window title
         button_name (str, optional): list window button caption
-        multiselect (bool, optional):
+        multiple (bool, optional):
             allow multi-selection (uses check boxes). defaults to True
         filterfunc (function):
             filter function to be applied to context items.
@@ -2521,9 +2530,9 @@ def select_parameters(src_element,
         exclude_readonly (bool, optional): only shows parameters that are editable
 
     Returns:
-        list[:obj:`ParamDef`]: list of paramdef objects
+        (list[ParamDef]): list of paramdef objects
 
-    Example:
+    Examples:
         >>> forms.select_parameter(
         ...     src_element,
         ...     title='Select Parameters',
@@ -2596,7 +2605,7 @@ def select_family_parameters(family_doc,
         family_doc (DB.Document): source family document
         title (str, optional): list window title
         button_name (str, optional): list window button caption
-        multiselect (bool, optional):
+        multiple (bool, optional):
             allow multi-selection (uses check boxes). defaults to True
         filterfunc (function):
             filter function to be applied to context items.
@@ -2606,9 +2615,9 @@ def select_family_parameters(family_doc,
         include_labeled (bool, optional): list parameters used as labels
 
     Returns:
-        list[:obj:`DB.FamilyParameter`]: list of family parameter objects
+        (list[DB.FamilyParameter]): list of family parameter objects
 
-    Example:
+    Examples:
         >>> forms.select_family_parameters(
         ...     family_doc,
         ...     title='Select Parameters',
@@ -2677,18 +2686,20 @@ def alert(msg, title=None, sub_msg=None, expanded=None, footer='',
         title (str, optional): task dialog title
         sub_msg (str, optional): sub message
         expanded (str, optional): expanded area message
+        footer (str, optional): footer text
         ok (bool, optional): show OK button, defaults to True
         cancel (bool, optional): show Cancel button, defaults to False
         yes (bool, optional): show Yes button, defaults to False
         no (bool, optional): show NO button, defaults to False
         retry (bool, optional): show Retry button, defaults to False
-        options(list[str], optional): list of command link titles in order
+        warn_icon (bool, optional): show warning icon
+        options (list[str], optional): list of command link titles in order
         exitscript (bool, optional): exit if cancel or no, defaults to False
 
     Returns:
-        bool: True if okay, yes, or retry, otherwise False
+        (bool): True if okay, yes, or retry, otherwise False
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.alert('Are you sure?',
         ...              ok=False, yes=True, no=True, exitscript=True)
@@ -2785,6 +2796,10 @@ def alert_ifnot(condition, msg, *args, **kwargs):
     Args:
         condition (bool): condition to test
         msg (str): message to be displayed
+        *args (Any): additional arguments
+        **kwargs (Any): additional keyword arguments
+
+    Keyword Args:
         title (str, optional): task dialog title
         ok (bool, optional): show OK button, defaults to True
         cancel (bool, optional): show Cancel button, defaults to False
@@ -2794,9 +2809,9 @@ def alert_ifnot(condition, msg, *args, **kwargs):
         exitscript (bool, optional): exit if cancel or no, defaults to False
 
     Returns:
-        bool: True if okay, yes, or retry, otherwise False
+        (bool): True if okay, yes, or retry, otherwise False
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.alert_ifnot(value > 12,
         ...                   'Are you sure?',
@@ -2811,9 +2826,10 @@ def pick_folder(title=None, owner=None):
 
     Args:
         title (str, optional): title for the window
+        owner (object, optional): owner of the dialog
 
     Returns:
-        str: folder path
+        (str): folder path
     """
     if CPDialogs:
         fb_dlg = CPDialogs.CommonOpenFileDialog()
@@ -2844,21 +2860,19 @@ def result_item_result_clicked(sender, e, debug=False):
 
 
 def show_balloon(header, text, tooltip='', group='', is_favourite=False, is_new=False, timestamp=None, click_result=result_item_result_clicked):
-    r"""Show ballon in the info center section
+    r"""Show ballon in the info center section.
 
     Args:
         header (str): Category section (Bold)
         text (str): Title section (Regular)
         tooltip (str): Tooltip
+        group (str): Group
         is_favourite (bool): Add a blue star before header
         is_new (bool): Flag to new
         timestamp (str): Set timestamp
         click_result (def): Executed after a click event
 
-    Returns:
-        balloon: None
-
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> date = '2019-01-01 00:00:00'
         >>> date = datetime.datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
@@ -2894,9 +2908,9 @@ def pick_file(file_ext='*', files_filter='', init_dir='',
         title (str): text to show in the title bar
 
     Returns:
-        str or list[str]: file path or list of file paths if multi_file=True
+        (str | list[str]): file path or list of file paths if multi_file=True
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.pick_file(file_ext='csv')
         ... r'C:\output\somefile.csv'
@@ -2947,9 +2961,9 @@ def save_file(file_ext='', files_filter='', init_dir='', default_name='',
         title (str): text to show in the title bar
 
     Returns:
-        str: file path
+        (str): file path
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.save_file(file_ext='csv')
         ... r'C:\output\somefile.csv'
@@ -2982,7 +2996,7 @@ def pick_excel_file(save=False, title=None):
         title (str): text to show in the title bar
 
     Returns:
-        str: file path
+        (str): file path
     """
     if save:
         return save_file(file_ext='xlsx')
@@ -2998,7 +3012,7 @@ def save_excel_file(title=None):
         title (str): text to show in the title bar
 
     Returns:
-        str: file path
+        (str): file path
     """
     return pick_excel_file(save=True, title=title)
 
@@ -3011,7 +3025,7 @@ def check_workshared(doc=None, message='Model is not workshared.'):
         message (str): prompt message if returning False
 
     Returns:
-        bool: True if doc is workshared
+        (bool): True if doc is workshared
     """
     doc = doc or DOCS.doc
     if not doc.IsWorkshared:
@@ -3029,7 +3043,7 @@ def check_selection(exitscript=False,
         message (str): prompt message if returning False
 
     Returns:
-        bool: True if selection has at least one item
+        (bool): True if selection has at least one item
     """
     if revit.get_selection().is_empty:
         alert(message, exitscript=exitscript)
@@ -3046,9 +3060,9 @@ def check_familydoc(doc=None, family_cat=None, exitscript=False):
         exitscript (bool): exit script if returning False
 
     Returns:
-        bool: True if doc is a Family and of provided category
+        (bool): True if doc is a Family and of provided category
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.check_familydoc(doc=revit.doc, family_cat='Data Devices')
         ... True
@@ -3076,9 +3090,9 @@ def check_modeldoc(doc=None, exitscript=False):
         exitscript (bool): exit script if returning False
 
     Returns:
-        bool: True if doc is a Model
+        (bool): True if doc is a Model
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.check_modeldoc(doc=revit.doc)
         ... True
@@ -3100,9 +3114,9 @@ def check_modelview(view, exitscript=False):
         exitscript (bool): exit script if returning False
 
     Returns:
-        bool: True if view is model view
+        (bool): True if view is model view
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.check_modelview(view=revit.active_view)
         ... True
@@ -3114,7 +3128,7 @@ def check_modelview(view, exitscript=False):
 
 
 def check_viewtype(view, view_type, exitscript=False):
-    """Verify target view is of given type
+    """Verify target view is of given type.
 
     Args:
         view (DB.View): target view
@@ -3122,9 +3136,9 @@ def check_viewtype(view, view_type, exitscript=False):
         exitscript (bool): exit script if returning False
 
     Returns:
-        bool: True if view is of given type
+        (bool): True if view is of given type
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.check_viewtype(revit.active_view, DB.ViewType.DrawingSheet)
         ... True
@@ -3140,16 +3154,16 @@ def check_viewtype(view, view_type, exitscript=False):
 
 
 def check_graphicalview(view, exitscript=False):
-    """Verify target view is a graphical view
+    """Verify target view is a graphical view.
 
     Args:
         view (DB.View): target view
         exitscript (bool): exit script if returning False
 
     Returns:
-        bool: True if view is a graphical view
+        (bool): True if view is a graphical view
 
-    Example:
+    Examples:
         >>> from pyrevit import forms
         >>> forms.check_graphicalview(revit.active_view)
         ... True
@@ -3175,7 +3189,7 @@ def toast(message, title='pyRevit', appid='pyRevit',
         click (str): click action commands string
         actions (dict): dictionary of button names and action strings
 
-    Example:
+    Examples:
         >>> script.toast("Hello World!",
         ...              title="My Script",
         ...              appid="MyAPP",
@@ -3207,9 +3221,9 @@ def ask_for_string(default=None, prompt=None, title=None, **kwargs):
         kwargs (type): other arguments to be passed to :obj:`GetValueWindow`
 
     Returns:
-        str: selected string value
+        (str): selected string value
 
-    Example:
+    Examples:
         >>> forms.ask_for_string(
         ...     default='some-tag',
         ...     prompt='Enter new tag name:',
@@ -3241,9 +3255,9 @@ def ask_for_unique_string(reserved_values,
         kwargs (type): other arguments to be passed to :obj:`GetValueWindow`
 
     Returns:
-        str: selected unique string
+        (str): selected unique string
 
-    Example:
+    Examples:
         >>> forms.ask_for_unique_string(
         ...     prompt='Enter a Unique Name',
         ...     title=self.Title,
@@ -3280,9 +3294,9 @@ def ask_for_one_item(items, default=None, prompt=None, title=None, **kwargs):
         kwargs (type): other arguments to be passed to :obj:`GetValueWindow`
 
     Returns:
-        str: selected item
+        (str): selected item
 
-    Example:
+    Examples:
         >>> forms.ask_for_one_item(
         ...     ['test item 1', 'test item 2', 'test item 3'],
         ...     default='test item 2',
@@ -3314,9 +3328,9 @@ def ask_for_date(default=None, prompt=None, title=None, **kwargs):
         kwargs (type): other arguments to be passed to :obj:`GetValueWindow`
 
     Returns:
-        datetime.datetime: selected date
+        (datetime.datetime): selected date
 
-    Example:
+    Examples:
         >>> forms.ask_for_date(default="", title="Enter deadline:")
         ... datetime.datetime(2019, 5, 17, 0, 0)
     """
@@ -3347,9 +3361,9 @@ def ask_for_number_slider(default=None, min=0, max=100, interval=1, prompt=None,
         kwargs (type): other arguments to be passed to :obj:`GetValueWindow`
 
     Returns:
-        str: selected string value
+        (str): selected string value
 
-    Example:
+    Examples:
         >>> forms.ask_for_number_slider(
         ...     default=50,
         ...     min = 0,
@@ -3361,7 +3375,6 @@ def ask_for_number_slider(default=None, min=0, max=100, interval=1, prompt=None,
     
     In this example, the slider will allow values such as '40, 45, 50, 55, 60' etc
     """
-
     return GetValueWindow.show(
         None,
         value_type='slider',
@@ -3402,16 +3415,15 @@ def ask_to_use_selected(type_name, count=None, multiple=True):
 
 
 def ask_for_color(default=None):
-    """Show system color picker and ask for color
+    """Show system color picker and ask for color.
 
     Args:
         default (str): default color in HEX ARGB e.g. #ff808080
-        val (type): desc
 
     Returns:
-        str: selected color in HEX ARGB e.g. #ff808080, or None if cancelled
+        (str): selected color in HEX ARGB e.g. #ff808080, or None if cancelled
 
-    Example:
+    Examples:
         >>> forms.ask_for_color()
         ... '#ff808080'
     """
@@ -3435,7 +3447,7 @@ def ask_for_color(default=None):
 def inform_wip():
     """Show work-in-progress prompt to user and exit script.
 
-    Example:
+    Examples:
         >>> forms.inform_wip()
     """
     alert("Work in progress.", exitscript=True)

--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -297,6 +297,7 @@ class WPFWindow(framework.Windows.Window):
             DEFAULT_RECOGNIZE_ACCESS_KEY
 
     def setup_default_handlers(self):
+        """Set the default handlers."""
         self.PreviewKeyDown += self.handle_input_key    #pylint: disable=E1101
 
     def handle_input_key(self, sender, args):    #pylint: disable=W0613

--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -90,6 +90,7 @@ class reactive(property):
         super(reactive, self).__init__(newgetter)
 
     def setter(self, setter):
+        """Property setter."""
         def newsetter(ui_control, newvalue):
             oldvalue = self.fget(ui_control)
             if oldvalue != newvalue:
@@ -107,12 +108,19 @@ class Reactive(ComponentModel.INotifyPropertyChanged):
     PropertyChanged, _propertyChangedCaller = pyevent.make_event()
 
     def add_PropertyChanged(self, value):
+        """Called when a property is added to the object."""
         self.PropertyChanged += value
 
     def remove_PropertyChanged(self, value):
+        """Called when a property is removed from the object."""
         self.PropertyChanged -= value
 
     def OnPropertyChanged(self, prop_name):
+        """Called when a property is changed.
+
+        Args:
+            prop_name (str): property name
+        """
         if self._propertyChangedCaller:
             args = ComponentModel.PropertyChangedEventArgs(prop_name)
             self._propertyChangedCaller(self, args)
@@ -163,6 +171,20 @@ class WPFWindow(framework.Windows.Window):
             )
 
     def load_xaml(self, xaml_source, literal_string=False, handle_esc=True, set_owner=True):
+        """Load the window XAML file.
+
+        Args:
+            xaml_source (str): The XAML content or file path to load.
+            literal_string (bool, optional): True if `xaml_source` is content,
+                False if it is a path. Defaults to False.
+            handle_esc (bool, optional): Whether the ESC key should be handled.
+                Defaults to True.
+            set_owner (bool, optional): Whether to se the window owner.
+                Defaults to True.
+
+        Returns:
+            None
+        """
         # create new id for this window
         self.window_id = coreutils.new_uuid()
 
@@ -226,14 +248,24 @@ class WPFWindow(framework.Windows.Window):
         self.Resources.MergedDictionaries.Add(lang_dictionary)
 
     def get_locale_string(self, string_name):
+        """Get localized string.
+
+        Args:
+            string_name (str): string name
+
+        Returns:
+            (str): localized string
+        """
         return self.FindResource(string_name)
 
     def setup_owner(self):
+        """Set the window owner."""
         wih = Interop.WindowInteropHelper(self)
         wih.Owner = AdWindows.ComponentManager.ApplicationWindow
 
     @staticmethod
     def setup_resources(wpf_ctrl):
+        """Sets the WPF resources."""
         #2c3e50
         wpf_ctrl.Resources['pyRevitDarkColor'] = \
             Media.Color.FromArgb(0xFF, 0x2c, 0x3e, 0x50)
@@ -281,6 +313,7 @@ class WPFWindow(framework.Windows.Window):
         self.set_icon(op.join(BIN_DIR, 'pyrevit_settings.png'))
 
     def hide(self):
+        """Hide window."""
         self.Hide()
 
     def show(self, modal=False):
@@ -321,6 +354,13 @@ class WPFWindow(framework.Windows.Window):
         WPFWindow.set_image_source_file(wpf_element, image_file)
 
     def dispatch(self, func, *args, **kwargs):
+        """Runs the function in a new thread.
+
+        Args:
+            func (Callable): function to run
+            *args (Any): positional arguments to pass to func
+            **kwargs (Any): keyword arguments to pass to func
+        """
         if framework.get_current_thread_id() == self.thread_id:
             t = threading.Thread(
                 target=func,
@@ -338,6 +378,7 @@ class WPFWindow(framework.Windows.Window):
                 )
 
     def conceal(self):
+        """Conceal window."""
         return WindowToggler(self)
 
     @property
@@ -1039,6 +1080,7 @@ class SelectFromList(TemplateUserInputWindow):
                 self.in_uncheck = False
 
     def button_reset(self, sender, args):#pylint: disable=W0613
+        """Handle reset button click."""
         if self.reset_func:
             all_items = self.list_lb.ItemsSource
             self.reset_func(all_items)
@@ -1061,12 +1103,14 @@ class SelectFromList(TemplateUserInputWindow):
         self._list_options(option_filter=self.search_tb.Text)
 
     def selection_changed(self, sender, args):
+        """Handle selection change."""
         if self.info_panel:
             self._toggle_info_panel(state=False)
 
         self._list_options(option_filter=self.search_tb.Text)
 
     def selected_item_changed(self, sender, args):
+        """Handle selected item change."""
         if self.info_panel and self.list_lb.SelectedItem is not None:
             self._toggle_info_panel(state=True)
             self.infoData.Text = \
@@ -2854,6 +2898,7 @@ def pick_folder(title=None, owner=None):
 
 
 def result_item_result_clicked(sender, e, debug=False):
+    """Callback for a result item click event."""
     if debug:
         print("Result clicked")  # using print_md here will break the script
     pass

--- a/pyrevitlib/pyrevit/forms/utils.py
+++ b/pyrevitlib/pyrevit/forms/utils.py
@@ -11,7 +11,7 @@ def bitmap_from_file(bitmap_file):
         bitmap_file (str): path to bitmap file
 
     Returns:
-        BitmapImage: bitmap image object
+        (BitmapImage): bitmap image object
     """
     bitmap = Imaging.BitmapImage()
     bitmap.BeginInit()
@@ -31,7 +31,7 @@ def load_component(xaml_file, comp_type):
         comp_type (System.Windows.Controls): WPF control type
 
     Returns:
-        System.Windows.Controls: loaded WPF control
+        (System.Windows.Controls): loaded WPF control
     """
     return wpf.LoadComponent(comp_type, xaml_file)
 
@@ -43,7 +43,7 @@ def load_ctrl_template(xaml_file):
         xaml_file (str): xaml file path
 
     Returns:
-        System.Windows.Controls.ControlTemplate: loaded control template
+        (System.Windows.Controls.ControlTemplate): loaded control template
     """
     return load_component(xaml_file, Controls.ControlTemplate())
 
@@ -55,6 +55,6 @@ def load_itemspanel_template(xaml_file):
         xaml_file (str): xaml file path
 
     Returns:
-        System.Windows.Controls.ControlTemplate: loaded items-panel template
+        (System.Windows.Controls.ControlTemplate): loaded items-panel template
     """
     return load_component(xaml_file, Controls.ItemsPanelTemplate())

--- a/pyrevitlib/pyrevit/framework.py
+++ b/pyrevitlib/pyrevit/framework.py
@@ -1,6 +1,6 @@
 """Provide access to DotNet Framework.
 
-Example:
+Examples:
     >>> from pyrevit.framework import Assembly, Windows
 """
 

--- a/pyrevitlib/pyrevit/interop/adc.py
+++ b/pyrevitlib/pyrevit/interop/adc.py
@@ -1,4 +1,4 @@
-"""Wrapping Autodesk Desktop Connector API"""
+"""Wrapping Autodesk Desktop Connector API."""
 #pylint: disable=bare-except,broad-except
 import os.path as op
 from pyrevit import PyRevitException
@@ -123,7 +123,7 @@ def _get_item_property_id_value(adc, drive, item, prop_id):
 
 
 def is_available():
-    """Check if ADC service is available"""
+    """Check if ADC service is available."""
     try:
         _get_adc().Discover()
         return True
@@ -132,13 +132,13 @@ def is_available():
 
 
 def get_drive_paths():
-    """Get dict of local paths for ADC drives"""
+    """Get dict of local paths for ADC drives."""
     adc = _get_adc()
     return {x.Name: x.WorkspaceLocation for x in _get_drives_info(adc)}
 
 
 def get_local_path(path):
-    """Convert ADC BIM360 drive path to local path"""
+    """Convert ADC BIM360 drive path to local path."""
     adc = _get_adc()
     drv_info = _get_drive_from_path(adc, path)
     if drv_info:
@@ -146,14 +146,14 @@ def get_local_path(path):
 
 
 def lock_file(path):
-    """Lock given file"""
+    """Lock given file."""
     adc = _get_adc()
     item = _get_item(adc, path)
     adc.LockFile(item.Id)
 
 
 def is_locked(path):
-    """Check if file is locked"""
+    """Check if file is locked."""
     adc = _get_adc()
     item = _get_item(adc, path)
     lock_status = _get_item_lockstatus(adc, item)
@@ -162,14 +162,14 @@ def is_locked(path):
 
 
 def unlock_file(path):
-    """Unlock given file"""
+    """Unlock given file."""
     adc = _get_adc()
     item = _get_item(adc, path)
     adc.UnlockFile(item.Id)
 
 
 def is_synced(path):
-    """Check if file is synchronized"""
+    """Check if file is synchronized."""
     adc = _get_adc()
     item = _get_item(adc, path)
     drive = _get_item_drive(adc, item)
@@ -188,7 +188,7 @@ def is_synced(path):
 
 
 def sync_file(path, force=False):
-    """Force ADC to sync given file to latest version"""
+    """Force ADC to sync given file to latest version."""
     if not force and is_synced(path):
         return
     adc = _get_adc()

--- a/pyrevitlib/pyrevit/interop/bbx.py
+++ b/pyrevitlib/pyrevit/interop/bbx.py
@@ -2,6 +2,15 @@
 
 
 def load(inputfile):
+    """Read list of bounding boxes from file.
+
+    Args:
+        inputfile (str): path to input file
+
+    Returns:
+        (list[tuple[tuple[float, float, float], tuple[float, float, float]]]):
+            bounding boxes
+    """
     bboxes = []
     with open(inputfile, 'r') as bbxfile:
         # bbox_count = int(bbxfile.readline())   #noqa
@@ -15,6 +24,13 @@ def load(inputfile):
 
 
 def dump(outputfile, bbox_list):
+    """Write list of bounding boxes to file.
+
+    Args:
+        outputfile (str): path to output file
+        bbox_list (list[tuple[tuple[float, float, float], tuple[float, float, float]]]): 
+            bounding boxes
+    """
     bbox_count = len(bbox_list)
     with open(outputfile, 'w') as bbxfile:
         bbxfile.write(str(bbox_count) + '\n')

--- a/pyrevitlib/pyrevit/interop/dxf.py
+++ b/pyrevitlib/pyrevit/interop/dxf.py
@@ -1,3 +1,4 @@
+"""IxMIlia.Dxf assembly import."""
 # pylint: skip-file
 import os.path as op
 from pyrevit import clr, BIN_DIR

--- a/pyrevitlib/pyrevit/interop/ifc.py
+++ b/pyrevitlib/pyrevit/interop/ifc.py
@@ -1,3 +1,4 @@
+"""IFC.Net assembly import."""
 # pylint: skip-file
 import os.path as op
 from pyrevit import clr, BIN_DIR

--- a/pyrevitlib/pyrevit/interop/rhino.py
+++ b/pyrevitlib/pyrevit/interop/rhino.py
@@ -1,3 +1,4 @@
+"""Rhinoceros interop."""
 # pylint: skip-file
 import os.path as op
 from pyrevit import clr, BIN_DIR

--- a/pyrevitlib/pyrevit/interop/xl.py
+++ b/pyrevitlib/pyrevit/interop/xl.py
@@ -20,6 +20,22 @@ def _read_xlsheet(xlsheet, columns=[], datatype=None, headers=True):
 
 
 def load(xlfile, sheets=[], columns=[], datatype=None, headers=True):
+    """Read data from Excel file.
+
+    Args:
+        xlfile (str): full path of the excel file to read
+        sheets (list, optional): worksheets to read. Defaults to all the sheets.
+        columns (list, optional): Names to give to the columns.
+            It builds a dictionary for each row with the column name and value.
+            If none given (default), it returns a simple list of values.
+        datatype (type, optional): Type of the data. Defaults to None.
+        headers (bool, optional): Whether to use the first row as headers. 
+            Defaults to True.
+
+    Returns:
+        (dict[str, dict[str, Any]]): Excel data grouped by worksheet.
+            Each worksheet is a dictionary with `headers` and `rows`.
+    """
     xldata = {}
     xlwb = xlrd.open_workbook(xlfile)
     for xlsheet in xlwb.sheets():
@@ -38,7 +54,14 @@ def load(xlfile, sheets=[], columns=[], datatype=None, headers=True):
 
 
 def dump(xlfile, datadict):
-    # create workbook
+    """Write data to Excel file.
+
+    Creates a worksheet for each item of the input dictionary.
+
+    Args:
+        xlfile (str): full path of the target excel file
+        datadict (dict[str, list]): dictionary of worksheets names and data
+    """
     xlwb = xlsxwriter.Workbook(xlfile)
     # bold = xlwb.add_format({'bold': True})
     for xlsheetname, xlsheetdata in datadict.items():

--- a/pyrevitlib/pyrevit/labs.py
+++ b/pyrevitlib/pyrevit/labs.py
@@ -1,4 +1,4 @@
-"""Wrapper module for pyRevitLabs functionality"""
+"""Wrapper module for pyRevitLabs functionality."""
 import logging
 import os.path as op
 #pylint: disable=W0703,C0302,C0103,W0614,E0401,W0611,C0413
@@ -101,13 +101,13 @@ class PyRevitOutputTarget(NLog.Targets.TargetWithLayout):
 
 
 def extract_build_from_exe(proc_path):
-    """Extract build number from host .exe file
+    """Extract build number from host .exe file.
 
     Args:
         proc_path (str): full path of the host .exe file
 
     Returns:
-        str: build number (e.g. '20170927_1515(x64)')
+        (str): build number (e.g. '20170927_1515(x64)')
     """
     # Revit 2021 has a bug on .VersionBuild
     ## it reports identical value as .VersionNumber

--- a/pyrevitlib/pyrevit/loader/asmmaker.py
+++ b/pyrevitlib/pyrevit/loader/asmmaker.py
@@ -171,13 +171,13 @@ def _produce_asm_file(extension):
 
 
 def create_assembly(extension):
-    """
+    """Create an extension assembly.
 
     Args:
-        extension (pyrevit.extensions.components.Extension):
+        extension (pyrevit.extensions.components.Extension): pyRevit extension.
 
     Returns:
-
+        (ExtensionAssemblyInfo): assembly info
     """
     mlogger.debug('Creating assembly for extension: %s', extension.name)
     # create assembly file and return assembly path to be used in UI creation

--- a/pyrevitlib/pyrevit/loader/hooks.py
+++ b/pyrevitlib/pyrevit/loader/hooks.py
@@ -35,14 +35,32 @@ ExtensionEventHook = namedtuple('ExtensionEventHook', [
 
 
 def get_hooks_handler():
+    """Get the hook handler environment variable.
+
+    Returns:
+        (EventHooks): hook handler
+    """
     return envvars.get_pyrevit_env_var(envvars.HOOKSHANDLER_ENVVAR)
 
 
 def set_hooks_handler(handler):
+    """Set the hook handler environment variable.
+
+    Args:
+        handler (EventHooks): hook handler
+    """
     envvars.set_pyrevit_env_var(envvars.HOOKSHANDLER_ENVVAR, handler)
 
 
 def is_valid_hook_script(hook_script):
+    """Check if the given hook script is valid.
+
+    Args:
+        hook_script (str): hook script path
+
+    Returns:
+        (bool): True if the script is valid, False otherwise
+    """
     return op.splitext(op.basename(hook_script))[1] in SUPPORTED_LANGUAGES
 
 
@@ -70,6 +88,14 @@ def _create_hook_id(extension, hook_script):
 
 
 def get_extension_hooks(extension):
+    """Get the hooks of the given extension.
+
+    Args:
+        extension (pyrevit.extensions.components.Extension): pyRevit extension
+
+    Returns:
+        (list[ExtensionEventHook]): list of hooks
+    """
     event_hooks = []
     for hook_script in extension.get_hooks():
         if is_valid_hook_script(hook_script):
@@ -89,11 +115,17 @@ def get_extension_hooks(extension):
 
 
 def get_event_hooks():
+    """Get all the event hooks."""
     hooks_handler = get_hooks_handler()
     return hooks_handler.GetAllEventHooks()
 
 
 def register_hooks(extension):
+    """Register the hooks for the given extension.
+
+    Args:
+        extension (pyrevit.extensions.components.Extension): pyRevit extension
+    """
     hooks_handler = get_hooks_handler()
     for ext_hook in get_extension_hooks(extension):
         try:
@@ -111,27 +143,42 @@ def register_hooks(extension):
 
 
 def unregister_hooks(extension):
+    """Unregister all hooks for the given extension.
+
+    Args:
+        extension (pyrevit.extensions.components.Extension): pyRevit extension
+    """
     hooks_handler = get_hooks_handler()
     for ext_hook in get_extension_hooks(extension):
         hooks_handler.UnRegisterHook(uniqueId=ext_hook.id)
 
 
 def unregister_all_hooks():
+    """Unregister all hooks."""
     hooks_handler = get_hooks_handler()
     hooks_handler.UnRegisterAllHooks(uiApp=HOST_APP.uiapp)
 
 
 def activate():
+    """Activate all event hooks."""
     hooks_handler = get_hooks_handler()
     hooks_handler.ActivateEventHooks(uiApp=HOST_APP.uiapp)
 
 
 def deactivate():
+    """Deactivate all event hooks."""
     hooks_handler = get_hooks_handler()
     hooks_handler.DeactivateEventHooks(uiApp=HOST_APP.uiapp)
 
 
 def setup_hooks(session_id=None):
+    """Setup the hooks for the given session.
+    
+    If no session is specified, use the current one.
+
+    Args:
+        session_id (str, optional): Session. Defaults to None.
+    """
     # make sure session id is availabe
     if not session_id:
         session_id = sessioninfo.get_session_uuid()

--- a/pyrevitlib/pyrevit/loader/sessioninfo.py
+++ b/pyrevitlib/pyrevit/loader/sessioninfo.py
@@ -76,9 +76,9 @@ def get_runtime_info():
     """Return runtime information tuple.
 
     Returns:
-        :obj:`RuntimeInfo`: runtime info tuple
+        (RuntimeInfo): runtime info tuple
 
-    Example:
+    Examples:
         >>> sessioninfo.get_runtime_info()
     """
     # FIXME: add example output
@@ -102,7 +102,7 @@ def get_session_uuid():
     """Read session uuid from environment variable.
 
     Returns:
-        str: session uuid string
+        (str): session uuid string
     """
     return envvars.get_pyrevit_env_var(envvars.SESSIONUUID_ENVVAR)
 
@@ -111,7 +111,7 @@ def new_session_uuid():
     """Create a new uuid for a pyRevit session.
 
     Returns:
-        str: session uuid string
+        (str): session uuid string
     """
     uuid_str = safe_strtype(coreutils.new_uuid())
     set_session_uuid(uuid_str)
@@ -122,7 +122,7 @@ def get_loaded_pyrevit_assemblies():
     """Return list of loaded pyRevit assemblies from environment variable.
 
     Returns:
-        list[str]: list of loaded assemblies
+        (list[str]): list of loaded assemblies
     """
     # FIXME: verify and document return type
     loaded_assms_str = envvars.get_pyrevit_env_var(envvars.LOADEDASSMS_ENVVAR)
@@ -137,7 +137,6 @@ def set_loaded_pyrevit_assemblies(loaded_assm_name_list):
 
     Args:
         loaded_assm_name_list (list[str]): list of assembly names
-        val (type): desc
     """
     envvars.set_pyrevit_env_var(
         envvars.LOADEDASSMS_ENVVAR,

--- a/pyrevitlib/pyrevit/loader/sessionmgr.py
+++ b/pyrevitlib/pyrevit/loader/sessionmgr.py
@@ -1,12 +1,12 @@
-"""
-The loader module manages the workflow of loading a new pyRevit session.
-It's main purpose is to orchestrate the process of finding pyRevit extensions,
+"""The loader module manages the workflow of loading a new pyRevit session.
+
+Its main purpose is to orchestrate the process of finding pyRevit extensions,
 creating dll assemblies for them, and creating a user interface
 in the host application.
 
-Everything starts from ``sessionmgr.load_session()`` function...
+Everything starts from `sessionmgr.load_session()` function...
 
-The only public function is ``load_session()`` that loads a new session.
+The only public function is `load_session()` that loads a new session.
 Everything else is private.
 """
 import sys
@@ -162,14 +162,7 @@ def _perform_onsessionloadcomplete_ops():
 
 
 def _new_session():
-    """
-    Get all installed extensions (UI extension only) and creates an assembly,
-    and a ui for each.
-
-    Returns:
-        None
-    """
-
+    """Create an assembly and UI for each installed UI extensions."""
     assembled_exts = []
     # get all installed ui extensions
     for ui_ext in extensionmgr.get_installed_ui_extensions():
@@ -256,16 +249,17 @@ def _new_session():
 
 def load_session():
     """Handles loading/reloading of the pyRevit addin and extensions.
+
     To create a proper ui, pyRevit extensions needs to be properly parsed and
     a dll assembly needs to be created. This function handles these tasks
-    through interactions with .extensions, .loader.asmmaker, and .loader.uimaker
+    through interactions with .extensions, .loader.asmmaker, and .loader.uimaker.
 
-    Example:
+    Examples:
         >>> from pyrevit.loader.sessionmgr import load_session
         >>> load_session()     # start loading a new pyRevit session
 
     Returns:
-        None
+        (str): sesion uuid
     """
     # setup runtime environment variables
     sessioninfo.setup_runtime_vars()
@@ -333,6 +327,7 @@ def reload_pyrevit():
 # pyrevit command or script in current session
 # -----------------------------------------------------------------------------
 class PyRevitExternalCommandType(object):
+    """PyRevit external command type."""
     def __init__(self, extcmd_type, extcmd_availtype):
         self._extcmd_type = extcmd_type
         self._extcmd = extcmd_type()
@@ -467,12 +462,14 @@ def find_all_available_commands(use_current_context=True, cache=True):
 
 
 def find_pyrevitcmd(pyrevitcmd_unique_id):
-    """Searches the pyRevit-generated assemblies under current session for
+    """Find a pyRevit command.
+
+    Searches the pyRevit-generated assemblies under current session for
     the command with the matching unique name (class name) and returns the
     command type. Notice that this returned value is a 'type' and should be
     instantiated before use.
 
-    Example:
+    Examples:
         >>> cmd = find_pyrevitcmd('pyRevitCorepyRevitpyRevittoolsReload')
         >>> command_instance = cmd()
         >>> command_instance.Execute() # Provide commandData, message, elements
@@ -481,7 +478,7 @@ def find_pyrevitcmd(pyrevitcmd_unique_id):
         pyrevitcmd_unique_id (str): Unique name for the command
 
     Returns:
-        Type for the command with matching unique name
+        (type):Type for the command with matching unique name
     """
     # go through assmebles loaded under current pyRevit session
     # and try to find the command
@@ -546,11 +543,7 @@ def execute_command(pyrevitcmd_unique_id):
 
     Args:
         pyrevitcmd_unique_id (str): Unique/Class Name of the pyRevit command
-
-    Returns:
-        results from the executed command
     """
-
     cmd_class = find_pyrevitcmd(pyrevitcmd_unique_id)
 
     if not cmd_class:
@@ -566,9 +559,8 @@ def execute_extension_startup_script(script_path, ext_name, sys_paths=None):
 
     Args:
         script_path (str): Address of the script file
-
-    Returns:
-        results dictionary from the executed script
+        ext_name (str): Name of the extension
+        sys_paths (list): additional search paths
     """
     core_syspaths = [MAIN_LIB_DIR, MISC_LIB_DIR]
     if sys_paths:

--- a/pyrevitlib/pyrevit/loader/systemdiag.py
+++ b/pyrevitlib/pyrevit/loader/systemdiag.py
@@ -35,8 +35,7 @@ def check_host_drive_freespace():
 
 
 def system_diag():
-    """Verifies system status is appropriate for a pyRevit session.
-    """
+    """Verifies system status is appropriate for a pyRevit session."""
     # checking available drive space
     check_host_drive_freespace()
 

--- a/pyrevitlib/pyrevit/loader/uimaker.py
+++ b/pyrevitlib/pyrevit/loader/uimaker.py
@@ -23,6 +23,15 @@ CONFIG_SCRIPT_TITLE_POSTFIX = u'\u25CF'
 
 
 class UIMakerParams:
+    """UI maker parameters.
+
+    Args:
+        par_ui (_PyRevitUI): Parent UI item
+        par_cmp (GenericUIComponent): Parent UI component
+        cmp_item (GenericUIComponent): UI component item
+        asm_info (AssemblyInfo): Assembly info
+        create_beta (bool): Create beta button
+    """
     def __init__(self, par_ui, par_cmp, cmp_item, asm_info, create_beta=False):
         self.parent_ui = par_ui
         self.parent_cmp = par_cmp
@@ -106,30 +115,30 @@ def _set_highlights(button, ui_item):
 
 
 def _get_effective_classname(button):
-    """
-    Verifies if button has class_name set. This means that typemaker has
-    created a executor type for this command. If class_name is not set,
-    this function returns button.unique_name. This allows for the UI button
-    to be created and linked to the previously created assembly.
+    """Verifies if button has class_name set.
+
+    This means that typemaker has created a executor type for this command.
+    If class_name is not set, this function returns button.unique_name.
+    This allows for the UI button to be created and linked to the previously 
+    created assembly.
     If the type does not exist in the assembly, the UI button will not work,
     however this allows updating the command with the correct executor type,
     once command script has been fixed and pyrevit is reloaded.
 
     Args:
-        button (pyrevit.extensions.genericcomps.GenericUICommand):
+        button (pyrevit.extensions.genericcomps.GenericUICommand): button
 
     Returns:
-        str: class_name (or unique_name if class_name is None)
-
+        (str): class_name (or unique_name if class_name is None)
     """
     return button.class_name if button.class_name else button.unique_name
 
 
 def _produce_ui_separator(ui_maker_params):
-    """
+    """Crete a separator.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui_item = ui_maker_params.parent_ui
     ext_asm_info = ui_maker_params.asm_info
@@ -138,7 +147,7 @@ def _produce_ui_separator(ui_maker_params):
         mlogger.debug('Adding separator to: %s', parent_ui_item)
         try:
             if hasattr(parent_ui_item, 'add_separator'):    # re issue #361
-                parent_ui_item.add_separator()
+                parent_ui_item.z()
         except PyRevitException as err:
             mlogger.error('UI error: %s', err.msg)
 
@@ -146,10 +155,10 @@ def _produce_ui_separator(ui_maker_params):
 
 
 def _produce_ui_slideout(ui_maker_params):
-    """
+    """Create a slide out.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui_item = ui_maker_params.parent_ui
     ext_asm_info = ui_maker_params.asm_info
@@ -165,10 +174,10 @@ def _produce_ui_slideout(ui_maker_params):
 
 
 def _produce_ui_smartbutton(ui_maker_params):
-    """
+    """Create a smart button.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui_item = ui_maker_params.parent_ui
     parent = ui_maker_params.parent_cmp
@@ -276,10 +285,10 @@ def _produce_ui_smartbutton(ui_maker_params):
 
 
 def _produce_ui_linkbutton(ui_maker_params):
-    """
+    """Create a link button.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui_item = ui_maker_params.parent_ui
     parent = ui_maker_params.parent_cmp
@@ -340,10 +349,10 @@ def _produce_ui_linkbutton(ui_maker_params):
 
 
 def _produce_ui_pushbutton(ui_maker_params):
-    """
+    """Create a push button.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui_item = ui_maker_params.parent_ui
     parent = ui_maker_params.parent_cmp
@@ -382,10 +391,10 @@ def _produce_ui_pushbutton(ui_maker_params):
 
 
 def _produce_ui_pulldown(ui_maker_params):
-    """
+    """Create a pulldown button.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ribbon_panel = ui_maker_params.parent_ui
     pulldown = ui_maker_params.component
@@ -406,10 +415,10 @@ def _produce_ui_pulldown(ui_maker_params):
 
 
 def _produce_ui_split(ui_maker_params):
-    """
+    """Produce a split button.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ribbon_panel = ui_maker_params.parent_ui
     split = ui_maker_params.component
@@ -430,10 +439,10 @@ def _produce_ui_split(ui_maker_params):
 
 
 def _produce_ui_splitpush(ui_maker_params):
-    """
+    """Create split push button.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ribbon_panel = ui_maker_params.parent_ui
     splitpush = ui_maker_params.component
@@ -454,10 +463,10 @@ def _produce_ui_splitpush(ui_maker_params):
 
 
 def _produce_ui_stacks(ui_maker_params):
-    """
+    """Create a stack of ui items.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui_panel = ui_maker_params.parent_ui
     stack_parent = ui_maker_params.parent_cmp
@@ -507,10 +516,10 @@ def _produce_ui_stacks(ui_maker_params):
 
 
 def _produce_ui_panelpushbutton(ui_maker_params):
-    """
+    """Create a push button with the given parameters.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui_item = ui_maker_params.parent_ui
     # parent = ui_maker_params.parent_cmp
@@ -545,17 +554,20 @@ def _produce_ui_panelpushbutton(ui_maker_params):
 
 
 def _produce_ui_panels(ui_maker_params):
-    """
+    """Create a panel with the given parameters.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
+
+    Returns:
+        (RevitNativeRibbonPanel): The created panel
     """
     parent_ui_tab = ui_maker_params.parent_ui
     panel = ui_maker_params.component
-    
+
     if panel.is_beta and not ui_maker_params.create_beta_cmds:
         return None
-    
+
     mlogger.debug('Producing ribbon panel: %s', panel)
     try:
         parent_ui_tab.create_ribbon_panel(panel.name, update_if_exists=True)
@@ -583,10 +595,10 @@ def _produce_ui_panels(ui_maker_params):
 
 
 def _produce_ui_tab(ui_maker_params):
-    """
+    """Create a tab with the given parameters.
 
     Args:
-        ui_maker_params (UIMakerParams): Standard parameters for making ui item
+        ui_maker_params (UIMakerParams): Standard parameters for making ui item.
     """
     parent_ui = ui_maker_params.parent_ui
     tab = ui_maker_params.component
@@ -676,9 +688,12 @@ if not EXEC_PARAMS.doc_mode:
 
 
 def update_pyrevit_ui(ui_ext, ext_asm_info, create_beta=False):
-    """
-    Updates/Creates pyRevit ui for the given extension and
-    provided assembly dll address.
+    """Updates/Creates pyRevit ui for the extension and assembly dll address.
+
+    Args:
+        ui_ext (GenericUIContainer): UI container.
+        ext_asm_info (AssemblyInfo): Assembly info.
+        create_beta (bool, optional): Create beta ui. Defaults to False.
     """
     mlogger.debug('Creating/Updating ui for extension: %s', ui_ext)
     cmp_count = _recursively_produce_ui_items(
@@ -687,6 +702,11 @@ def update_pyrevit_ui(ui_ext, ext_asm_info, create_beta=False):
 
 
 def sort_pyrevit_ui(ui_ext):
+    """Sorts pyRevit UI.
+
+    Args:
+        ui_ext (GenericUIContainer): UI container.
+    """
     # only works on panels so far
     # re-ordering of ui components deeper than panels have not been implemented
     for tab in current_ui.get_pyrevit_tabs():
@@ -703,9 +723,12 @@ def sort_pyrevit_ui(ui_ext):
 
 
 def cleanup_pyrevit_ui():
-    # hide all items that were not touched after a reload
-    # meaning they have been removed in extension folder structure
-    # and thus are not updated
+    """Cleanup the pyrevit UI.
+
+    Hide all items that were not touched after a reload
+    meaning they have been removed in extension folder structure
+    and thus are not updated.
+    """
     untouched_items = current_ui.get_unchanged_items()
     for item in untouched_items:
         if not item.is_native():
@@ -717,7 +740,7 @@ def cleanup_pyrevit_ui():
 
 
 def reflow_pyrevit_ui(direction=applocales.DEFAULT_LANG_DIR):
-    # set flow direction of the tabs
+    """Set the flow direction of the tabs."""
     if direction == "LTR":
         current_ui.set_LTR_flow()
     elif direction == "RTL":

--- a/pyrevitlib/pyrevit/output/__init__.py
+++ b/pyrevitlib/pyrevit/output/__init__.py
@@ -5,7 +5,7 @@ pyRevit command. The proper way to access this wrapper object is through
 the :func:`get_output` of :mod:`pyrevit.script` module. This method, in return
 uses the `pyrevit.output` module to get access to the output wrapper.
 
-Example:
+Examples:
     >>> from pyrevit import script
     >>> output = script.get_output()
 
@@ -103,7 +103,7 @@ class PyRevitOutputWindow(object):
         """Return html renderer inside output window.
 
         Returns:
-            ``System.Windows.Forms.WebBrowser`` (In current implementation)
+            (System.Windows.Forms.WebBrowser): HTML renderer
         """
         if self.window:
             return self.window.renderer
@@ -133,10 +133,12 @@ class PyRevitOutputWindow(object):
 
     @property
     def is_closed_by_user(self):
+        """Whether the window has been closed by the user."""
         return self.window.ClosedByUser
 
     @property
     def last_line(self):
+        """Last line of the output window."""
         return self.window.GetLastLine()
 
     @property
@@ -175,7 +177,7 @@ class PyRevitOutputWindow(object):
             element_contents (str): html code of the element contents
             attribs (:obj:`dict`): dictionary of attribute names and value
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.inject_to_head('script',
                                       '',   # no script since it's a link
@@ -203,7 +205,7 @@ class PyRevitOutputWindow(object):
             element_contents (str): html code of the element contents
             attribs (:obj:`dict`): dictionary of attribute names and value
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.inject_to_body('script',
                                       '',   # no script since it's a link
@@ -231,7 +233,7 @@ class PyRevitOutputWindow(object):
             attribs (:obj:`dict`): dictionary of attribute names and value
             body (bool, optional): injects script into body instead of head
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.inject_script('',   # no script since it's a link
                                      {'src': js_script_file_path})
@@ -248,7 +250,7 @@ class PyRevitOutputWindow(object):
             style_code (str): css styling code
             attribs (:obj:`dict`): dictionary of attribute names and value
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.add_style('body { color: blue; }')
         """
@@ -292,7 +294,7 @@ class PyRevitOutputWindow(object):
         self.set_height(height)
 
     def center(self):
-        """Center the output window on the screen"""
+        """Center the output window on the screen."""
         screen_area = HOST_APP.proc_screen_workarea
         left = \
             (abs(screen_area.Right - screen_area.Left) / 2) \
@@ -404,7 +406,7 @@ class PyRevitOutputWindow(object):
             cur_value (float): current progress value e.g. 50
             max_value (float): total value e.g. 100
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> for i in range(100):
             >>>     output.update_progress(i, 100)
@@ -428,7 +430,7 @@ class PyRevitOutputWindow(object):
             self.window.SetActivityBarVisibility(True)
 
     def indeterminate_progress(self, state):
-        """Show or hide indeterminate progress bar. """
+        """Show or hide indeterminate progress bar."""
         if self.window:
             self.window.UpdateActivityBar(state)
 
@@ -487,7 +489,7 @@ class PyRevitOutputWindow(object):
     def print_html(html_str):
         """Add the html code to the output window.
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.print_html('<strong>Title</strong>')
         """
@@ -498,7 +500,7 @@ class PyRevitOutputWindow(object):
     def print_code(code_str):
         """Print code to the output window with special formatting.
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.print_code('value = 12')
         """
@@ -516,7 +518,7 @@ class PyRevitOutputWindow(object):
     def print_md(md_str):
         """Process markdown code and print to output window.
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.print_md('### Title')
         """
@@ -531,13 +533,13 @@ class PyRevitOutputWindow(object):
         """Print provided data in a table in output window.
 
         Args:
-            table_data (:obj:`list` of iterables): 2D array of data
+            table_data (list[iterable[Any]]): 2D array of data
             title (str): table title
-            columns (:obj:`list` str): list of column names
-            formats (:obj:`list` str): column data formats
+            columns (list[str]): list of column names
+            formats (list[str]): column data formats
             last_line_style (str): css style of last row
 
-        Example:
+        Examples:
             >>> data = [
             ... ['row1', 'data', 'data', 80 ],
             ... ['row2', 'data', 'data', 45 ],
@@ -601,7 +603,7 @@ class PyRevitOutputWindow(object):
     def print_image(self, image_path):
         r"""Prints given image to the output.
 
-        Example:
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> output.print_image(r'C:\image.gif')
         """
@@ -630,11 +632,14 @@ class PyRevitOutputWindow(object):
         This method, creates the link but does not print it directly.
 
         Args:
-            element_ids (`ElementId`) or
-            element_ids (:obj:`list` of `ElementId`): single or multiple ids
+            element_ids (ElementId | list[ElementId]): single or multiple ids
             title (str): tile of the link. defaults to list of element ids
+            
 
-        Example:
+        Returns:
+            (str): clickable link
+
+        Examples:
             >>> output = pyrevit.output.get_output()
             >>> for idx, elid in enumerate(element_ids):
             >>>     print('{}: {}'.format(idx+1, output.linkify(elid)))

--- a/pyrevitlib/pyrevit/output/linkmaker.py
+++ b/pyrevitlib/pyrevit/output/linkmaker.py
@@ -41,7 +41,7 @@ def make_link(element_ids, contents=None):
     links is handled by the output wrapper object through the :func:`linkify`
     method.
 
-    Example:
+    Examples:
         >>> output = pyrevit.output.get_output()
         >>> for idx, elid in enumerate(element_ids):
         >>>     print('{}: {}'.format(idx+1, output.linkify(elid)))

--- a/pyrevitlib/pyrevit/preflight/__init__.py
+++ b/pyrevitlib/pyrevit/preflight/__init__.py
@@ -1,4 +1,4 @@
-"""Preflight checks framework
+"""Preflight checks framework.
 
 This framework is designed to automate verification and quality control
 checks that need to be completed before model is published. The framework works
@@ -34,7 +34,7 @@ def _get_check_name(check_script):
 
 
 class PreflightCheck(object):
-    """Preflight Check"""
+    """Preflight Check."""
 
     def __init__(self, extension, check_type, script_path):
         self.check_case = check_type
@@ -57,10 +57,11 @@ class PreflightCheck(object):
 
 
 def run_preflight_check(check, doc, output):
-    """Run a preflight check
+    """Run a preflight check.
 
     Args:
         check (PreflightCheck): preflight test case object
+        doc (Document): Revit document
         output (pyrevit.output.PyRevitOutputWindow): output window wrapper
     """
     check_case = check.check_case()
@@ -71,7 +72,7 @@ def run_preflight_check(check, doc, output):
 
 
 def get_all_preflight_checks():
-    """Find all the preflight checks in installed extensions"""
+    """Find all the preflight checks in installed extensions."""
     preflight_checks = []
     # get all installed ui extensions
     for ext in extensionmgr.get_installed_ui_extensions():

--- a/pyrevitlib/pyrevit/revit/__init__.py
+++ b/pyrevitlib/pyrevit/revit/__init__.py
@@ -1,3 +1,4 @@
+"""Revit application wrapper."""
 import types
 import sys
 
@@ -38,10 +39,19 @@ mlogger = get_logger(__name__)
 
 
 def get_imported_symbol(symbol_name):
+    """Geth an imported symbol by its name.
+
+    Args:
+        symbol_name (str): symbol name
+
+    Returns:
+        (Any): imported symbol, if found, None otherwise.
+    """
     return globals().get(symbol_name, None)
 
 
 class RevitWrapper(types.ModuleType):
+    """Revit application wrapper."""
     def __init__(self):
         pass
 
@@ -58,18 +68,22 @@ class RevitWrapper(types.ModuleType):
 
     @property
     def uidoc(self):
+        """Active UI Document."""
         return HOST_APP.uidoc
 
     @property
     def doc(self):
+        """Active document."""
         return DOCS.doc
 
     @property
     def docs(self):
+        """Active documents."""
         return DOCS.docs
 
     @property
     def active_view(self):
+        """Active view."""
         return HOST_APP.active_view
 
     @active_view.setter
@@ -78,6 +92,7 @@ class RevitWrapper(types.ModuleType):
 
     @property
     def active_ui_view(self):
+        """Active UI view."""
         if isinstance(self.active_view, DB.View):
             for uiview in self.uidoc.GetOpenUIViews():
                 if uiview.ViewId == self.active_view.Id:
@@ -85,6 +100,7 @@ class RevitWrapper(types.ModuleType):
 
     @property
     def servers(self):
+        """Available revit server names."""
         return HOST_APP.available_servers
 
     @staticmethod
@@ -95,7 +111,7 @@ class RevitWrapper(types.ModuleType):
             doc_path (str): document file path
 
         Returns:
-            DB.Document: opened document
+            (DB.Document): opened document
         """
         return HOST_APP.app.OpenDocumentFile(doc_path)
 
@@ -110,7 +126,7 @@ class RevitWrapper(types.ModuleType):
 
     @staticmethod
     def post_command(command_id):
-        """Request Revit to run a command
+        """Request Revit to run a command.
 
         Args:
             command_id (str): command identifier e.g. ID_REVIT_SAVE_AS_TEMPLATE
@@ -119,9 +135,9 @@ class RevitWrapper(types.ModuleType):
 
 
 class ErrorSwallower():
-    """Suppresses warnings during script execution
+    """Suppresses warnings during script execution.
 
-    Example:
+    Examples:
         >>> with ErrorSwallower() as swallower:
         >>>     for fam in families:
         >>>         revit.doc.EditFamily(fam)
@@ -134,7 +150,7 @@ class ErrorSwallower():
         self._logerror = log_errors
 
     def on_failure_processing(self, _, event_args):
-        """Failure processing event handler"""
+        """Failure processing event handler."""
         try:
             failure_accesssor = event_args.GetFailuresAccessor()
             mlogger.debug('request for failure processing...')
@@ -147,20 +163,20 @@ class ErrorSwallower():
             mlogger.error('Error occured while processing failures. | %s', fpex)
 
     def get_swallowed_errors(self):
-        """Return swallowed errors"""
+        """Return swallowed errors."""
         return self._fswallower.get_swallowed_failures()
 
     def reset(self):
-        """Reset swallowed errors"""
+        """Reset swallowed errors."""
         self._fswallower.reset()
 
     def __enter__(self):
-        """Start listening to failure processing events"""
+        """Start listening to failure processing events."""
         HOST_APP.app.FailuresProcessing += self.on_failure_processing
         return self
 
     def __exit__(self, exception, exception_value, traceback):
-        """Stop listening to failure processing events"""
+        """Stop listening to failure processing events."""
         HOST_APP.app.FailuresProcessing -= self.on_failure_processing
         if exception and self._logerror:
             mlogger.error('Error in ErrorSwallower Context. | %s:%s',

--- a/pyrevitlib/pyrevit/revit/bim360.py
+++ b/pyrevitlib/pyrevit/revit/bim360.py
@@ -1,4 +1,4 @@
-"""BIM360-related utilities"""
+"""BIM360-related utilities."""
 #pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
 import os
 import os.path as op
@@ -16,7 +16,7 @@ COLLAB_CACHE_PATH_FORMAT = \
 
 
 class CollabCacheModel(object):
-    """Collaboration cache for a Revit project"""
+    """Collaboration cache for a Revit project."""
     def __init__(self, model_path):
         self.model_path = model_path
         self.model_dir = op.dirname(model_path)
@@ -45,7 +45,7 @@ class CollabCacheModel(object):
 
 
 class CollabCache(object):
-    """Collaboration cache instance containing multiple projects"""
+    """Collaboration cache instance containing multiple projects."""
     def __init__(self, cache_path):
         self.cache_path = cache_path
         self.cache_id = op.basename(cache_path)
@@ -70,7 +70,7 @@ class CollabCache(object):
 
 
 def get_collab_caches():
-    """Get a list of project caches stored under collaboration cache"""
+    """Get a list of project caches stored under collaboration cache."""
     collab_root = op.normpath(op.expandvars(
         COLLAB_CACHE_PATH_FORMAT.format(version=HOST_APP.version)
     ))
@@ -90,7 +90,7 @@ def get_collab_caches():
 
 
 def clear_model_cache(collab_cache_model):
-    """Clear caches for given collaboration cache model
+    """Clear caches for given collaboration cache model.
 
     Args:
         collab_cache_model (bim360.CollabCacheModel): cache model to clear

--- a/pyrevitlib/pyrevit/revit/db/__init__.py
+++ b/pyrevitlib/pyrevit/revit/db/__init__.py
@@ -1,3 +1,4 @@
+"""Revit DB objects wrappers."""
 import os.path as op
 
 from pyrevit import HOST_APP, PyRevitException
@@ -14,6 +15,7 @@ __all__ = ('BaseWrapper', 'ElementWrapper',
 
 
 class BaseWrapper(object):
+    """Base revit databse object wrapper."""
     def __init__(self, obj=None):
         self._wrapped = obj
 
@@ -54,6 +56,7 @@ class BaseWrapper(object):
 
 
 class ElementWrapper(BaseWrapper):
+    """Revit element wrapper."""
     def __init__(self, element):
         super(ElementWrapper, self).__init__(element)
         if not isinstance(self._wrapped, DB.Element):
@@ -129,6 +132,7 @@ class ElementWrapper(BaseWrapper):
 
 
 class ExternalRef(ElementWrapper):
+    """External reference wraper."""
     def __init__(self, link, extref):
         super(ExternalRef, self).__init__(link)
         self._extref = extref
@@ -155,6 +159,7 @@ class ExternalRef(ElementWrapper):
 
 
 class ProjectParameter(BaseWrapper):
+    """Project parameter wrapper."""
     def __init__(self, param_def, param_binding=None, param_ext_def=False):
         super(ProjectParameter, self).__init__()
         self.param_def = param_def
@@ -210,6 +215,7 @@ class ProjectParameter(BaseWrapper):
 
 
 class ProjectInfo(BaseWrapper):
+    """Project information."""
     def __init__(self, doc):
         super(ProjectInfo, self).__init__()
         self._doc = doc
@@ -298,6 +304,7 @@ class ProjectInfo(BaseWrapper):
 
 
 class XYZPoint(BaseWrapper):
+    """Wrapper for XYZ point."""
     @property
     def x(self):
         return round(self._wrapped.X)

--- a/pyrevitlib/pyrevit/revit/db/create.py
+++ b/pyrevitlib/pyrevit/revit/db/create.py
@@ -1,3 +1,4 @@
+"""Database objects creation functions."""
 import sys
 
 from pyrevit import HOST_APP, DOCS, PyRevitException
@@ -28,6 +29,7 @@ PARAM_VALUE_EVALUATORS = {
 
 # http://www.revitapidocs.com/2018.1/5da8e3c5-9b49-f942-02fc-7e7783fe8f00.htm
 class FamilyLoaderOptionsHandler(DB.IFamilyLoadOptions):
+    """Family loader options handler."""
     def __init__(self, overwriteParameterValues=True):
         self._overwriteParameterValues = overwriteParameterValues
 

--- a/pyrevitlib/pyrevit/revit/db/delete.py
+++ b/pyrevitlib/pyrevit/revit/db/delete.py
@@ -1,3 +1,4 @@
+"""Database elements deletion functions."""
 from pyrevit import DOCS
 from pyrevit.framework import List
 from pyrevit import DB

--- a/pyrevitlib/pyrevit/revit/db/ensure.py
+++ b/pyrevitlib/pyrevit/revit/db/ensure.py
@@ -1,3 +1,4 @@
+"""Idempotent operations to ensure a datbase object exists."""
 import os.path as op
 
 from pyrevit import HOST_APP, DOCS, PyRevitException

--- a/pyrevitlib/pyrevit/revit/db/failure.py
+++ b/pyrevitlib/pyrevit/revit/db/failure.py
@@ -1,3 +1,4 @@
+"""Revit failures handler."""
 from pyrevit import HOST_APP, DB
 from pyrevit import framework
 from pyrevit import coreutils
@@ -27,6 +28,7 @@ RESOLUTION_TYPES = [DB.FailureResolutionType.MoveElements,
 # http://www.revitapidocs.com/2018.1/f147e6e6-4b2e-d61c-df9b-8b8e5ebe3fcb.htm
 # explains usage of FailureProcessingResult options
 class FailureSwallower(DB.IFailuresPreprocessor):
+    """Swallows all failures."""
     def __init__(self, log_errors=True):
         self._logerror = log_errors
         self._failures_swallowed = []
@@ -60,15 +62,15 @@ class FailureSwallower(DB.IFailuresPreprocessor):
         return failures
 
     def reset(self):
-        """Reset swallowed errors"""
+        """Reset swallowed errors."""
         self._failures_swallowed = []
 
     def preprocess_failures(self, failure_accessor):
-        """Pythonic wrapper for `PreprocessFailures` interface method"""
+        """Pythonic wrapper for `PreprocessFailures` interface method."""
         return self.PreprocessFailures(failure_accessor)
 
     def PreprocessFailures(self, failuresAccessor):
-        """Required IFailuresPreprocessor interface method"""
+        """Required IFailuresPreprocessor interface method."""
         severity = failuresAccessor.GetSeverity()
         # log some info
         mlogger.debug('processing failure with severity: %s', severity)

--- a/pyrevitlib/pyrevit/revit/db/pickling.py
+++ b/pyrevitlib/pyrevit/revit/db/pickling.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-docstring,invalid-name,too-few-public-methods
-"""Methods and Classes to convert Revit types to serializable"""
+"""Methods and Classes to convert Revit types to serializable."""
 from pyrevit import PyRevitException, api
 from pyrevit import DB
 from pyrevit.compat import Iterable

--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -107,7 +107,7 @@ def get_type(element):
         element (DB.Element): source element
 
     Returns:
-        DB.ElementType: type object of given element
+        (DB.ElementType): type object of given element
     """
     type_id = element.GetTypeId()
     return element.Document.GetElement(type_id)
@@ -124,12 +124,12 @@ def get_family_name(element):
 # episode_id and guid explanation
 # https://thebuildingcoder.typepad.com/blog/2009/02/uniqueid-dwf-and-ifc-guid.html
 def get_episodeid(element):
-    """Extract episode id from element"""
+    """Extract episode id from element."""
     return str(element.UniqueId)[:36]
 
 
 def get_guid(element):
-    """Extract guid from given element"""
+    """Extract guid from given element."""
     uid = str(element.UniqueId)
     last_32_bits = int(uid[28:36], 16)
     element_id = int(uid[37:], 16)
@@ -157,7 +157,7 @@ def get_location(element):
         element (DB.Element): source element
 
     Returns:
-        DB.XYZ: X, Y, Z of location point element
+        (DB.XYZ): X, Y, Z of location point element
     """
     locp = element.Location.Point
     return (locp.X, locp.Y, locp.Z)
@@ -1424,7 +1424,7 @@ def get_doors(elements=None, doc=None, room_id=None):
         room_id (DB.ElementId): only doors associated with given room
 
     Returns:
-        list[DB.Element]: room instances
+        (list[DB.Element]): room instances
     """
     doc = doc or DOCS.doc
     all_doors = get_elements_by_categories([DB.BuiltInCategory.OST_Doors],
@@ -1526,13 +1526,13 @@ def get_titleblock_print_settings(tblock, printer_name, doc_psettings):
 
 
 def get_crop_region(view):
-    """Takes crop region of a view
+    """Takes crop region of a view.
 
     Args:
         view (DB.View): view to get crop region from
 
     Returns:
-        list[DB.CurveLoop]: list of curve loops
+        (list[DB.CurveLoop]): list of curve loops
     """
     crsm = view.GetCropRegionShapeManager()
     if HOST_APP.is_newer_than(2015):
@@ -1551,7 +1551,7 @@ def get_crop_region(view):
 
 
 def is_cropable_view(view):
-    """Check if view can be cropped"""
+    """Check if view can be cropped."""
     return not isinstance(view, (DB.ViewSheet, DB.TableView)) \
         and view.ViewType not in (DB.ViewType.Legend, DB.ViewType.DraftingView)
 

--- a/pyrevitlib/pyrevit/revit/db/select.py
+++ b/pyrevitlib/pyrevit/revit/db/select.py
@@ -1,3 +1,4 @@
+"""Selection utilities."""
 from pyrevit.revit.db import query
 
 

--- a/pyrevitlib/pyrevit/revit/db/transaction.py
+++ b/pyrevitlib/pyrevit/revit/db/transaction.py
@@ -1,3 +1,4 @@
+"""Revit transactions facility."""
 from pyrevit import HOST_APP, DOCS, DB
 from pyrevit import coreutils
 from pyrevit.coreutils.logger import get_logger
@@ -16,8 +17,10 @@ DEFAULT_TRANSACTION_NAME = 'pyRevit Transaction'
 
 
 class Transaction():
-    """Simplifies transactions by applying ``Transaction.Start()`` and
-    ``Transaction.Commit()`` before and after the context.
+    """Adds a context manager around Revit Transaction object.
+
+    Runs `Transaction.Start()` and `Transaction.Commit()`
+    before and after the context.
     Automatically rolls back if exception is raised.
 
     >>> with Transaction('Move Wall'):
@@ -97,11 +100,13 @@ class Transaction():
 
 
 class DryTransaction(Transaction):
+    """Wrapper to a transaction that doesn't commit anything (dry-run)."""
     def __exit__(self, exception, exception_value, traceback):
         self._rvtxn.RollBack()
 
 
 class TransactionGroup():
+    """Transactions group with context manager."""
     def __init__(self, name=None, doc=None, assimilate=True, log_errors=True):
         self._rvtxn_grp = \
             DB.TransactionGroup(doc or DOCS.doc,
@@ -151,13 +156,14 @@ class TransactionGroup():
 
 
 def carryout(name, doc=None):
-    """Transaction Decorator
+    """Transaction Decorator.
 
     Decorate any function with ``@doc.carryout('Txn name')``
     and the funciton will run within an Transaction context.
 
     Args:
         name (str): Name of the Transaction
+        doc (Document): Revit document
 
     >>> @doc.carryout('Do Something')
     >>> def set_some_parameter(wall, value):

--- a/pyrevitlib/pyrevit/revit/db/update.py
+++ b/pyrevitlib/pyrevit/revit/db/update.py
@@ -116,7 +116,7 @@ def set_keynote_file(keynote_file, doc=None):
 
 
 def set_crop_region(view, curve_loops):
-    """Sets crop region to a view
+    """Sets crop region to a view.
 
     Args:
         view (DB.View): view to change
@@ -137,7 +137,7 @@ def set_crop_region(view, curve_loops):
 
 
 def set_active_workset(workset_id, doc=None):
-    """Set active workset
+    """Set active workset.
 
     Args:
         workset_id (DB.WorksetId): target workset id

--- a/pyrevitlib/pyrevit/revit/dc3dserver.py
+++ b/pyrevitlib/pyrevit/revit/dc3dserver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""DirectContext3DServer wrapper and utilities"""
+"""DirectContext3DServer wrapper and utilities."""
 
 from collections import namedtuple
 import traceback
@@ -13,7 +13,7 @@ Edge = namedtuple('Edge', ['a', 'b', 'color'])
 Triangle = namedtuple('Triangle', ['a', 'b', 'c', 'normal', 'color'])
 
 class Mesh(object):
-    """Geometry container class to generate DirectContext3DServer buffers"""
+    """Geometry container class to generate DirectContext3DServer buffers."""
     def __init__(self, edges, triangles):
         if not isinstance(edges, list):
             raise ValueError("List of Edges should be provided")
@@ -95,7 +95,7 @@ class Mesh(object):
 
     @classmethod
     def from_boundingbox(cls, bounding_box, color, black_edges = True):
-        """Generates a Mesh object from the input BoundigBoxXYZ
+        """Generates a Mesh object from the input BoundigBoxXYZ.
 
         Args:
             bounding_box (DB.BoundingBoxXYZ): The source object.
@@ -105,7 +105,7 @@ class Mesh(object):
                 Defaults to True.
 
         Returns:
-            Mesh: The resulting Mesh
+            (Mesh): The resulting Mesh
         """
         try:
             # get all untransformed vertices of the boundingbox
@@ -247,7 +247,7 @@ class Mesh(object):
 
 
 class Buffer(object):
-    """Buffer container for DirectContext3DServer"""
+    """Buffer container for DirectContext3DServer."""
     def __init__(self,
                  display_style,
                  vertex_buffer,
@@ -438,7 +438,7 @@ class Buffer(object):
 
 
 class Server(dc3d.IDirectContext3DServer):
-    """A generic DirectContext3dServer interface implementation"""
+    """A generic DirectContext3dServer interface implementation."""
     def __init__(
             self,
             guid=None,
@@ -448,7 +448,7 @@ class Server(dc3d.IDirectContext3DServer):
             vendor_id="pyRevit",
             register=True
     ):
-        """Initalize a DirectContext3DServer instance
+        """Initalize a DirectContext3DServer instance.
 
         Args:
             guid (System.Guid, optional):

--- a/pyrevitlib/pyrevit/revit/events.py
+++ b/pyrevitlib/pyrevit/revit/events.py
@@ -1,3 +1,4 @@
+"""Revit events handler management."""
 #pylint: disable=unused-argument
 from pyrevit import HOST_APP
 from pyrevit import EXEC_PARAMS, DB, UI
@@ -9,6 +10,7 @@ mlogger = get_logger(__name__)
 
 
 class FuncAsEventHandler(UI.IExternalEventHandler):
+    """Turns a function into an event handler."""
     __namespace__ = EXEC_PARAMS.exec_id
 
     def __init__(self, handler_func, purge=True):

--- a/pyrevitlib/pyrevit/revit/features.py
+++ b/pyrevitlib/pyrevit/revit/features.py
@@ -1,4 +1,4 @@
-"""Host application feature detectors"""
+"""Host application feature detectors."""
 #pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
 from pyrevit import DB, UI
 

--- a/pyrevitlib/pyrevit/revit/files.py
+++ b/pyrevitlib/pyrevit/revit/files.py
@@ -48,17 +48,25 @@ def correct_text_encoding(filename):
 
 
 def read_text(filepath):
-    """Safely read text files with Revit encoding"""
+    """Safely read text files with Revit encoding."""
     with codecs.open(filepath, 'r', 'utf_16_le') as text_file:
         return text_file.read()
 
 
 def write_text(filepath, contents):
-    """Safely write text files with Revit encoding"""
+    """Safely write text files with Revit encoding."""
     # if 'utf_16_le' is specified, codecs will not write the BOM
     with codecs.open(filepath, 'w', 'utf_16') as text_file:
         text_file.write(contents)
 
 
 def get_file_info(filepath):
+    """Returns file information.
+
+    Args:
+        filepath (str): file path
+
+    Returns:
+        (RevitModelFile): file information
+    """
     return TargetApps.Revit.RevitModelFile(filepath)

--- a/pyrevitlib/pyrevit/revit/geom.py
+++ b/pyrevitlib/pyrevit/revit/geom.py
@@ -11,7 +11,7 @@ def convert_point_coord_system(rvt_point, rvt_transform):
         rvt_transform (DB.Transform): Revit transform for target coord system
 
     Returns:
-        DB.XYZ: Point coordinates in new coordinate system.
+        (DB.XYZ): Point coordinates in new coordinate system.
     """
     # transform the origin of the old coordinate system in the new
     # coordinate system

--- a/pyrevitlib/pyrevit/revit/report.py
+++ b/pyrevitlib/pyrevit/revit/report.py
@@ -6,6 +6,13 @@ from pyrevit.revit import query
 
 
 def print_revision(rev, prefix='', print_id=True):
+    """Print a revision.
+
+    Args:
+        rev (DB.Revision): revision to output
+        prefix (str, optional): prefix to add to the output text.
+        print_id (bool, optional): whether to print the revision id.
+    """
     outstr = 'SEQ#: {} REV#: {} DATE: {} TYPE: {} DESC: {} ' \
              .format(rev.SequenceNumber,
                      str(query.get_param(rev, 'RevisionNumber', '')).ljust(5),
@@ -18,6 +25,13 @@ def print_revision(rev, prefix='', print_id=True):
 
 
 def print_sheet(sht, prefix='', print_id=True):
+    """Print the name of a sheet.
+
+    Args:
+        sht (DB.ViewSheet): sheet to output
+        prefix (str, optional): prefix to add to the output text.
+        print_id (bool, optional): whether to print the sheet id.
+    """
     outstr = '{}\t{}'.format(
         sht.Parameter[DB.BuiltInParameter.SHEET_NUMBER].AsString(),
         sht.Parameter[DB.BuiltInParameter.SHEET_NAME].AsString()
@@ -28,6 +42,13 @@ def print_sheet(sht, prefix='', print_id=True):
 
 
 def print_view(view, prefix='', print_id=True):
+    """Print the name of a view.
+
+    Args:
+        view (DB.View): view to output
+        prefix (str, optional): prefix to add to the output text.
+        print_id (bool, optional): whether to print the view id. Defaults to True.
+    """
     outstr = query.get_name(view)
     if print_id:
         outstr = PyRevitOutputWindow.linkify(view.Id) + '\t' + outstr

--- a/pyrevitlib/pyrevit/revit/selection.py
+++ b/pyrevitlib/pyrevit/revit/selection.py
@@ -18,11 +18,16 @@ __all__ = ('pick_element', 'pick_element_by_category',
            'get_selection')
 
 
-#pylint: disable=W0703,C0302,C0103
+# pylint: disable=W0703,C0302,C0103
 mlogger = get_logger(__name__)
 
 
 class ElementSelection:
+    """Element selection handler.
+
+    Args:
+        element_list (list[DB.Element]): list of selected elements
+    """
     def __init__(self, element_list=None):
         if element_list is None:
             if HOST_APP.uidoc:
@@ -211,11 +216,33 @@ def _pick_obj(obj_type, message, multiple=False, world=False, selection_filter=N
 
 
 def pick_element(message=''):
+    """Asks the user to pick an element.
+
+    Args:
+        message (str): An optional message to display.
+
+    Returns:
+        (Eleement): element selected by the user.
+    """
     return _pick_obj(UI.Selection.ObjectType.Element,
                      message)
 
 
 def pick_element_by_category(cat_name_or_builtin, message=''):
+    """Returns the element of the specified category picked by the user.
+
+    Args:
+        cat_name_or_builtin (str): name or built-in category of the element
+            to pick.
+        message (str, optional): message to display on selection.
+            Defaults to ''.
+
+    Returns:
+        (Element): picked element.
+
+    Raises:
+        PyRevitException: If no category matches the specified name or builtin.
+    """
     category = query.get_category(cat_name_or_builtin)
     if category:
         pick_filter = PickByCategorySelectionFilter(category.Id)
@@ -228,33 +255,88 @@ def pick_element_by_category(cat_name_or_builtin, message=''):
 
 
 def pick_elementpoint(message='', world=False):
+    """Returns the element point selected by the user.
+
+    Args:
+        message (str, optional): message to display. Defaults to ''.
+        world (bool, optional): whether to use world coordinates.
+
+    Returns:
+        (PointOnElement): The selected point.
+    """
     return _pick_obj(UI.Selection.ObjectType.PointOnElement,
                      message,
                      world=world)
 
 
 def pick_edge(message=''):
+    """Returns the edge selected by the user.
+
+    Args:
+        message (str, optional): message to display. Defaults to ''.
+
+    Returns:
+        (Edge): The selected edge.
+    """
     return _pick_obj(UI.Selection.ObjectType.Edge,
                      message)
 
 
 def pick_face(message=''):
+    """Returns the face selected by the user.
+
+    Args:
+        message (str, optional): message to display. Defaults to ''.
+
+    Returns:
+        (Face): The selected face.
+    """
     return _pick_obj(UI.Selection.ObjectType.Face,
                      message)
 
 
 def pick_linked(message=''):
+    """Returns the linked element selected by the user.
+
+    Args:
+        message (str, optional): message to display. Defaults to ''.
+
+    Returns:
+        (LinkedElement): The selected linked element.
+    """
     return _pick_obj(UI.Selection.ObjectType.LinkedElement,
                      message)
 
 
 def pick_elements(message=''):
+    """Asks the user to pick multiple elements.
+
+    Args:
+        message (str): An optional message to display.
+
+    Returns:
+        (list[Eleement]): elements selected by the user.
+    """
     return _pick_obj(UI.Selection.ObjectType.Element,
                      message,
                      multiple=True)
 
 
 def pick_elements_by_category(cat_name_or_builtin, message=''):
+    """Returns the elements of the specified category picked by the user.
+
+    Args:
+        cat_name_or_builtin (str): name or built-in category of the elements
+            to pick.
+        message (str, optional): message to display on selection.
+            Defaults to ''.
+
+    Returns:
+        (list[Element]): picked elements.
+
+    Raises:
+        PyRevitException: If no category matches the specified name or builtin.
+    """
     category = query.get_category(cat_name_or_builtin)
     if category:
         pick_filter = PickByCategorySelectionFilter(category.Id)
@@ -268,6 +350,16 @@ def pick_elements_by_category(cat_name_or_builtin, message=''):
 
 
 def get_picked_elements(message=''):
+    """Allows the user to pick multple elements, one at a time.
+
+    It keeps asking the user to pick an element until no elements are selected.
+
+    Args:
+        message (str, optional): The message to display. Defaults to ''.
+
+    Yields:
+        (DB.Element): selected element
+    """
     picked_element = True
     while picked_element:
         picked_element = pick_element(message=message)
@@ -277,6 +369,17 @@ def get_picked_elements(message=''):
 
 
 def get_picked_elements_by_category(cat_name_or_builtin, message=''):
+    """Pick elements by category.
+
+    Keeps asking the user to pick an element until no elements are selected.
+
+    Args:
+        cat_name_or_builtin (str): category name or built-in category.
+        message (str, optional): message to display while picking elements.
+
+    Yields:
+        The picked elements from the specified category.
+    """
     picked_element = True
     while picked_element:
         picked_element = pick_element_by_category(cat_name_or_builtin,
@@ -287,30 +390,72 @@ def get_picked_elements_by_category(cat_name_or_builtin, message=''):
 
 
 def pick_elementpoints(message='', world=False):
+    """Selects element points.
+
+    Args:
+        message (str): The message to display when selecting element points.
+        world (bool, optional): Select points in world coordinates.
+
+    Returns:
+        (list[PointOnElement]): selected element points.
+    """
     return _pick_obj(UI.Selection.ObjectType.PointOnElement,
                      message,
                      multiple=True, world=world)
 
 
 def pick_edges(message=''):
+    """Selects edges.
+
+    Args:
+        message (str): The message to display when selecting edges.
+
+    Returns:
+        (list[Edge]): selected edges.
+    """
     return _pick_obj(UI.Selection.ObjectType.Edge,
                      message,
                      multiple=True)
 
 
 def pick_faces(message=''):
+    """Selects faces.
+
+    Args:
+        message (str): The message to display when selecting the faces.
+
+    Returns:
+        (list[Face]): selected faces.
+    """
     return _pick_obj(UI.Selection.ObjectType.Face,
                      message,
                      multiple=True)
 
 
 def pick_linkeds(message=''):
+    """Selects linked elements.
+
+    Args:
+        message (str): The message to display when selecting linked elements.
+
+    Returns:
+        (list[LinkedElement]): selected linked elements.
+    """
     return _pick_obj(UI.Selection.ObjectType.LinkedElement,
                      message,
                      multiple=True)
 
 
 def pick_point(message=''):
+    """Pick a point from the user interface.
+
+    Args:
+        message (str): A message to display when prompting for the point.
+
+    Returns:
+        (tuple or None): A tuple representing the picked point as (x, y, z)
+            coordinates, or None if no point was picked or an error occurred.
+    """
     try:
         return HOST_APP.uidoc.Selection.PickPoint(message)
     except Exception:
@@ -318,6 +463,17 @@ def pick_point(message=''):
 
 
 def pick_rectangle(message='', pick_filter=None):
+    """Picks elements from the user interface by specifying a rectangular area.
+
+    Args:
+        message (str, optional): A custom message to display when prompting
+            the user to pick elements. Default is an empty string.
+        pick_filter (object, optional): An object specifying the filter to apply
+            when picking elements. Default is None.
+
+    Returns:
+        (list[DB.ElementId]): The selected elements.
+    """
     if pick_filter:
         return HOST_APP.uidoc.Selection.PickElementsByRectangle(pick_filter,
                                                                 message)
@@ -326,6 +482,11 @@ def pick_rectangle(message='', pick_filter=None):
 
 
 def get_selection_category_set():
+    """Returns a CategorySet with the categories of the selected elements.
+
+    Returns:
+        (CategorySet): categories of the selected elements.
+    """
     selection = ElementSelection()
     cset = DB.CategorySet()
     for element in selection:
@@ -334,4 +495,9 @@ def get_selection_category_set():
 
 
 def get_selection():
+    """Returns the current selected items.
+
+    Returns:
+        (ElementSelection): the current selected items
+    """
     return ElementSelection()

--- a/pyrevitlib/pyrevit/revit/selection.py
+++ b/pyrevitlib/pyrevit/revit/selection.py
@@ -1,3 +1,4 @@
+"""Elements selection utilities."""
 from pyrevit import HOST_APP, DOCS, PyRevitException
 from pyrevit import framework, DB, UI
 from pyrevit.coreutils.logger import get_logger

--- a/pyrevitlib/pyrevit/revit/serverutils.py
+++ b/pyrevitlib/pyrevit/revit/serverutils.py
@@ -28,7 +28,7 @@ def get_server_path(doc, path_dict):
         doc (Document): revit document object
         path_dict (dict): dict of RSN paths and their directory paths
 
-    Example:
+    Examples:
         >>> rsn_paths = {'RSN://SERVERNAME': '//servername/filestore'}
         >>> get_server_path(doc, rsn_paths)
         ... "//servername/filestore/path/to/model.rvt"
@@ -48,9 +48,9 @@ def get_model_sync_history(server_path):
         server_path (str): directory path of revit server filestore
 
     Returns:
-        :obj:`list`(``SyncHistory``): list of SyncHistory instances
+        (list[SyncHistory]): list of SyncHistory instances
 
-    Example:
+    Examples:
         >>> get_model_sync_history("//servername/path/to/model.rvt")
         ... [SyncHistory(index=498, userid="user",
         ...              timestamp="2017-12-13 19:56:20")]

--- a/pyrevitlib/pyrevit/revit/tabs.py
+++ b/pyrevitlib/pyrevit/revit/tabs.py
@@ -1,4 +1,4 @@
-"""Document colorizer python API"""
+"""Document colorizer python API."""
 #pylint: disable=import-error,invalid-name,broad-except
 #pylint: disable=no-member
 from pyrevit import HOST_APP
@@ -9,14 +9,14 @@ from pyrevit.coreutils import envvars
 
 
 def hex_to_brush(color_hex):
-    """Convert hex color to WPF brush"""
+    """Convert hex color to WPF brush."""
     return Media.SolidColorBrush(
         Media.ColorConverter.ConvertFromString(color_hex)
     )
 
 
 def hex_from_brush(solid_brush):
-    """Convert WPF brush to hex color"""
+    """Convert WPF brush to hex color."""
     color = solid_brush.Color
     color_hex = ''.join(
         '{:02X}'.format(int(x)) for x in
@@ -97,7 +97,7 @@ def _set_family_tabstyle(tabcfgs, theme):
 
 
 def get_tabcoloring_theme(usercfg):
-    """Get tab coloring theme from settings"""
+    """Get tab coloring theme from settings."""
     tabcfgs = _get_tabcoloring_cfgs(usercfg)
 
     theme = types.TabColoringTheme()
@@ -112,13 +112,13 @@ def get_tabcoloring_theme(usercfg):
 
 
 def reset_tab_ordercolors(usercfg, theme):
-    """Reset tab order colors to internal default"""
+    """Reset tab order colors to internal default."""
     tabcfgs = _get_tabcoloring_cfgs(usercfg)
     theme.TabOrderRules = _get_tab_orderrules(tabcfgs, default=True)
 
 
 def set_tabcoloring_theme(usercfg, theme):
-    """set tab coloring theme in settings"""
+    """Set tab coloring theme in settings."""
     tabcfgs = _get_tabcoloring_cfgs(usercfg)
 
     _set_sort_colorize_docs(tabcfgs, theme)
@@ -130,30 +130,30 @@ def set_tabcoloring_theme(usercfg, theme):
 
 
 def get_tab_orderrule(theme, index):
-    """Get coloring rule from active theme, at index"""
+    """Get coloring rule from active theme, at index."""
     return hex_from_brush(theme.TabOrderRules[index].Brush)
 
 
 def add_tab_orderrule(theme, color):
-    """Add coloring rule to active theme"""
+    """Add coloring rule to active theme."""
     theme.TabOrderRules.Add(
         types.TabColoringRule(hex_to_brush(color))
         )
 
 
 def remove_tab_orderrule(theme, index):
-    """Remove coloring rule at index, from active theme"""
+    """Remove coloring rule at index, from active theme."""
     theme.TabOrderRules.RemoveAt(index)
 
 
 def update_tab_orderrule(theme, index, color):
-    """Update coloring rule at index, on active theme"""
+    """Update coloring rule at index, on active theme."""
     tor = theme.TabOrderRules[index]
     tor.Brush = hex_to_brush(color)
 
 
 def get_tab_filterrule(theme, index):
-    """Get coloring filter rule from active theme, at index"""
+    """Get coloring filter rule from active theme, at index."""
     tfr = theme.TabFilterRules[index]
     color = tfr.Brush.Color
     color_hex = ''.join(
@@ -164,18 +164,18 @@ def get_tab_filterrule(theme, index):
 
 
 def add_tab_filterrule(theme, color, title_filter):
-    """Add coloring filter rule to active theme"""
+    """Add coloring filter rule to active theme."""
     fc = types.TabColoringRule(hex_to_brush(color), title_filter)
     theme.TabFilterRules.Add(fc)
 
 
 def remove_tab_filterrule(theme, index):
-    """Remove coloring filter rule at index, from active theme"""
+    """Remove coloring filter rule at index, from active theme."""
     theme.TabFilterRules.RemoveAt(index)
 
 
 def update_tab_filterrule(theme, index, color=None, title_filter=None):
-    """Update coloring filter rule at index, on active theme"""
+    """Update coloring filter rule at index, on active theme."""
     tfr = theme.TabFilterRules[index]
     if color:
         tfr.Brush = hex_to_brush(color)
@@ -184,33 +184,33 @@ def update_tab_filterrule(theme, index, color=None, title_filter=None):
 
 
 def update_tabstyle(theme, tab_style):
-    """Update current tab style"""
+    """Update current tab style."""
     for ts in types.TabColoringTheme.AvailableStyles:
         if ts.Name == tab_style.Name:
             theme.TabStyle = ts
 
 
 def update_family_tabstyle(theme, tab_style):
-    """Update current family tab style"""
+    """Update current family tab style."""
     for ts in types.TabColoringTheme.AvailableStyles:
         if ts.Name == tab_style.Name:
             theme.FamilyTabStyle = ts
 
 
 def get_doc_colorizer_state():
-    """Get state of document colorizer"""
+    """Get state of document colorizer."""
     return types.DocumentTabEventUtils.IsUpdatingDocumentTabs
 
 
 def get_styled_slots():
-    """Get list of current styling slots"""
+    """Get list of current styling slots."""
     active_theme = types.DocumentTabEventUtils.TabColoringTheme
     if active_theme:
         return list(active_theme.StyledDocuments)
 
 
 def toggle_doc_colorizer():
-    """Toggle state of document colorizer"""
+    """Toggle state of document colorizer."""
     if types.DocumentTabEventUtils.IsUpdatingDocumentTabs:
         types.DocumentTabEventUtils.StopGroupingDocumentTabs()
     else:
@@ -219,12 +219,12 @@ def toggle_doc_colorizer():
 
 
 def reset_doc_colorizer():
-    """Reset document colorizer"""
+    """Reset document colorizer."""
     types.DocumentTabEventUtils.ResetGroupingDocumentTabs()
 
 
 def init_doc_colorizer(usercfg):
-    """Initialize document colorizer from settings"""
+    """Initialize document colorizer from settings."""
     uiapp = HOST_APP.uiapp
     if HOST_APP.is_newer_than(2018):
         current_tabcolorizer = \

--- a/pyrevitlib/pyrevit/revit/ui.py
+++ b/pyrevitlib/pyrevit/revit/ui.py
@@ -15,10 +15,21 @@ from pyrevit.coreutils import envvars
 
 
 def get_mainwindow_hwnd():
+    """
+    Get the handle of the main window.
+
+    Returns:
+        (intptr): The handle of the main window.
+    """
     return HOST_APP.proc_window
 
 
 def get_mainwindow():
+    """Get the main window of the application.
+
+    Returns:
+        The root visual of the main window.
+    """
     try:
         hwnd_source = Interop.HwndSource.FromHwnd(HOST_APP.proc_window)
         return hwnd_source.RootVisual
@@ -27,6 +38,11 @@ def get_mainwindow():
 
 
 def get_statusbar_hwnd():
+    """Retrieves the handle of the status bar control belonging to the main window.
+
+    Returns:
+        (IntPtr): The handle of the status bar control.
+    """
     return Common.User32.FindWindowEx(
         get_mainwindow_hwnd(),
         IntPtr.Zero,
@@ -35,6 +51,14 @@ def get_statusbar_hwnd():
 
 
 def set_statusbar_text(text):
+    """Sets the text of the status bar.
+
+    Parameters:
+        text (str): The text to be displayed in the status bar.
+
+    Returns:
+        bool: True if the text was successfully set, False otherwise.
+    """
     status_bar_ptr = get_statusbar_hwnd()
 
     if status_bar_ptr != IntPtr.Zero:
@@ -45,15 +69,40 @@ def set_statusbar_text(text):
 
 
 def get_window_rectangle():
+    """Get the rectangle coordinates of the main window.
+
+    Returns:
+        (Tuple[int, int, int, int]): The left, top, right, and bottom 
+            coordinates of the window rectangle.
+    """
     return Common.User32.GetWindowRect(get_mainwindow_hwnd())
 
 
 def is_infocenter_visible():
+    """
+    Check if the InfoCenter toolbar is visible.
+
+    Returns:
+        (bool): True if the InfoCenter toolbar is visible, False otherwise.
+    """
     return ad.ComponentManager.InfoCenterToolBar.Visibility == \
         Windows.Visibility.Visible
 
 
 def toggle_infocenter():
+    """
+    Toggles the visibility of the InfoCenter toolbar.
+
+    This function retrieves the current visibility state of the InfoCenter 
+    toolbar and toggles it to the opposite state.
+    If the toolbar is currently collapsed, it will be set to visible,
+    and if it is currently visible, it will be set to collapsed.
+    The function then returns the visibility state of the InfoCenter toolbar
+    after the toggle operation.
+
+    Returns:
+        (bool): True if the InfoCenter toolbar is visible, False otherwise.
+    """
     current_state = ad.ComponentManager.InfoCenterToolBar.Visibility
     is_hidden = (current_state == Windows.Visibility.Collapsed)
     ad.ComponentManager.InfoCenterToolBar.Visibility = \
@@ -63,6 +112,11 @@ def toggle_infocenter():
 
 
 def get_ribbon_roottype():
+    """Get the type of the ribbon root.
+
+    Returns:
+        (type): type of the ribbon root
+    """
     ap_assm = clr.GetClrType(ap.Windows.RibbonTabList).Assembly
     for apt in ap_assm.GetTypes():
         if 'PanelSetListView' in apt.Name:

--- a/pyrevitlib/pyrevit/revit/ui.py
+++ b/pyrevitlib/pyrevit/revit/ui.py
@@ -1,3 +1,4 @@
+"""UI functions."""
 #pylint: disable=import-error,invalid-name,broad-except
 from pyrevit import HOST_APP
 from pyrevit.framework import clr

--- a/pyrevitlib/pyrevit/revit/ui.py
+++ b/pyrevitlib/pyrevit/revit/ui.py
@@ -15,8 +15,7 @@ from pyrevit.coreutils import envvars
 
 
 def get_mainwindow_hwnd():
-    """
-    Get the handle of the main window.
+    """Get the handle of the main window.
 
     Returns:
         (intptr): The handle of the main window.
@@ -79,8 +78,7 @@ def get_window_rectangle():
 
 
 def is_infocenter_visible():
-    """
-    Check if the InfoCenter toolbar is visible.
+    """Check if the InfoCenter toolbar is visible.
 
     Returns:
         (bool): True if the InfoCenter toolbar is visible, False otherwise.
@@ -90,8 +88,7 @@ def is_infocenter_visible():
 
 
 def toggle_infocenter():
-    """
-    Toggles the visibility of the InfoCenter toolbar.
+    """Toggles the visibility of the InfoCenter toolbar.
 
     This function retrieves the current visibility state of the InfoCenter 
     toolbar and toggles it to the opposite state.

--- a/pyrevitlib/pyrevit/revit/units.py
+++ b/pyrevitlib/pyrevit/revit/units.py
@@ -12,7 +12,7 @@ def format_area(area_value, doc=None):
         doc (DB.Document, optional): Revit document, defaults to current
 
     Returns:
-        str: formatted value
+        (str): formatted value
     """
     doc = doc or DOCS.doc
     if HOST_APP.is_newer_than(2021):
@@ -36,7 +36,7 @@ def format_slope(slope_value, doc=None):
         doc (DB.Document, optional): Revit document, defaults to current
 
     Returns:
-        str: formatted value
+        (str): formatted value
     """
     doc = doc or DOCS.doc
     if HOST_APP.is_newer_than(2021):
@@ -53,7 +53,7 @@ def format_slope(slope_value, doc=None):
 
 
 def _create_view_plane(view):
-    """Get a plane parallel to a view
+    """Get a plane parallel to a view.
 
     Args:
         view (DB.View): view to align plane
@@ -66,14 +66,14 @@ def _create_view_plane(view):
 
 
 def project_to_viewport(xyz, view):
-    """Project a point to viewport coordinates
+    """Project a point to viewport coordinates.
 
     Args:
         xyz (DB.XYZ): point to project
         view (DB.View): target view
 
     Returns:
-        DB.UV: [description]
+        (DB.UV): [description]
     """
     plane = _create_view_plane(view)
     uv, _ = plane.Project(xyz)
@@ -88,7 +88,7 @@ def project_to_world(uv, view):
         view (DB.View): view to get coordinates from
 
     Returns:
-        DB.XYZ: point in world coordinates
+        (DB.XYZ): point in world coordinates
     """
     plane = _create_view_plane(view)
     trf = DB.Transform.Identity
@@ -100,6 +100,14 @@ def project_to_world(uv, view):
 
 
 def get_spec_name(forge_id):
+    """Returns the measurable spec name for the given unit id.
+
+    Args:
+        forge_id (DB.ForgeTypeId): Unit id
+
+    Returns:
+        (str): Spec name
+    """
     if HOST_APP.is_newer_than(2021) \
             and DB.UnitUtils.IsMeasurableSpec(forge_id):
         return DB.UnitUtils.GetTypeCatalogStringForSpec(forge_id)
@@ -107,6 +115,14 @@ def get_spec_name(forge_id):
 
 
 def get_unit_name(forge_id):
+    """Returns the unit name for the given unit id.
+
+    Args:
+        forge_id (DB.ForgeTypeId): Unit id
+
+    Returns:
+        (str): Unit name
+    """
     if HOST_APP.is_newer_than(2021) \
             and DB.UnitUtils.IsUnit(forge_id):
         return DB.UnitUtils.GetTypeCatalogStringForUnit(forge_id)

--- a/pyrevitlib/pyrevit/routes/__init__.py
+++ b/pyrevitlib/pyrevit/routes/__init__.py
@@ -6,12 +6,12 @@ from pyrevit.routes.server import *
 
 
 class API(object):
-    """API root object
+    """API root object.
 
     Args:
         name (str): URL-safe unique root name of the API
 
-    Example:
+    Examples:
         >>> from pyrevit import routes
         >>> api = routes.API("pyrevit-core")
         >>> @api.route('/sessions/', methods=['POST'])
@@ -38,5 +38,5 @@ class API(object):
 
 
 def active_routes_api():
-    """Activates routes API"""
+    """Activates routes API."""
     from pyrevit.routes import api

--- a/pyrevitlib/pyrevit/routes/api.py
+++ b/pyrevitlib/pyrevit/routes/api.py
@@ -1,4 +1,4 @@
-"""Builtin routes API
+"""Builtin routes API.
 
 This module also provides the API object to be used by third-party
 api developers to define new apis
@@ -24,7 +24,7 @@ routes_api = routes.API('routes')
 # GET /status
 @routes_api.route('/status', methods=['GET'])
 def get_status():
-    """Get server status"""
+    """Get server status."""
     return {
         "host": HOST_APP.pretty_name,
         "username": HOST_APP.username,
@@ -34,13 +34,13 @@ def get_status():
 # GET /sisters
 @routes_api.route('/sisters', methods=['GET'])
 def get_sisters():
-    """Get other servers running on the same machine"""
+    """Get other servers running on the same machine."""
     return [x.get_cache_data() for x in serverinfo.get_registered_servers()]
 
 
 # GET /sisters/<int:year>
 @routes_api.route('/sisters/<int:version>', methods=['GET'])
 def get_sisters_by_year(version):
-    """Get servers of specific version, running on the same machine"""
+    """Get servers of specific version, running on the same machine."""
     return [x.get_cache_data() for x in serverinfo.get_registered_servers()
             if int(x.version) == version]

--- a/pyrevitlib/pyrevit/routes/server/__init__.py
+++ b/pyrevitlib/pyrevit/routes/server/__init__.py
@@ -30,7 +30,7 @@ mlogger = get_logger(__name__)
 
 
 def init():
-    """Initialize routes. Reset all registered routes and shutdown servers"""
+    """Initialize routes. Reset all registered routes and shutdown servers."""
     # clear all routes
     router.reset_routes()
     # stop existing server
@@ -38,7 +38,7 @@ def init():
 
 
 def activate_server():
-    """Activate routes server for this host instance"""
+    """Activate routes server for this host instance."""
     routes_server = envvars.get_pyrevit_env_var(envvars.ROUTES_SERVER)
     if not routes_server:
         try:
@@ -57,7 +57,7 @@ def activate_server():
 
 
 def deactivate_server():
-    """Deactivate the active routes server for this host instance"""
+    """Deactivate the active routes server for this host instance."""
     routes_server = envvars.get_pyrevit_env_var(envvars.ROUTES_SERVER)
     if routes_server:
         try:
@@ -69,12 +69,12 @@ def deactivate_server():
 
 
 def get_active_server():
-    """Get active routes server for this host instance"""
+    """Get active routes server for this host instance."""
     return envvars.get_pyrevit_env_var(envvars.ROUTES_SERVER)
 
 
 def make_response(data, status=OK, headers=None):
-    """Create Reponse object with"""
+    """Create Reponse object with."""
     res = Response(status=status, data=data)
     for key, value in (headers or {}).items():
         res.add_header(key, value)
@@ -82,7 +82,7 @@ def make_response(data, status=OK, headers=None):
 
 
 def get_routes(api_name):
-    """Get all registered routes for given API name
+    """Get all registered routes for given API name.
 
     Args:
         api_name (str): unique name of the api
@@ -91,7 +91,7 @@ def get_routes(api_name):
 
 
 def add_route(api_name, pattern, method, handler_func):
-    """Add new route for given API name
+    """Add new route for given API name.
 
     Args:
         api_name (str): unique name of the api
@@ -103,7 +103,7 @@ def add_route(api_name, pattern, method, handler_func):
 
 
 def remove_route(api_name, pattern, method):
-    """Remove previously registered route for given API name
+    """Remove previously registered route for given API name.
 
     Args:
         api_name (str): unique name of the api

--- a/pyrevitlib/pyrevit/routes/server/base.py
+++ b/pyrevitlib/pyrevit/routes/server/base.py
@@ -1,4 +1,4 @@
-"""Utility functions and types"""
+"""Utility functions and types."""
 #pylint: disable=import-error,invalid-name,broad-except
 #pylint: disable=unused-import,useless-object-inheritance
 from pyrevit.compat import IRONPY340, PY3
@@ -18,7 +18,7 @@ DEFAULT_SOURCE = "pyrevit.routes"
 
 
 class Request(object):
-    """Request wrapper object"""
+    """Request wrapper object."""
     def __init__(self, path='/', method='GET', data=None, params=None):
         self.path = path
         self.method = method
@@ -28,28 +28,28 @@ class Request(object):
 
     @property
     def headers(self):
-        """Request headers dict"""
+        """Request headers dict."""
         return self._headers
 
     @property
     def params(self):
-        """Request parameters"""
+        """Request parameters."""
         return self._params
 
     @property
     def callback_url(self):
-        """Request callback url, if provided in payload"""
+        """Request callback url, if provided in payload."""
         if isinstance(self.data, dict):
             return self.data.get("callbackUrl", None)
         return None
 
     def add_header(self, key, value):
-        """Add new header key:value"""
+        """Add new header key:value."""
         self._headers[key] = value
 
 
 class Response(object):
-    """Response wrapper object"""
+    """Response wrapper object."""
     def __init__(self, status=200, data=None, headers=None):
         self.status = status
         self.data = data
@@ -57,9 +57,9 @@ class Response(object):
 
     @property
     def headers(self):
-        """Response headers dict"""
+        """Response headers dict."""
         return self._headers
 
     def add_header(self, key, value):
-        """Add new header key:value"""
+        """Add new header key:value."""
         self._headers[key] = value

--- a/pyrevitlib/pyrevit/routes/server/exceptions.py
+++ b/pyrevitlib/pyrevit/routes/server/exceptions.py
@@ -1,10 +1,10 @@
-"""Route custom exceptions"""
+"""Route custom exceptions."""
 #pylint: disable=import-error,invalid-name,broad-except
 from pyrevit import HOST_APP
 
 
 class ServerException(Exception):
-    """Server error"""
+    """Server error."""
     def __init__(self, message, exception_type, exception_traceback):
         message = "Server error (%s): %s\n%s\n" % (
             exception_type.__name__ if exception_type else "",
@@ -16,7 +16,7 @@ class ServerException(Exception):
 
 
 class APINotDefinedException(Exception):
-    """API is not defined exception"""
+    """API is not defined exception."""
     def __init__(self, api_name):
         message = "API is not defined: \"%s\"" % api_name
         super(APINotDefinedException, self).__init__(message)
@@ -24,7 +24,7 @@ class APINotDefinedException(Exception):
 
 
 class RouteHandlerNotDefinedException(Exception):
-    """Route does not exits exception"""
+    """Route does not exits exception."""
     def __init__(self, api_name, route, method):
         message = \
         "Route does not exits: \"%s %s%s\"" % (method, api_name, route)
@@ -33,7 +33,7 @@ class RouteHandlerNotDefinedException(Exception):
 
 
 class RouteHandlerDeniedException(Exception):
-    """Route handler was denied by host"""
+    """Route handler was denied by host."""
     def __init__(self, request):
         message = "Route handler was denied by host: \"%s\"" % request.route
         super(RouteHandlerDeniedException, self).__init__(message)
@@ -42,7 +42,7 @@ class RouteHandlerDeniedException(Exception):
 
 
 class RouteHandlerTimedOutException(Exception):
-    """Route handler was timed out by host"""
+    """Route handler was timed out by host."""
     def __init__(self, request):
         message = "Route handler was timed out by host: \"%s\"" % request.route
         super(RouteHandlerTimedOutException, self).__init__(message)
@@ -51,7 +51,7 @@ class RouteHandlerTimedOutException(Exception):
 
 
 class RouteHandlerIsNotCallableException(Exception):
-    """Route handler is not callable"""
+    """Route handler is not callable."""
     def __init__(self, hndlr_name):
         message = "Route handler is not callable: \"%s\"" % hndlr_name
         super(RouteHandlerIsNotCallableException, self).__init__(message)
@@ -60,7 +60,7 @@ class RouteHandlerIsNotCallableException(Exception):
 
 
 class RouteHandlerExecException(Exception):
-    """Route handler exception"""
+    """Route handler exception."""
     def __init__(self, message):
         message = "Route exception in Execute: %s" % message
         super(RouteHandlerExecException, self).__init__(message)
@@ -69,7 +69,7 @@ class RouteHandlerExecException(Exception):
 
 
 class RouteHandlerException(Exception):
-    """Route handler exception"""
+    """Route handler exception."""
     def __init__(self,
                  message, exception_type, exception_traceback,
                  clsx_message, clsx_source, clsx_stacktrace, clsx_targetsite):

--- a/pyrevitlib/pyrevit/routes/server/handler.py
+++ b/pyrevitlib/pyrevit/routes/server/handler.py
@@ -1,4 +1,4 @@
-"""Revit-aware event handler"""
+"""Revit-aware event handler."""
 #pylint: disable=import-error,invalid-name,broad-except
 import sys
 import traceback
@@ -39,25 +39,25 @@ class RequestHandler(UI.IExternalEventHandler):
 
     @property
     def request(self):
-        """Get registered request"""
+        """Get registered request."""
         with self._lock: #pylint: disable=not-context-manager
             return self._request
 
     @request.setter
     def request(self, request):
-        """Set a new request to be passed to handler when event is raised"""
+        """Set a new request to be passed to handler when event is raised."""
         with self._lock:
             self._request = request
 
     @property
     def handler(self):
-        """Get registered handler"""
+        """Get registered handler."""
         with self._lock: #pylint: disable=not-context-manager
             return self._handler
 
     @handler.setter
     def handler(self, handler):
-        """Set a new handler to be executed when event is raised"""
+        """Set a new handler to be executed when event is raised."""
         if handler and callable(handler):
             with self._lock:
                 self._handler = handler
@@ -66,13 +66,13 @@ class RequestHandler(UI.IExternalEventHandler):
 
     @property
     def response(self):
-        """Get registered response"""
+        """Get registered response."""
         with self._lock: #pylint: disable=not-context-manager
             return self._response
 
     @property
     def done(self):
-        """Check if execution of handler is completed and response is set"""
+        """Check if execution of handler is completed and response is set."""
         with self._lock: #pylint: disable=not-context-manager
             return self._done
 
@@ -82,13 +82,13 @@ class RequestHandler(UI.IExternalEventHandler):
             self._done = True
 
     def reset(self):
-        """Reset internals for new execution"""
+        """Reset internals for new execution."""
         with self._lock: #pylint: disable=not-context-manager
             self._response = None
             self._done = False
 
     def join(self):
-        """Allow other threads to call this method and wait for completion"""
+        """Allow other threads to call this method and wait for completion."""
         # wait until handler signals completion
         while True:
             with self._lock:
@@ -97,7 +97,7 @@ class RequestHandler(UI.IExternalEventHandler):
 
     @staticmethod
     def run_handler(handler, kwargs):
-        """Execute the handler function and return base.Response"""
+        """Execute the handler function and return base.Response."""
         response = None
         kwargs = kwargs or {}
         if handler and callable(handler):
@@ -132,7 +132,7 @@ class RequestHandler(UI.IExternalEventHandler):
 
     @staticmethod
     def make_callback(callback_url, response):
-        """Prepare request from base.Response and submit to callback url"""
+        """Prepare request from base.Response and submit to callback url."""
         # parse response object
         r = RequestHandler.parse_response(response)
         # prepare and submit request
@@ -140,7 +140,7 @@ class RequestHandler(UI.IExternalEventHandler):
 
     @staticmethod
     def wants_api_context(handler):
-        """Check if handler needs host api context"""
+        """Check if handler needs host api context."""
         return modutils.has_any_arguments(
             function_obj=handler,
             arg_name_list=[
@@ -151,7 +151,7 @@ class RequestHandler(UI.IExternalEventHandler):
 
     @staticmethod
     def prepare_handler_kwargs(request, handler, uiapp=None):
-        """Prepare call arguments for handler function"""
+        """Prepare call arguments for handler function."""
         uidoc = doc = None
         if uiapp:
             uidoc = getattr(uiapp, 'ActiveUIDocument', None)
@@ -172,7 +172,7 @@ class RequestHandler(UI.IExternalEventHandler):
 
     @staticmethod
     def parse_response(response):
-        """Parse any given response data and return Response object"""
+        """Parse any given response data and return Response object."""
         status = base.OK
         headers = {}
         data = None

--- a/pyrevitlib/pyrevit/routes/server/router.py
+++ b/pyrevitlib/pyrevit/routes/server/router.py
@@ -1,4 +1,4 @@
-"""Route dictionary"""
+"""Route dictionary."""
 #pylint: disable=import-error,invalid-name,broad-except
 import re
 import uuid
@@ -62,7 +62,7 @@ def _cast_value(cast, val):
 
 
 def route_match(route, path, method):
-    """Test if route pattern matches given request path"""
+    """Test if route pattern matches given request path."""
     finder_pattern = _make_finder_pattern(route.pattern)
     # if same method and matching pattern
     if route.method == method \
@@ -91,9 +91,9 @@ def route_match(route, path, method):
 
 
 def extract_route_params(route_pattern, request_path):
-    """Extracts route params from request path based on pattern
+    """Extracts route params from request path based on pattern.
 
-    Example:
+    Examples:
         >>> extract_route_params('api/v1/posts/<int:id>', 'api/v1/posts/12')
         ... [<RouteParam key:id value=12>]
     """
@@ -118,15 +118,19 @@ def extract_route_params(route_pattern, request_path):
 
 
 def reset_routes():
-    """Reset registered APIs and routes"""
+    """Reset registered APIs and routes."""
     envvars.set_pyrevit_env_var(envvars.ROUTES_ROUTES, {})
 
 
 def get_routes(api_name):
-    """Get all registered routes for given API name
+    """Get all registered routes for given API name.
 
     Args:
         api_name (str): unique name of the api
+        
+
+    Returns:
+        (dict[str, Caller[]]): registered routes
     """
     if api_name is None:
         raise Exception("API name can not be None.")
@@ -145,7 +149,7 @@ def get_routes(api_name):
 
 
 def get_route_handler(api_name, path, method):
-    """Return registered handler for given API, path, and method
+    """Return registered handler for given API, path, and method.
 
     Args:
         api_name (str): unique name of the api
@@ -153,7 +157,8 @@ def get_route_handler(api_name, path, method):
         method (str): method name
 
     Returns:
-        function: registered route handler function
+        api_route (Route): API route
+        route_handler (Caller): registered route handler function
     """
     for api_route, route_handler in get_routes(api_name).items():
         if route_match(api_route, path, method):
@@ -162,7 +167,7 @@ def get_route_handler(api_name, path, method):
 
 
 def add_route(api_name, pattern, method, handler_func):
-    """Add new route for given API name
+    """Add new route for given API name.
 
     Args:
         api_name (str): unique name of the api
@@ -179,7 +184,7 @@ def add_route(api_name, pattern, method, handler_func):
 
 
 def remove_route(api_name, pattern, method):
-    """Remove prevriously defined route for given API name
+    """Remove prevriously defined route for given API name.
 
     Args:
         api_name (str): unique name of the api

--- a/pyrevitlib/pyrevit/routes/server/server.py
+++ b/pyrevitlib/pyrevit/routes/server/server.py
@@ -18,7 +18,7 @@ from pyrevit.routes.server import handler
 from pyrevit.routes.server import router
 
 if PY3:
-    from http.server import BaseHTTPRequestHandler,HTTPServer
+    from http.server import BaseHTTPRequestHandler, HTTPServer
     from socketserver import ThreadingMixIn
 else:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
@@ -37,6 +37,7 @@ EVENT_HNDLR = UI.ExternalEvent.Create(REQUEST_HNDLR)
 
 
 class HttpRequestHandler(BaseHTTPRequestHandler):
+    """HTTP Requests Handler."""
     def _parse_api_path(self):
         url_parts = urlparse(self.path)
         if url_parts:
@@ -228,6 +229,7 @@ class HttpRequestHandler(BaseHTTPRequestHandler):
 
 
 class ThreadedHttpServer(ThreadingMixIn, HTTPServer):
+    """Threaded HTTP server."""
     allow_reuse_address = True
 
     def shutdown(self):
@@ -236,6 +238,14 @@ class ThreadedHttpServer(ThreadingMixIn, HTTPServer):
 
 
 class RoutesServer(object):
+    """Route server thread handler.
+
+    It runs an HTTP server on the given host and port.
+
+    Args:
+        host (str): host
+        port (int): port
+    """
     def __init__(self, host, port):
         self.server = ThreadedHttpServer((host, port), HttpRequestHandler)
         self.host = host

--- a/pyrevitlib/pyrevit/routes/server/serverinfo.py
+++ b/pyrevitlib/pyrevit/routes/server/serverinfo.py
@@ -1,4 +1,4 @@
-"""Defines the basic server management api"""
+"""Defines the basic server management api."""
 #pylint: disable=invalid-name,broad-except,useless-object-inheritance
 #pylint: disable=too-few-public-methods,too-many-arguments
 import os.path as op
@@ -19,7 +19,7 @@ mlogger = get_logger(__name__)
 
 
 class RoutesServerInfo(object):
-    """Routes server info"""
+    """Routes server info."""
     def __init__(self,
                  host, version, process_id,
                  server_host, server_port):
@@ -32,7 +32,7 @@ class RoutesServerInfo(object):
         self.server_port = server_port
 
     def get_cache_data(self):
-        """Get json string of this instance"""
+        """Get json string of this instance."""
         data_dict = OrderedDict()
         for key in sorted(self.__dict__.keys()):
             data_dict[key] = self.__dict__[key]
@@ -100,16 +100,16 @@ def _get_new_serverinfo(data_file):
 
 
 def get_registered_servers():
-    """Get all registered servers on this machine
+    """Get all registered servers on this machine.
 
     Returns:
-        list[RoutesServerInfo]: list of registered servers
+        (list[RoutesServerInfo]): list of registered servers
     """
     return _get_all_serverinfo()
 
 
 def register():
-    """Register host:port for this host instance"""
+    """Register host:port for this host instance."""
     data_file = _get_host_serverinfo_file()
     if op.exists(data_file):
         return _read_serverinfo(data_file)
@@ -118,7 +118,7 @@ def register():
 
 
 def unregister():
-    """Remove registered server host:port for this host instance"""
+    """Remove registered server host:port for this host instance."""
     data_file = _get_host_serverinfo_file()
     if op.exists(data_file):
         appdata.garbage_data_file(data_file)

--- a/pyrevitlib/pyrevit/runtime/__init__.py
+++ b/pyrevitlib/pyrevit/runtime/__init__.py
@@ -239,6 +239,11 @@ def _get_reference_file(ref_name):
 
 
 def get_references():
+    """Get list of all referenced assemblies.
+
+    Returns:
+        (list): referenced assemblies
+    """
     # 'IronRuby', 'IronRuby.Libraries',
     ref_list = [
         # system stuff
@@ -324,6 +329,16 @@ def _get_runtime_asm():
 
 
 def create_ipyengine_configs(clean=False, full_frame=False, persistent=False):
+    """Return the configuration for ipython engine.
+
+    Args:
+        clean (bool, optional): Engine should be clean. Defaults to False.
+        full_frame (bool, optional): Engine shoul be full frame. Defaults to False.
+        persistent (bool, optional): Engine should persist. Defaults to False.
+
+    Returns:
+        (str): Configuration
+    """
     return json.dumps({
         exts.MDATA_ENGINE_CLEAN: clean,
         exts.MDATA_ENGINE_FULLFRAME: full_frame,
@@ -339,8 +354,8 @@ def create_ext_command_attrs():
     ``RegenerationOption.Manual`` and ``TransactionMode.Manual``
 
     Returns:
-        list: list of :obj:`CustomAttributeBuilder` for
-        :obj:`RegenerationOption` and :obj:`TransactionMode` attributes.
+        (list[CustomAttributeBuilder]): object for `RegenerationOption` 
+            and `TransactionMode` attributes.
     """
     regen_const_info = \
         framework.clr.GetClrType(api.Attributes.RegenerationAttribute) \
@@ -387,12 +402,12 @@ def create_type(modulebuilder, type_class, class_name, custom_attr_list, *args):
         type_class (type): source dotnet type for the command
         class_name (str): name for the new type
         custom_attr_list (:obj:`list`): list of dotnet attributes for the type
-        *args: list of arguments to be used with type constructor
+        *args (Any): list of arguments to be used with type constructor
 
     Returns:
-        type: returns created dotnet type
+        (type): returns created dotnet type
 
-    Example:
+    Examples:
         >>> asm_builder = AppDomain.CurrentDomain.DefineDynamicAssembly(
         ... win_asm_name, AssemblyBuilderAccess.RunAndSave, filepath
         ... )

--- a/pyrevitlib/pyrevit/runtime/dynamotypemaker.py
+++ b/pyrevitlib/pyrevit/runtime/dynamotypemaker.py
@@ -11,15 +11,13 @@ mlogger = logger.get_logger(__name__)
 
 
 def create_executor_type(extension, module_builder, cmd_component):
-    """
+    """Create the dotnet type for the executor.
 
     Args:
-        extension:
-        module_builder:
+        extension (pyrevit.extensions.components.Extension): pyRevit extension
+        module_builder (ModuleBuilder): module builder
         cmd_component (pyrevit.extensions.genericcomps.GenericUICommand):
-
-    Returns:
-
+            command
     """
     engine_configs = json.dumps({
         exts.MDATA_ENGINE_CLEAN:

--- a/pyrevitlib/pyrevit/runtime/pythontypemaker.py
+++ b/pyrevitlib/pyrevit/runtime/pythontypemaker.py
@@ -48,14 +48,13 @@ def _does_need_clean_engine(extension, cmd_component):
 
 
 def create_executor_type(extension, module_builder, cmd_component):
-    """
+    """Create the dotnet type for the executor.
 
     Args:
-        module_builder:
+        extension (pyrevit.extensions.components.Extension): pyRevit extension
+        module_builder (ModuleBuilder): module builder
         cmd_component (pyrevit.extensions.genericcomps.GenericUICommand):
-
-    Returns:
-
+            command
     """
     cmd_component.requires_clean_engine = \
         _does_need_clean_engine(extension, cmd_component)

--- a/pyrevitlib/pyrevit/runtime/typemaker.py
+++ b/pyrevitlib/pyrevit/runtime/typemaker.py
@@ -115,15 +115,13 @@ def create_exec_types(extension, cmd_component, module_builder=None):
 
 # public base class maker function ---------------------------------------------
 def make_bundle_types(extension, cmd_component, module_builder=None):
-    """
+    """Create the types for the bundle.
 
     Args:
-        extension:
+        extension (pyrevit.extensions.components.Extension): pyRevit extension
         cmd_component (pyrevit.extensions.genericcomps.GenericUICommand):
-        module_builder:
-
-    Returns:
-
+            command
+        module_builder (ModuleBuilder): module builder.
     """
     # make command interface type for the given command
     try:

--- a/pyrevitlib/pyrevit/runtime/urltypemaker.py
+++ b/pyrevitlib/pyrevit/runtime/urltypemaker.py
@@ -9,6 +9,13 @@ mlogger = logger.get_logger(__name__)
 
 
 def create_executor_type(extension, module_builder, cmd_component):
+    """Create the dotnet type for the executor.
+
+    Args:
+        extension (Extension): pyRevit extension
+        module_builder (ModuleBuilder): module builder
+        cmd_component (GenericUICommand): command component
+    """
     cmd_component.arguments = [cmd_component.get_target_url()]
     bundletypemaker.create_executor_type(
         extension,

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -1,6 +1,6 @@
 """Provide basic utilities for pyRevit scripts.
 
-Example:
+Examples:
     >>> from pyrevit import script
     >>> script.clipboard_copy('some text')
     >>> data = script.journal_read('data-key')
@@ -47,7 +47,7 @@ def get_info():
     """Return info on current pyRevit command.
 
     Returns:
-        :obj:`pyrevit.extensions.genericcomps.GenericUICommand`:
+        (pyrevit.extensions.genericcomps.GenericUICommand):
             Command info object
     """
     from pyrevit.extensions.extensionmgr import get_command_from_path
@@ -58,7 +58,7 @@ def get_script_path():
     """Return script path of the current pyRevit command.
 
     Returns:
-        str: script path
+        (str): script path
     """
     return EXEC_PARAMS.command_path
 
@@ -67,7 +67,7 @@ def get_alt_script_path():
     """Return config script path of the current pyRevit command.
 
     Returns:
-        str: config script path
+        (str): config script path
     """
     return EXEC_PARAMS.command_config_path
 
@@ -76,7 +76,7 @@ def get_bundle_name():
     """Return bundle name of the current pyRevit command.
 
     Returns:
-        str: bundle name (e.g. MyButton.pushbutton)
+        (str): bundle name (e.g. MyButton.pushbutton)
     """
     return EXEC_PARAMS.command_bundle
 
@@ -85,7 +85,7 @@ def get_extension_name():
     """Return extension name of the current pyRevit command.
 
     Returns:
-        str: extension name (e.g. MyExtension.extension)
+        (str): extension name (e.g. MyExtension.extension)
     """
     return EXEC_PARAMS.command_extension
 
@@ -94,7 +94,7 @@ def get_unique_id():
     """Return unique id of the current pyRevit command.
 
     Returns:
-        str: command unique id
+        (str): command unique id
     """
     return EXEC_PARAMS.command_uniqueid
 
@@ -103,7 +103,7 @@ def get_results():
     """Return command results dictionary for logging.
 
     Returns:
-        :obj:`pyrevit.telemetry.record.CommandCustomResults`:
+        (pyrevit.telemetry.record.CommandCustomResults):
             Command results dict
     """
     from pyrevit.telemetry.record import CommandCustomResults
@@ -114,7 +114,7 @@ def get_pyrevit_version():
     """Return pyRevit version.
 
     Returns:
-        :obj:`pyrevit.versionmgr._PyRevitVersion`: pyRevit version provider
+        (pyrevit.versionmgr._PyRevitVersion): pyRevit version provider
     """
     return versionmgr.get_pyrevit_version()
 
@@ -123,7 +123,7 @@ def get_logger():
     """Create and return logger named for current script.
 
     Returns:
-        :obj:`pyrevit.coreutils.logger.LoggerWrapper`: Logger object
+        (pyrevit.coreutils.logger.LoggerWrapper): Logger object
     """
     return logger.get_logger(EXEC_PARAMS.command_name)
 
@@ -132,7 +132,7 @@ def get_output():
     """Return object wrapping output window for current script.
 
     Returns:
-        :obj:`pyrevit.output.PyRevitOutputWindow`: Output wrapper object
+        (pyrevit.output.PyRevitOutputWindow): Output wrapper object
     """
     return output.get_output()
 
@@ -141,10 +141,11 @@ def get_config(section=None):
     """Create and return config section parser object for current script.
 
     Args:
-        section (str, optional): config section name
+        section (str, optional): config section name. If not provided,
+            it will default to the command name plus the 'config' suffix.
 
     Returns:
-        :obj:`pyrevit.coreutils.configparser.PyRevitConfigSectionParser`:
+        (pyrevit.coreutils.configparser.PyRevitConfigSectionParser):
             Config section parser object
     """
     from pyrevit.userconfig import user_config
@@ -154,7 +155,7 @@ def get_config(section=None):
 
     try:
         return user_config.get_section(section)
-    except Exception:
+    except AttributeError:
         return user_config.add_section(section)
 
 
@@ -199,7 +200,7 @@ def get_universal_data_file(file_id, file_ext, add_cmd_name=False):
     File name is generated in this format:
     ``pyRevit_{file_id}.{file_ext}``
 
-    Example:
+    Examples:
         >>> script.get_universal_data_file('mydata', 'data')
         '.../pyRevit_mydata.data'
         >>> script.get_universal_data_file('mydata', 'data', add_cmd_name=True)
@@ -214,7 +215,7 @@ def get_universal_data_file(file_id, file_ext, add_cmd_name=False):
         add_cmd_name (bool, optional): add command name to file name
 
     Returns:
-        str: full file path
+        (str): full file path
     """
     if add_cmd_name:
         script_file_id = '{}_{}'.format(EXEC_PARAMS.command_name, file_id)
@@ -230,7 +231,7 @@ def get_data_file(file_id, file_ext, add_cmd_name=False):
     File name is generated in this format:
     ``pyRevit_{Revit Version}_{file_id}.{file_ext}``
 
-    Example:
+    Examples:
         >>> script.get_data_file('mydata', 'data')
         '.../pyRevit_2018_mydata.data'
         >>> script.get_data_file('mydata', 'data', add_cmd_name=True)
@@ -245,7 +246,7 @@ def get_data_file(file_id, file_ext, add_cmd_name=False):
         add_cmd_name (bool, optional): add command name to file name
 
     Returns:
-        str: full file path
+        (str): full file path
     """
     if add_cmd_name:
         script_file_id = '{}_{}'.format(EXEC_PARAMS.command_name, file_id)
@@ -261,7 +262,7 @@ def get_instance_data_file(file_id, add_cmd_name=False):
     File name is generated in this format:
     ``pyRevit_{Revit Version}_{Process Id}_{file_id}.{file_ext}``
 
-    Example:
+    Examples:
         >>> script.get_instance_data_file('mydata')
         '.../pyRevit_2018_6684_mydata.tmp'
         >>> script.get_instance_data_file('mydata', add_cmd_name=True)
@@ -274,7 +275,7 @@ def get_instance_data_file(file_id, add_cmd_name=False):
         add_cmd_name (bool, optional): add command name to file name
 
     Returns:
-        str: full file path
+        (str): full file path
     """
     if add_cmd_name:
         script_file_id = '{}_{}'.format(EXEC_PARAMS.command_name, file_id)
@@ -290,7 +291,7 @@ def get_document_data_file(file_id, file_ext, add_cmd_name=False):
     File name is generated in this format:
     ``pyRevit_{Revit Version}_{file_id}_{Project Name}.{file_ext}``
 
-    Example:
+    Examples:
         >>> script.get_document_data_file('mydata', 'data')
         '.../pyRevit_2018_mydata_Project1.data'
         >>> script.get_document_data_file('mydata', 'data', add_cmd_name=True)
@@ -305,7 +306,7 @@ def get_document_data_file(file_id, file_ext, add_cmd_name=False):
         add_cmd_name (bool, optional): add command name to file name
 
     Returns:
-        str: full file path
+        (str): full file path
     """
     proj_info = revit.query.get_project_info()
 
@@ -323,7 +324,7 @@ def get_document_data_file(file_id, file_ext, add_cmd_name=False):
 
 
 def remove_data_file(filepath):
-    """Remove given data file"""
+    """Remove given data file."""
     appdata.garbage_data_file(filepath)
 
 
@@ -334,7 +335,7 @@ def get_bundle_file(file_name):
         file_name (str): bundle file name
 
     Returns:
-        str: full bundle file path
+        (str): full bundle file path
     """
     return op.join(EXEC_PARAMS.command_path, file_name)
 
@@ -343,7 +344,7 @@ def get_bundle_files(sub_path=None):
     """Return full path to all file under current script bundle.
 
     Returns:
-        list[str]: list of bundle file paths
+        (list[str]): list of bundle file paths
     """
     if sub_path:
         command_path = op.join(EXEC_PARAMS.command_path, sub_path)
@@ -374,7 +375,7 @@ def journal_read(data_key):
         data_key (str): data key
 
     Returns:
-        str: data value string
+        (str): data value string
     """
     # Get the StringStringMap class which can write data into.
     data_map = EXEC_PARAMS.command_data.JournalData
@@ -387,7 +388,7 @@ def get_button():
     """Find and return current script ui button.
 
     Returns:
-        :obj:`pyrevit.coreutils.ribbon._PyRevitRibbonButton`: ui button object
+        (pyrevit.coreutils.ribbon._PyRevitRibbonButton): ui button object
     """
     from pyrevit.coreutils.ribbon import get_current_ui
     pyrvt_tabs = get_current_ui().get_pyrevit_tabs()
@@ -406,7 +407,7 @@ def get_all_buttons():
     icon adjustments.
 
     Returns:
-        :obj:`list(pyrevit.coreutils.ribbon._PyRevitRibbonButton)`:
+        (list[pyrevit.coreutils.ribbon._PyRevitRibbonButton]):
             list of ui button objects
     """
     from pyrevit.coreutils.ribbon import get_current_ui
@@ -431,6 +432,7 @@ def toggle_icon(new_state, on_icon_path=None, off_icon_path=None, icon_size=ICON
                                       default='on.png'
         off_icon_path (str, optional): full path of icon for off state.
                                        default='off.png'
+        icon_size (int): size of the icon. Defaults to medium (24x24)
     """
     # find the ui button
     uibuttons = get_all_buttons()
@@ -543,9 +545,9 @@ def get_envvar(envvar):
         envvar (str): name of environment variable
 
     Returns:
-        any: type of object stored in environment variable
+        (Any): object stored in environment variable
 
-    Example:
+    Examples:
         >>> script.get_envvar('ToolActiveState')
         True
     """
@@ -564,7 +566,7 @@ def set_envvar(envvar, value):
         envvar (str): name of environment variable
         value (any): value of environment variable
 
-    Example:
+    Examples:
         >>> script.set_envvar('ToolActiveState', False)
         >>> script.get_envvar('ToolActiveState')
         False
@@ -591,7 +593,7 @@ def load_json(filepath):
         filepath (str): json file path
 
     Returns:
-        object: deserialized data
+        (object): deserialized data
     """
     with codecs.open(filepath, 'r', "utf-8") as json_file:
         return json.load(json_file)
@@ -610,20 +612,20 @@ def dump_csv(data, filepath):
 
 
 def load_csv(filepath):
-    """Read lines from given csv file
+    """Read lines from given csv file.
 
     Args:
         filepath (str): csv file path
 
     Returns:
-        list[list[str]]: csv data
+        (list[list[str]]): csv data
     """
     with codecs.open(filepath, 'rb', encoding='utf-8') as csvfile:
         return list(csv.reader(csvfile, delimiter=',', quotechar='\"'))
 
 
 def store_data(slot_name, data, this_project=True):
-    """Wraps python pickle.dump() to easily store data to pyRevit data files
+    """Wraps python pickle.dump() to easily store data to pyRevit data files.
 
     To store native Revit objects, use revit.serialize(). See Example
 
@@ -632,7 +634,7 @@ def store_data(slot_name, data, this_project=True):
         data (obj): any pickalable data
         this_project (bool): data belongs to this project only
 
-    Example:
+    Examples:
         >>> from pyrevit import revit
         ... from pyrevit import script
         ...
@@ -677,7 +679,7 @@ def store_data(slot_name, data, this_project=True):
 
 
 def load_data(slot_name, this_project=True):
-    """Wraps python pickle.load() to easily load data from pyRevit data files
+    """Wraps python pickle.load() to easily load data from pyRevit data files.
 
     To recover native Revit objects, use revit.deserialize(). See Example
 
@@ -689,9 +691,9 @@ def load_data(slot_name, this_project=True):
         this_project (bool): data belongs to this project only
 
     Returns:
-        obj: stored data
+        (object): stored data
 
-    Example:
+    Examples:
         >>> from pyrevit import revit
         ... from pyrevit import script
         ...
@@ -739,7 +741,7 @@ def data_exists(slot_name, this_project=True):
         this_project (bool): data belongs to this project only
 
     Returns:
-        bool: true if the path exists
+        (bool): true if the path exists
     """
     # for this specific project?
     if this_project:

--- a/pyrevitlib/pyrevit/telemetry/__init__.py
+++ b/pyrevitlib/pyrevit/telemetry/__init__.py
@@ -1,19 +1,18 @@
-"""
-This module manages the telemetry system.
+"""This module manages the telemetry system.
 
-    This function is used to setup the telemetry system on pyRevit startup:
-        >>> setup_telemetry()
+This function is used to setup the telemetry system on pyRevit startup:
+>>> setup_telemetry()
 
-    These functions are used to query information about the logging system:
-        >>> get_telemetry_state()
+These functions are used to query information about the logging system:
+>>> get_telemetry_state()
 
-        >>> get_apptelemetry_state()
+>>> get_apptelemetry_state()
 
-    This module also provides a wrapper class around the command results
-    dictionary that is included with the telemetry record.
+This module also provides a wrapper class around the command results
+dictionary that is included with the telemetry record.
 
-    Scripts should use the instance of this class provided by the
-    script module. See `script.get_results()` for examples
+Scripts should use the instance of this class provided by the
+script module. See `script.get_results()` for examples
 """
 import os.path as op
 import json
@@ -211,7 +210,6 @@ def get_status():
 
 def setup_telemetry(session_id=None):
     """Sets up the telemetry default config and environment values."""
-
     # make sure session id is availabe
     if not session_id:
         session_id = sessioninfo.get_session_uuid()

--- a/pyrevitlib/pyrevit/telemetry/events.py
+++ b/pyrevitlib/pyrevit/telemetry/events.py
@@ -22,6 +22,7 @@ def register_event_telemetry(handler, flags):
     """Registers application event telemetry handlers based on given flags.
 
     Args:
+        handler (EventTelemetry): event telemetry handler
         flags (int): event flags
     """
     try:
@@ -36,6 +37,7 @@ def unregister_event_telemetry(handler, flags):
     """Unregisters application event telemetry handlers based on given flags.
 
     Args:
+        handler (EventTelemetry): event telemetry handler
         flags (int): event flags
     """
     try:

--- a/pyrevitlib/pyrevit/telemetry/record.py
+++ b/pyrevitlib/pyrevit/telemetry/record.py
@@ -5,15 +5,14 @@ from pyrevit.compat import safe_strtype
 
 
 class CommandCustomResults(object):
-    """
-    This class provides an interface wrapper around the EXEC_PARAMS.result_dict
-    dictionary that is provided by the ScriptExecutor C# object.
+    """Wrapper around ScriptExecutor's EXEC_PARAMS.result_dict.
+    
     ScriptExecutor provides this results dictionary to all scripts, and scripts
     can add key:value pairs to the dictionary. But since the provided
     dictionary is a C# dictionary, this class provides a very easy
     to use wrapper around it.
 
-    Example:
+    Examples:
         >>> CommandCustomResults().returnparam = 'some return value'
 
     """

--- a/pyrevitlib/pyrevit/unittests/runner.py
+++ b/pyrevitlib/pyrevit/unittests/runner.py
@@ -59,7 +59,7 @@ class PyRevitTestResult(TestResult):
         """Returns the description of the test.
 
         Args:
-            test (Any): Unit test.
+            test (TestCase): Unit test.
 
         Returns:
             (str): test description
@@ -67,22 +67,44 @@ class PyRevitTestResult(TestResult):
         return test.shortDescription() or test
 
     def startTest(self, test):
+        """Starts the test.
+
+        Args:
+            test (TestCase): unit test
+        """
         super(PyRevitTestResult, self).startTest(test)
         mlogger.debug('Running test: %s', self.getDescription(test))
 
     def addSuccess(self, test):
+        """Adds a test success.
+
+        Args:
+            test (TestCase): unit test case
+        """
         super(PyRevitTestResult, self).addSuccess(test)
         mlogger.debug(DEBUG_OKAY_RESULT)
         self.writer.write(RESULT_DIV_OKAY
                           .format(test=self.getDescription(test)))
 
     def addError(self, test, err):
+        """Adds a test error.
+
+        Args:
+            test (TestCase): unit test case
+            err (OptExcInfo): test exception info
+        """
         super(PyRevitTestResult, self).addError(test, err)
         mlogger.debug(DEBUG_FAIL_RESULT)
         self.writer.write(RESULT_DIV_ERROR
                           .format(test=self.getDescription(test)))
 
     def addFailure(self, test, err):
+        """Adds a test failure.
+
+        Args:
+            test (TestCase): unit test case
+            err (OptExcInfo): test exception info
+        """
         super(PyRevitTestResult, self).addFailure(test, err)
         mlogger.debug(DEBUG_FAIL_RESULT)
         self.writer.write(RESULT_DIV_FAIL

--- a/pyrevitlib/pyrevit/unittests/runner.py
+++ b/pyrevitlib/pyrevit/unittests/runner.py
@@ -1,3 +1,4 @@
+"""Unit tests facility."""
 import time
 from unittest import TestResult, TestLoader
 
@@ -30,21 +31,40 @@ RESULT_DIV_ERROR = '<div class="unittest unittesterror">' \
 
 
 class OutputWriter:
+    """Output writer for tests results."""
     def __init__(self):
         self._output = get_output()
 
     def write(self, output_str):
+        """Prints the results to the output window.
+
+        Args:
+            output_str (str): Text to output
+        """
         self._output.print_html(output_str)
 
 
 class PyRevitTestResult(TestResult):
+    """Pyrevit Test Result.
+
+    Args:
+        verbosity (int): verbosity level.
+    """
     def __init__(self, verbosity):
         super(PyRevitTestResult, self).__init__(verbosity=verbosity)
         self.writer = OutputWriter()
 
     @staticmethod
     def getDescription(test):
-        return test.shortDescription() if test.shortDescription() else test
+        """Returns the description of the test.
+
+        Args:
+            test (Any): Unit test.
+
+        Returns:
+            (str): test description
+        """
+        return test.shortDescription() or test
 
     def startTest(self, test):
         super(PyRevitTestResult, self).startTest(test)
@@ -79,6 +99,15 @@ class PyRevitTestResult(TestResult):
 
 
 class PyRevitTestRunner(object):
+    """Test runner.
+
+    Args:
+        verbosity (int): level of vermosity. Defaults to 1.
+        failfast (bool): if True, stops at the first failure. Defaults to False.
+        use_buffer (bool): use a buffer. Defaults to False.
+        resultclass (type): Class to use to hold the results. 
+            Defaults to `PyRevitTestResult`.
+    """
     resultclass = PyRevitTestResult
 
     def __init__(self, verbosity=1, failfast=False,
@@ -93,6 +122,14 @@ class PyRevitTestRunner(object):
         return self.resultclass(self.verbosity)
 
     def run(self, test):
+        """Runs a test suite.
+
+        Args:
+            test (TestSuite): Test suite to run
+
+        Returns:
+            (PyRevitTestResult): Test suite results.
+        """
         # setup results object
         result = self._make_result()
         result.failfast = self.failfast
@@ -156,6 +193,14 @@ class PyRevitTestRunner(object):
 
 
 def run_module_tests(test_module):
+    """Runs the unit tests of the given module.
+
+    Args:
+        test_module (module): module with tests
+
+    Returns:
+        (PyRevitTestResult): tests results.
+    """
     test_runner = PyRevitTestRunner()
     test_loader = TestLoader()
     # load all testcases from the given module into a testsuite

--- a/pyrevitlib/pyrevit/userconfig.py
+++ b/pyrevitlib/pyrevit/userconfig.py
@@ -1,14 +1,13 @@
 """Handle reading and parsing, writin and saving of all user configurations.
 
 This module handles the reading and writing of the pyRevit configuration files.
-It's been used extensively by pyRevit sub-modules. :obj:`user_config` is
+It's been used extensively by pyRevit sub-modules. user_config is
 set up automatically in the global scope by this module and can be imported
 into scripts and other modules to access the default configurations.
 
 All other modules use this module to query user config.
 
-Example:
-
+Examples:
     >>> from pyrevit.userconfig import user_config
     >>> user_config.add_section('newsection')
     >>> user_config.newsection.property = value
@@ -16,15 +15,14 @@ Example:
     >>> user_config.save_changes()
 
 
-The :obj:`user_config` object is also the destination for reading and writing
+The user_config object is also the destination for reading and writing
 configuration by pyRevit scripts through :func:`get_config` of
 :mod:`pyrevit.script` module. Here is the function source:
 
 .. literalinclude:: ../../pyrevitlib/pyrevit/script.py
     :pyobject: get_config
 
-Example:
-
+Examples:
     >>> from pyrevit import script
     >>> cfg = script.get_config()
     >>> cfg.property = value
@@ -66,7 +64,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         cfg_file_path (str): full path to config file to be used.
         config_type (str): type of config file
 
-    Example:
+    Examples:
         >>> cfg = PyRevitConfig(cfg_file_path)
         >>> cfg.add_section('sectionname')
         >>> cfg.sectionname.property = value
@@ -110,30 +108,35 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def environment(self):
+        """Environment section."""
         if not self.has_section(CONSTS.EnvConfigsSectionName):
             self.add_section(CONSTS.EnvConfigsSectionName)
         return self.get_section(CONSTS.EnvConfigsSectionName)
 
     @property
     def core(self):
+        """Core section."""
         if not self.has_section(CONSTS.ConfigsCoreSection):
             self.add_section(CONSTS.ConfigsCoreSection)
         return self.get_section(CONSTS.ConfigsCoreSection)
 
     @property
     def routes(self):
+        """Routes section."""
         if not self.has_section(CONSTS.ConfigsRoutesSection):
             self.add_section(CONSTS.ConfigsRoutesSection)
         return self.get_section(CONSTS.ConfigsRoutesSection)
 
     @property
     def telemetry(self):
+        """Telemetry section."""
         if not self.has_section(CONSTS.ConfigsTelemetrySection):
             self.add_section(CONSTS.ConfigsTelemetrySection)
         return self.get_section(CONSTS.ConfigsTelemetrySection)
 
     @property
     def bin_cache(self):
+        """"Whether to use the cache for extensions."""
         return self.core.get_option(
             CONSTS.ConfigsBinaryCacheKey,
             default_value=CONSTS.ConfigsBinaryCacheDefault,
@@ -148,6 +151,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def check_updates(self):
+        """Whether to check for updates."""
         return self.core.get_option(
             CONSTS.ConfigsCheckUpdatesKey,
             default_value=CONSTS.ConfigsCheckUpdatesDefault,
@@ -162,6 +166,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def auto_update(self):
+        """Whether to automatically update pyRevit."""
         return self.core.get_option(
             CONSTS.ConfigsAutoUpdateKey,
             default_value=CONSTS.ConfigsAutoUpdateDefault,
@@ -176,6 +181,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def rocket_mode(self):
+        """Whether to enable rocket mode."""
         return self.core.get_option(
             CONSTS.ConfigsRocketModeKey,
             default_value=CONSTS.ConfigsRocketModeDefault,
@@ -190,6 +196,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def log_level(self):
+        """Logging level."""
         if self.core.get_option(
                 CONSTS.ConfigsDebugKey,
                 default_value=CONSTS.ConfigsDebugDefault,
@@ -216,6 +223,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def file_logging(self):
+        """Whether to enable file logging."""
         return self.core.get_option(
             CONSTS.ConfigsFileLoggingKey,
             default_value=CONSTS.ConfigsFileLoggingDefault,
@@ -230,6 +238,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def startuplog_timeout(self):
+        """Timeout for the startup log."""
         return self.core.get_option(
             CONSTS.ConfigsStartupLogTimeoutKey,
             default_value=CONSTS.ConfigsStartupLogTimeoutDefault,
@@ -244,6 +253,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def required_host_build(self):
+        """Host build required to run the commands."""
         return self.core.get_option(
             CONSTS.ConfigsRequiredHostBuildKey,
             default_value="",
@@ -258,6 +268,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def min_host_drivefreespace(self):
+        """Minimum free space for running the commands."""
         return self.core.get_option(
             CONSTS.ConfigsMinDriveSpaceKey,
             default_value=CONSTS.ConfigsMinDriveSpaceDefault,
@@ -272,6 +283,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def load_beta(self):
+        """Whether to load commands in beta."""
         return self.core.get_option(
             CONSTS.ConfigsLoadBetaKey,
             default_value=CONSTS.ConfigsLoadBetaDefault,
@@ -286,6 +298,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def cpython_engine_version(self):
+        """CPython engine version to use."""
         return self.core.get_option(
             CONSTS.ConfigsCPythonEngineKey,
             default_value=CONSTS.ConfigsCPythonEngineDefault,
@@ -300,6 +313,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def user_locale(self):
+        """User locale."""
         return self.core.get_option(
             CONSTS.ConfigsLocaleKey,
             default_value="",
@@ -314,6 +328,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def output_stylesheet(self):
+        """Stylesheet used for output."""
         return self.core.get_option(
             CONSTS.ConfigsOutputStyleSheet,
             default_value="",
@@ -331,6 +346,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def routes_host(self):
+        """Routes API host."""
         return self.routes.get_option(
             CONSTS.ConfigsRoutesHostKey,
             default_value=CONSTS.ConfigsRoutesHostDefault,
@@ -345,6 +361,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def routes_port(self):
+        """API routes port."""
         return self.routes.get_option(
             CONSTS.ConfigsRoutesPortKey,
             default_value=CONSTS.ConfigsRoutesPortDefault,
@@ -359,6 +376,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def load_core_api(self):
+        """Whether to load pyRevit core api."""
         return self.routes.get_option(
             CONSTS.ConfigsLoadCoreAPIKey,
             default_value=CONSTS.ConfigsConfigsLoadCoreAPIDefault,
@@ -373,6 +391,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def telemetry_utc_timestamp(self):
+        """Whether to use UTC timestamps in telemetry."""
         return self.telemetry.get_option(
             CONSTS.ConfigsTelemetryUTCTimestampsKey,
             default_value=CONSTS.ConfigsTelemetryUTCTimestampsDefault,
@@ -387,6 +406,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def telemetry_status(self):
+        """Telemetry status."""
         return self.telemetry.get_option(
             CONSTS.ConfigsTelemetryStatusKey,
             default_value=CONSTS.ConfigsTelemetryStatusDefault,
@@ -401,6 +421,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def telemetry_file_dir(self):
+        """Telemetry file directory."""
         return self.telemetry.get_option(
             CONSTS.ConfigsTelemetryFileDirKey,
             default_value="",
@@ -415,6 +436,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def telemetry_server_url(self):
+        """Telemetry server URL."""
         return self.telemetry.get_option(
             CONSTS.ConfigsTelemetryServerUrlKey,
             default_value="",
@@ -429,6 +451,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def telemetry_include_hooks(self):
+        """Whether to include hooks in telemetry."""
         return self.telemetry.get_option(
             CONSTS.ConfigsTelemetryIncludeHooksKey,
             default_value=CONSTS.ConfigsTelemetryIncludeHooksDefault,
@@ -443,6 +466,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def apptelemetry_status(self):
+        """Telemetry status."""
         return self.telemetry.get_option(
             CONSTS.ConfigsAppTelemetryStatusKey,
             default_value=CONSTS.ConfigsAppTelemetryStatusDefault,
@@ -457,6 +481,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def apptelemetry_server_url(self):
+        """App telemetry server URL."""
         return self.telemetry.get_option(
             CONSTS.ConfigsAppTelemetryServerUrlKey,
             default_value="",
@@ -471,6 +496,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def apptelemetry_event_flags(self):
+        """Telemetry event flags."""
         return self.telemetry.get_option(
             CONSTS.ConfigsAppTelemetryEventFlagsKey,
             default_value="",
@@ -485,6 +511,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def user_can_update(self):
+        """Whether the user can update pyRevit repos."""
         return self.core.get_option(
             CONSTS.ConfigsUserCanUpdateKey,
             default_value=CONSTS.ConfigsUserCanUpdateDefault,
@@ -499,6 +526,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def user_can_extend(self):
+        """Whether the user can manage pyRevit Extensions."""
         return self.core.get_option(
             CONSTS.ConfigsUserCanExtendKey,
             default_value=CONSTS.ConfigsUserCanExtendDefault,
@@ -513,6 +541,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def user_can_config(self):
+        """Whether the user can access the configuration."""
         return self.core.get_option(
             CONSTS.ConfigsUserCanConfigKey,
             default_value=CONSTS.ConfigsUserCanConfigDefault,
@@ -527,6 +556,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def colorize_docs(self):
+        """Whether to enable the document colorizer."""
         return self.core.get_option(
             CONSTS.ConfigsColorizeDocsKey,
             default_value=CONSTS.ConfigsColorizeDocsDefault,
@@ -541,6 +571,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def tooltip_debug_info(self):
+        """Whether to append debug info on tooltips."""
         return self.core.get_option(
             CONSTS.ConfigsAppendTooltipExKey,
             default_value=CONSTS.ConfigsAppendTooltipExDefault,
@@ -555,6 +586,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def routes_server(self):
+        """Whether the server routes are enabled."""
         return self.routes.get_option(
             CONSTS.ConfigsRoutesServerKey,
             default_value=CONSTS.ConfigsRoutesServerDefault,
@@ -569,6 +601,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
 
     @property
     def respect_language_direction(self):
+        """Whether the system respects the language direction."""
         return False
 
     @respect_language_direction.setter
@@ -576,14 +609,18 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         pass
 
     def get_config_version(self):
-        """Return version of config file used for change detection."""
+        """Return version of config file used for change detection.
+
+        Returns:
+            (str): hash of the config file
+        """
         return self.get_config_file_hash()
 
     def get_thirdparty_ext_root_dirs(self, include_default=True):
         """Return a list of external extension directories set by the user.
 
         Returns:
-            :obj:`list`: list of strings. External user extension directories.
+            (list[str]): External user extension directories.
         """
         dir_list = set()
         if include_default:
@@ -606,7 +643,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         """Return a list of all extension directories.
 
         Returns:
-            :obj:`list`: list of strings. user extension directories.
+            (list[str]): user extension directories.
 
         """
         dir_list = set()
@@ -616,7 +653,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         return list(dir_list)
 
     def get_ext_sources(self):
-        """Return a list of extension definition source files"""
+        """Return a list of extension definition source files."""
         ext_sources = self.environment.get_option(
             CONSTS.EnvConfigsExtensionLookupSourcesKey,
             default_value=[],
@@ -624,7 +661,7 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         return list(set(ext_sources))
 
     def set_thirdparty_ext_root_dirs(self, path_list):
-        """Updates list of external extension directories in config file
+        """Updates list of external extension directories in config file.
 
         Args:
             path_list (list[str]): list of external extension paths
@@ -689,10 +726,16 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
                           'current attachment: %s', attachment)
 
     def set_active_cpython_engine(self, pyrevit_engine):
+        """Set the active CPython engine.
+
+        Args:
+            pyrevit_engine (PyRevitEngine): python engine to set as active
+        """
         self.cpython_engine_version = pyrevit_engine.Version
 
     @property
     def is_readonly(self):
+        """bool: whether the config is read only."""
         return self._admin
 
     def save_changes(self):
@@ -735,7 +778,7 @@ def verify_configs(config_file_path=None):
         config_file_path (str, optional): config file full name and path
 
     Returns:
-        :obj:`pyrevit.userconfig.PyRevitConfig`: pyRevit config file handler
+        (pyrevit.userconfig.PyRevitConfig): pyRevit config file handler
     """
     if config_file_path:
         mlogger.debug('Creating default config file at: %s', config_file_path)

--- a/pyrevitlib/pyrevit/versionmgr/__init__.py
+++ b/pyrevitlib/pyrevit/versionmgr/__init__.py
@@ -1,6 +1,6 @@
 """Utility functions for managing pyRevit versions.
 
-Example:
+Examples:
     >>> from pyrevit import versionmgr
     >>> v = versionmgr.get_pyrevit_version()
     >>> v.get_formatted()
@@ -38,7 +38,7 @@ class _PyRevitVersion(object):
         self.signature = safe_strtype(signature)[:7]
 
     def as_int_tuple(self):
-        """Returns version as an int tuple (major, minor, patch)"""
+        """Returns version as an int tuple (major, minor, patch)."""
         try:
             signature = int(self.patch, 16)
         except Exception:
@@ -48,14 +48,14 @@ class _PyRevitVersion(object):
         return ver_tuple
 
     def as_str_tuple(self):
-        """Returns version as an string tuple ('major', 'minor', 'patch')"""
+        """Returns version as an string tuple ('major', 'minor', 'patch')."""
         ver_tuple = (safe_strtype(_PyRevitVersion.major),
                      safe_strtype(_PyRevitVersion.minor),
                      safe_strtype(self.patch))
         return ver_tuple
 
     def get_formatted(self, strict=False, extended=False):
-        """Returns 'major.minor.patch' in string"""
+        """Returns 'major.minor.patch' in string."""
         formatted_ver = '{}.{}.{}'.format(_PyRevitVersion.major,
                                           _PyRevitVersion.minor,
                                           _PyRevitVersion.patch)
@@ -73,7 +73,7 @@ def get_pyrevit_repo():
     """Return pyRevit repository.
 
     Returns:
-        :obj:`pyrevit.coreutils.git.RepoInfo`: repo wrapper object
+        (pyrevit.coreutils.git.RepoInfo): repo wrapper object
     """
     try:
         return git.get_repo(HOME_DIR)
@@ -86,7 +86,7 @@ def get_pyrevit_version():
     """Return information about active pyRevit version.
 
     Returns:
-        :obj:`_PyRevitVersion`: version wrapper object
+        (_PyRevitVersion): version wrapper object
     """
     try:
         return _PyRevitVersion(get_pyrevit_repo().last_commit_hash)
@@ -99,6 +99,6 @@ def get_pyrevit_cli_version():
     """Return version of shipped pyRevit CLI utility.
 
     Returns:
-        str: version string of pyRevit CLI utility binary
+        (str): version string of pyRevit CLI utility binary
     """
     return coreutils.get_exe_version(PYREVIT_CLI_PATH)

--- a/pyrevitlib/pyrevit/versionmgr/about.py
+++ b/pyrevitlib/pyrevit/versionmgr/about.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Utility module for pyRevit project information.
 
-Example:
+Examples:
     >>> from pyrevit.versionmgr import about
     >>> a = about.get_pyrevit_about()
     >>> a.subtitle
@@ -27,7 +27,7 @@ def get_pyrevit_about():
     """Return information about pyRevit project.
 
     Returns:
-        :obj:`PyRevitAbout`: pyRevit project info tuple
+        (PyRevitAbout): pyRevit project info tuple
     """
     return PyRevitAbout(subtitle='python RAD Environment for Autodesk Revit®',
                         madein="['pdx', 'hio', 'rno', 'sea']",

--- a/pyrevitlib/pyrevit/versionmgr/upgrade.py
+++ b/pyrevitlib/pyrevit/versionmgr/upgrade.py
@@ -1,4 +1,4 @@
-"""Perform upgrades between version, e.g. adding a new config parameter"""
+"""Perform upgrades between version, e.g. adding a new config parameter."""
 #pylint: disable=W0611
 import os
 import os.path as op
@@ -11,7 +11,6 @@ def upgrade_user_config(user_config):   #pylint: disable=W0613
 
     Args:
         user_config (:obj:`pyrevit.userconfig.PyRevitConfig`): config object
-        val (type): desc
     """
     # upgrade value formats
     for section in user_config:
@@ -20,8 +19,9 @@ def upgrade_user_config(user_config):   #pylint: disable=W0613
 
 
 def remove_leftover_temp_files():
-    """4.8.5 had a bug that would create temp files with extension ..bak
-    This cleans them up
+    """4.8.5 had a bug that would create temp files with extension ..bak.
+
+    This cleans them up.
     """
     univ_path = op.dirname(appdata.get_universal_data_file("X", 'bak'))
     if op.exists(univ_path):


### PR DESCRIPTION
As [discussed with @jmcouffin on the forum](https://discourse.pyrevitlabs.io/t/pyrevitlib-documentation-github-pages/1969), this PR updates and fixes some of the docstrings of the pyrevit package.

There are still many functions and methods without docstrings, and some docstring without the arguments and types description, but it's a start to have better documented code.

Some of the style choices (for example the return types between parenthesis) were a consequence of my desire to move to the more modern, markdown-centric, MkDocs documentation builder instead of sphinx, and some shortcomings found in mkdocstrings plugin, already discussed in the forum.

I added ruff to the root python 3.10 toolchain and enabled the documentation ("D") checks because of the vast performance gain over pylint; it could be used also for other checks and maybe for git pre-commit hooks and CI jobs in order to allow only clean code to be committed (but this is another story...).