### PR TITLE
Ci optimizations

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,10 +4,20 @@ on:
   push:
     branches:
       - docs
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - 'pyrevitlib/**'
+      - '*.md'
   # when PR from develop->master is created
   pull_request:
     branches:
       - master
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - 'pyrevitlib/**'
+      - '*.md'
   # manual run
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,24 @@ on:
   push:
     branches:
       - develop-4
+    paths:
+      - 'bin/**'
+      - 'dev/**'
+      - 'extensions/**'
+      - 'pyrevitlib/**'
+      - 'release/**'
+      - 'site-packages/**'
   # when PR from develop->master is created
   pull_request:
     branches:
       - master
+    paths:
+      - 'bin/**'
+      - 'dev/**'
+      - 'extensions/**'
+      - 'pyrevitlib/**'
+      - 'release/**'
+      - 'site-packages/**'
   # manual run
   workflow_dispatch:
 

--- a/.github/workflows/needs-info-manager.yml
+++ b/.github/workflows/needs-info-manager.yml
@@ -1,0 +1,13 @@
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  hello_world_job:
+    runs-on: ubuntu-latest
+    name: Toggle needs-more-info label
+    steps:
+      - name: Toggle needs-more-info label of issues
+        uses: jd-solanki/gh-action-toggle-awaiting-reply-label@v1.0.1      
+        with:
+          label: needs-more-info


### PR DESCRIPTION
- The main CI only runs if there are changes inside the source code folders
- The docs CI runs if the documentation or the pyrevitlib folder is changed
- Added a workflow to manage the `needs-more-info` label (automatically added if one of us comments on an issue, automaticalli removed if the author responds) - this works in tandem with the stale bot (that only works on issues labeled with `needs-more-info`.