### PR TITLE
fix: reorder search paths

### DIFF
--- a/pyrevitlib/pyrevit/runtime/CPythonEngine.cs
+++ b/pyrevitlib/pyrevit/runtime/CPythonEngine.cs
@@ -197,15 +197,15 @@ namespace PyRevitLabs.PyRevit.Runtime {
 
             // manually add PYTHONPATH since we are overwriting the sys paths
             var pythonPath = Environment.GetEnvironmentVariable("PYTHONPATH");
-            if (pythonPath != null && pythonPath != string.Empty) {
+            if (!string.IsNullOrEmpty(pythonPath)) {
                 var searthPathStr = new PyString(pythonPath);
-                sysPaths.Insert(0, searthPathStr);
+                sysPaths.Append(searthPathStr);
             }
 
             // now add the search paths for the script bundle
-            foreach (string searchPath in runtime.ScriptRuntimeConfigs.SearchPaths.Reverse<string>()) {
+            foreach (string searchPath in runtime.ScriptRuntimeConfigs.SearchPaths) {
                 var searthPathStr = new PyString(searchPath);
-                sysPaths.Insert(0, searthPathStr);
+                sysPaths.Append(searthPathStr);
             }
         }
 


### PR DESCRIPTION
this will ensure cpython built-in libraries are used instead of pyrevit site-packages

Fixes the issue raised in [this discussion](https://discourse.pyrevitlabs.io/t/how-to-use-python-package-like-langchain/2673) and [this one](https://discourse.pyrevitlabs.io/t/exporting-graphes-chart-wrapper-object-and-3rd-party/1617).

To check that it works:

- create a python 3.8.5 environment and install a package in it, for example langchain
- set the environment path as PYTHONPATH or use `sys.path.append`
- `import langchain`
