### PR TITLE
Better error message for linkify if too many elements are selected

### DIFF
--- a/pyrevitlib/pyrevit/output/linkmaker.py
+++ b/pyrevitlib/pyrevit/output/linkmaker.py
@@ -1,7 +1,6 @@
 """Handle creation of output window helper links."""
 
 from pyrevit.compat import safe_strtype, get_elementid_value_func
-from pyrevit import DB
 from pyrevit.coreutils.logger import get_logger
 
 
@@ -63,7 +62,21 @@ def make_link(element_ids, contents=None):
     link_title = ', '.join(strids)
 
     if len(reviturl) >= 2000:
-        alertjs = 'alert(&quot;Url was too long and discarded!&quot;);'
+        total_length = 0
+        max_elements = 0
+        elementquery_parts = ['element[]=' + strid for strid in strids]
+        for i, part in enumerate(elementquery_parts):
+            if i > 0:
+                total_length += 1  # for '&'
+            total_length += len(part)
+            if total_length >= 2000:
+                break
+            max_elements += 1
+
+        alertjs = \
+            'alert(&quot;URL was too long ({} characters). Maximum allowed is 2000. '\
+            'Only {} out of {} elements could fit.&quot;);'\
+            .format(len(reviturl), max_elements, len(strids))
         linkattrs_select = 'href="#" onClick="{}"'.format(alertjs)
         linkattrs_show = linkattrs_select
     else:


### PR DESCRIPTION
## Description

Adds a detailed count of displayable elements as well as total selected elements to the error message. Calculation is only run inside the if statement.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2847

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
