### PR TITLE
fix: re-add dlls to bin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,13 +11,14 @@ extensions/*
 !extensions/extensions.json
 !extensions/README.md
 !extensions/pyRevitBundlesCreatorExtension.extension/
-bin/*
-!bin/engines
-!bin/pyrevit.svg
-!bin/pyrevit_outputwindow.png
-!bin/pyrevit_settings.png
-!bin/pyrevit-hosts.json
-!bin/pyrevit-products.json
+
+# bin/*
+# !bin/engines
+# !bin/pyrevit.svg
+# !bin/pyrevit_outputwindow.png
+# !bin/pyrevit_settings.png
+# !bin/pyrevit-hosts.json
+# !bin/pyrevit-products.json
 
 # ignore visual studio files
 **/.vs


### PR DESCRIPTION
I've commented the gitignore lines that prevented binaries to be committed in the bin folder.

This should also be merged/cherry picked to the develop-4 branch.

For pyrevit5, we need to have a discussion about the future of pyrevit cli!