### PR TITLE
fix: recursion on emojis renderer

### DIFF
--- a/dev/pyRevitLabs/pyRevitLabs.Emojis.Tests/pyRevitLabs.Emojis.Tests.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Emojis.Tests/pyRevitLabs.Emojis.Tests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using pyRevitLabs.Emojis;
+
+namespace pyRevitLabs.Emojis.Tests
+{
+    public class Tests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void TestRepeatedEmojis()
+        {
+            var input = ":cross_mark: :cross_mark:";
+            var rendered = Emojis.Emojize(input);
+            var regex = new Regex("<span><img src=");
+            var matches = regex.Matches(rendered);
+            Assert.AreEqual(2, matches.Count);
+        }
+    }
+}

--- a/dev/pyRevitLabs/pyRevitLabs.Emojis.Tests/pyRevitLabs.Emojis.Tests.csproj
+++ b/dev/pyRevitLabs/pyRevitLabs.Emojis.Tests/pyRevitLabs.Emojis.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../pyRevitLabs.Emojis/pyRevitLabs.Emojis.csproj" />
+  </ItemGroup>
+</Project>

--- a/dev/pyRevitLabs/pyRevitLabs.Emojis/Emojis.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Emojis/Emojis.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Compression;
 using System.Drawing;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Reflection;
@@ -2645,10 +2646,12 @@ namespace pyRevitLabs.Emojis {
             if (_emojiZip is null)
                 ExtractEmojis();
 
-            var matches = new Regex(@"\:(?<code>[^\s]+?)\:").Matches(input);
+            var matches = new Regex(@"\:(?<code>[^\s]+?)\:").Matches(input)
+                .Cast<Match>()
+                .Select(m => m.Groups["code"].Value)
+                .Distinct();
             // find the emoji shorthands
-            foreach (Match match in matches) {
-                var emojiShortCode = match.Groups["code"].Value;
+            foreach (var emojiShortCode in matches) {
                 if (EmojiDict.ContainsKey(emojiShortCode)) {
                     // find the emoji unicode
                     var shortHand = string.Format(":{0}:", emojiShortCode);


### PR DESCRIPTION
fixes #2104 

Since this doesn't depend on Revit APIs, I added a unit test project that could be inserted in the CI pipeline (I will add it soon).

This still uses png icons, I'll tackle the unicode chars / emojis font in a separate PR.

This could be cherry picked in devel branch without any problem

