### PR TITLE
Bugfix/find rev clouds not show rev number

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -9,7 +9,7 @@ about: Create a report to help us improve
 
 ---
 
-**🙏 PLease use the search in the issue section before filing a new issue**
+**🙏 Please use the search in the issue section before filing a new issue**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pyRevit helps you quickly sketch out your automation and addon ideas, in whichev
 
 **↓** Read the pyRevit API reference to know everything about pyRevit available modules, functions, ...
 
-[PyRevit API Reference](https://ein.sh/pyRevit/reference/pyrevit/)
+[pyRevit API Reference](https://ein.sh/pyRevit/reference/pyrevit/)
 
 **↓** Read the docs to know everything about pyRevit scripts, extensions, ...
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ Made with [contrib.rocks](https://contrib.rocks)
 
 **</>** with 🖤 in [Portland](https://en.m.wikipedia.org/wiki/Portland,_Oregon), Oregon
 
-Copyright © 2014-2023 by Ehsan Iran-Nejad (pyrevitlabs.io) - All Rights Reserved
+Copyright © 2014-2024 by Ehsan Iran-Nejad (pyrevitlabs.io) - All Rights Reserved
 
 No part of this publication may be reproduced, distributed, or transmitted in any form or by any means, including photocopying, recording, or other electronic or mechanical methods, without the prior written permission of the publisher.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ pyRevit helps you quickly sketch out your automation and addon ideas, in whichev
 
 [Create Your First Command](https://www.notion.so/Create-Your-First-Command-2509b43e28bd498fba937f5c1be7f485)
 
+**↓** Read the pyRevit API reference to know everything about pyRevit available modules, functions, ...
+
+[PyRevit API Reference](https://ein.sh/pyRevit/reference/pyrevit/)
+
 **↓** Read the docs to know everything about pyRevit scripts, extensions, ...
 
 [Developer Docs](https://www.notion.so/Developer-Docs-2c88f3ecccde422d9504e20b6b9e04f8)
+
 
 **↓** pyRevit has a powerful command line utility
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Find All Revision Clouds On Views.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Find All Revision Clouds On Views.pushbutton/script.py
@@ -1,5 +1,7 @@
 from pyrevit import revit, DB
-
+from pyrevit import script
+output = script.get_output()
+output.close_others()
 
 revcs = DB.FilteredElementCollector(revit.doc)\
          .OfCategory(DB.BuiltInCategory.OST_RevisionClouds)\
@@ -12,12 +14,20 @@ for revc in revcs:
     else:
         rev = revit.doc.GetElement(revc.RevisionId)
         wrev = revit.query.get_name(rev)
-        print('REV#: {0}\t\tID: {2}\t\tON VIEW: {1}'
+        rev_number = revit.query.get_param(revc, "Revision Number").AsValueString()
+        rev_seq_id = revit.query.get_param(rev,
+                                        'Revision Number',
+                                        rev.SequenceNumber).AsValueString()
+        
+        rev_no = rev_number if not rev_seq_id else rev_seq_id
+        rev_seq_number = rev.SequenceNumber
+        selectable_cloud_id = output.linkify([revc.Id])
+
+        print('REV#: {rev_no}\t\tREV SEQ#: {rev_seq_no}\t\tID: {cloud_id}\t\tON VIEW: {view_name}'
               .format(
-                  revit.query.get_param(rev,
-                                        'RevisionNumber',
-                                        rev.SequenceNumber),
-                  revit.query.get_name(parent),
-                  revc.Id))
+                  rev_no=rev_no,
+                  view_name=revit.query.get_name(parent),
+                  cloud_id=selectable_cloud_id,
+                  rev_seq_no =rev_seq_number))
 
 print('\nSEARCH COMPLETED.')


### PR DESCRIPTION
Fixes #2003 
Adds a REV SEQ # to the output, to help distinguish between Revision Numbers and Sequence Numbers
Adds a linkified revision_cloud.Id for easy selection