### PR TITLE
Fix: Create config directory before writing

### DIFF
--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConfigs.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConfigs.cs
@@ -129,7 +129,9 @@ namespace pyRevitLabs.PyRevit
 
                 try
                 {
-                    CommonUtils.EnsurePath(Path.GetDirectoryName(targetFile));
+                    var directory = Path.GetDirectoryName(targetFile);
+                    if (!string.IsNullOrEmpty(directory))
+                        CommonUtils.EnsurePath(directory);
                     File.WriteAllText(targetFile, File.ReadAllText(sourceFile));
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Ensures the destination directory exists before writing the config file.

When setting up the user config file from a template, the code did not ensure that the destination directory existed before attempting to write the file. This would cause an error if the directory did not exist, which is the case for a new user.

This change adds a call to `CommonUtils.EnsurePath` to create the directory if it does not exist.

Trying to fix #2595
