### PR TITLE
Fix invokebutton

### DIFF
--- a/pyrevitlib/pyrevit/runtime/InvokableDLLEngine.cs
+++ b/pyrevitlib/pyrevit/runtime/InvokableDLLEngine.cs
@@ -9,9 +9,6 @@ using pyRevitLabs.Common;
 
 namespace PyRevitLabs.PyRevit.Runtime {
     public class InvokableDLLEngine : ScriptEngine {
-        private string scriptSig = string.Empty;
-        private Assembly scriptAssm = null;
-
         public override void Init(ref ScriptRuntime runtime) {
             base.Init(ref runtime);
 
@@ -39,12 +36,8 @@ namespace PyRevitLabs.PyRevit.Runtime {
                         className = parts[1];
                     }
 
-                    var currentSig = CommonUtils.GetFileSignature(assmFile);
-                    if (scriptSig == null || currentSig != scriptSig) {
-                        scriptAssm = Assembly.Load(File.ReadAllBytes(assmFile));
-                        scriptSig = currentSig;
-                    }
 
+                    Assembly scriptAssm = Assembly.Load(File.ReadAllBytes(assmFile));
                     var resultCode = CLREngine.ExecuteExternalCommand(scriptAssm, className, ref runtime);
                     if (resultCode == ScriptExecutorResultCodes.ExternalInterfaceNotImplementedException)
                         TaskDialog.Show(PyRevitLabsConsts.ProductName,

--- a/pyrevitlib/pyrevit/runtime/InvokableDLLEngine.cs
+++ b/pyrevitlib/pyrevit/runtime/InvokableDLLEngine.cs
@@ -44,7 +44,7 @@ namespace PyRevitLabs.PyRevit.Runtime {
                             string.Format(
                                 "Can not find type \"{0}\" in assembly \"{1}\"",
                                 className,
-                                scriptAssm.Location
+                                assmFile
                                 ));
                     return resultCode;
                 }


### PR DESCRIPTION
I fixed a bug with the assembly cache that I introduced in the last PR.

Wrong bundle config

was
![image](https://github.com/eirannejad/pyRevit/assets/5417225/47bf5262-65b9-4a5e-a6af-74dbd47bfe89)

became
![image](https://github.com/eirannejad/pyRevit/assets/5417225/8cce3f23-f898-4404-a37f-497214a6601a)

