### PR TITLE
Run CI workflow only official repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'eirannejad/pyRevit'
     runs-on: windows-latest
     steps:
       - name: Report Context


### PR DESCRIPTION
This adds a condition on the github workflow to only run on the main repository, so that the forks don't have to run and fail the workflow due to the signing related job steps.
