### PR TITLE
fix: make pyrevitlib cpython compatible

### DIFF
--- a/pyrevitlib/pyrevit/runtime/__init__.py
+++ b/pyrevitlib/pyrevit/runtime/__init__.py
@@ -290,18 +290,19 @@ def _generate_runtime_asm():
     source_list = list(_get_source_files())
     # now try to compile
     try:
-        mlogger.debug('Compiling base types to: %s', RUNTIME_ASSM_FILE)
+        messages = List[str]()
         res, msgs = labs.Common.CodeCompiler.CompileCSharp(
-            sourceFiles=Array[str](source_list),
-            outputPath=RUNTIME_ASSM_FILE,
-            references=Array[str](
-                get_references()
+            Array[str](source_list),
+            RUNTIME_ASSM_FILE,
+            Array[str](get_references()),
+            Array[str](
+                [
+                    "REVIT{}".format(HOST_APP.version),
+                    "REVIT{}".format(HOST_APP.subversion.replace(".", "_")),
+                ]
             ),
-            defines=Array[str]([
-                "REVIT{}".format(HOST_APP.version),
-                "REVIT{}".format(HOST_APP.subversion.replace('.', '_'))
-            ]),
-            debug=False
+            False,
+            messages,
         )
         # log results
         logfile = RUNTIME_ASSM_FILE.replace('.dll', '.log')

--- a/pyrevitlib/pyrevit/runtime/__init__.py
+++ b/pyrevitlib/pyrevit/runtime/__init__.py
@@ -290,20 +290,35 @@ def _generate_runtime_asm():
     source_list = list(_get_source_files())
     # now try to compile
     try:
-        messages = List[str]()
-        res, msgs = labs.Common.CodeCompiler.CompileCSharp(
-            Array[str](source_list),
-            RUNTIME_ASSM_FILE,
-            Array[str](get_references()),
-            Array[str](
-                [
-                    "REVIT{}".format(HOST_APP.version),
-                    "REVIT{}".format(HOST_APP.subversion.replace(".", "_")),
-                ]
-            ),
-            False,
-            messages,
-        )
+        mlogger.debug("Compiling base types to: %s", RUNTIME_ASSM_FILE)
+        try:
+            res, msgs = labs.Common.CodeCompiler.CompileCSharp(
+                sourceFiles=Array[str](source_list),
+                outputPath=RUNTIME_ASSM_FILE,
+                references=Array[str](get_references()),
+                defines=Array[str](
+                    [
+                        "REVIT{}".format(HOST_APP.version),
+                        "REVIT{}".format(HOST_APP.subversion.replace(".", "_")),
+                    ]
+                ),
+                debug=False,
+            )
+        except TypeError:
+            msgs = List[str]()
+            res = labs.Common.CodeCompiler.CompileCSharp(
+                Array[str](source_list),
+                RUNTIME_ASSM_FILE,
+                Array[str](get_references()),
+                Array[str](
+                    [
+                        "REVIT{}".format(HOST_APP.version),
+                        "REVIT{}".format(HOST_APP.subversion.replace(".", "_")),
+                    ]
+                ),
+                False,
+                msgs,
+            )
         # log results
         logfile = RUNTIME_ASSM_FILE.replace('.dll', '.log')
         with open(logfile, 'w') as lf:


### PR DESCRIPTION
Here we go, I finally got around this major blocker!
I don't think this is the only fix needed, but it solves some errors such as #1749.

Pythonnet 3.8.5 is more picky about function signatures.
In my tests, it seems that IronPython still works ok, but I suppose it has to be tested by a "beta" group before a broader public release.

This is only needed for pyRevit 4, since it is related to the dynamic compilation of the pyRevit assemblies that will be incorporated into the pyRevitLabs solution the next major release.