### PR TITLE
docs: set the domain for github pages once and for all

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.pyrevitlabs.io


### PR DESCRIPTION
Avoiding the silent, manual work of @jmcouffin and following what the [MkDocs docs says](https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains):

> ... If you use the web interface, GitHub will create the CNAME file for you and save it to the root of your "pages" branch. So that the file does not get removed the next time you deploy, you need to copy the file to your docs_dir. With the file properly included in your docs_dir, MkDocs will include the file in your built site and push it to your "pages" branch each time you run the gh-deploy command.