### PR TITLE
Copy Sheets to Open Documents: add “Preserve detail numbers” option (default ON), safer param handling, and richer logs

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Sheets to Open Documents.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Sheets to Open Documents.pushbutton/script.py
@@ -352,26 +352,38 @@ def apply_detail_number(original_vport, nvport):
         error_msg = "Missing view. Cannot match detail number"
         print("\t\t\t{}".format(error_msg))
         logger.error(error_msg)
+        return
     else:
         # Only apply detail number if the option is checked
         if OPTION_SET.op_preserve_detail_numbers:
             try:
                 dtl_num_param = DB.BuiltInParameter.VIEWPORT_DETAIL_NUMBER
-                original_detail_param = original_vport.get_Parameter(dtl_num_param) 
-                if original_detail_param: 
-                    original_detail_num = original_detail_param.AsString() 
+                original_detail_param = original_vport.get_Parameter(dtl_num_param)
+                if original_detail_param:
+                    original_detail_num = original_detail_param.AsString()
                     if original_detail_num:
-                        nvport.get_Parameter(dtl_num_param).Set(original_detail_num)
                         dest_param = nvport.get_Parameter(dtl_num_param)
                         if dest_param and not dest_param.IsReadOnly:
                             dest_param.Set(original_detail_num)
-                            print("\t\t\tPreserved detail number: {}".format(original_detail_num))
+                            print(
+                                "\t\t\tPreserved detail number: {}".format(
+                                    original_detail_num
+                                )
+                            )
                         else:
-                            logger.error("Destination viewport parameter for detail number is missing or read-only.")
-                            print("\t\t\tCould not preserve detail number: destination parameter issue")
-            except (AttributeError, System.ArgumentException) as e: 
-                logger.error("Error setting detail number: {}".format(str(e))) 
-                print("\t\t\tCould not preserve detail number: parameter issue ({})".format(str(e)))
+                            logger.error(
+                                "Destination viewport parameter for detail number is missing or read-only."
+                            )
+                            print(
+                                "\t\t\tCould not preserve detail number: destination parameter issue"
+                            )
+            except (AttributeError, System.ArgumentException) as e:
+                logger.error("Error setting detail number: {}".format(str(e)))
+                print(
+                    "\t\t\tCould not preserve detail number: parameter issue ({})".format(
+                        str(e)
+                    )
+                )
         else:
             print("\t\t\tSkipping detail number preservation (option not checked)")
 


### PR DESCRIPTION
# Copy Sheets to Open Documents: add “Preserve detail numbers” option (default ON), safer param handling, and richer logs

## Description
Extends PR [#2704](https://github.com/pyrevitlabs/pyRevit/pull/2704) by making preservation of viewport **Detail Number** optional.  Default is **ON** to match current behavior. Adds `try/except` guards to avoid script failure when the parameter is missing, and improves logging for transparency.


## Changes
- Added checkbox: **Preserve Detail Numbers** (default ON).
- Wrapped parameter read/write in `try/except` to prevent transaction rollback.
- More detailed logs: per-viewport outcome (preserved, renumbered, skipped).

## Why
- Some workflows require fresh numbering instead of preserving originals.
- Prevents crashes in models where the parameter isn’t available.
- Clearer feedback during batch copy.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

- Enhanced PR #[#2704](https://github.com/pyrevitlabs/pyRevit/pull/2704)

---

## Additional Notes

<img width="383" height="458" alt="option" src="https://github.com/user-attachments/assets/07250e4e-567b-48b5-98e6-ce28aa65e97d" />

<img width="685" height="460" alt="logs" src="https://github.com/user-attachments/assets/3a3623af-e549-48ce-91b9-6d7043b3b498" />
