### PR TITLE
Update cad_audit_check.py - Partial Compatibility with Cloud CAD Files

### DIFF
--- a/extensions/pyRevitTools.extension/checks/cad_audit_check.py
+++ b/extensions/pyRevitTools.extension/checks/cad_audit_check.py
@@ -83,17 +83,20 @@ def get_load_stat(cad, is_link):
     cad_type = doc.GetElement(cad.GetTypeId()) # Retreive the type from the instance
     
     if not is_link:
-        return ":warning: IMPORTED" # Not an external reference
+        return ":warning: IMPORTED"
+        
     try:
         exfs = cad_type.GetExternalFileReference()
+        if not exfs:
+            return ":warning: IMPORTED"
         status = exfs.GetLinkedFileStatus().ToString()
     except Exception:
         # Fallback for cloud-based CAD links (ACC/ADC)
         exfs = cad_type.GetExternalResourceReferences()
-        # exfs is a dictionary: {ExternalResourceType: ExternalResourceReference}
-        # Get the first ExternalResourceReference if there is one
         ext_ref = next(iter(exfs.Values)) if exfs.Count > 0 else None
-        status = ext_ref.GetResourceVersionStatus().ToString() if ext_ref else None
+        if not ext_ref:
+            return ":warning: IMPORTED"
+        status = ext_ref.GetResourceVersionStatus().ToString()
 
     if not exfs:
         return ":warning: IMPORTED" # Not an external reference


### PR DESCRIPTION
This PR addresses a persistent issue where the tool throws an exception when the model includes links on Autodesk Desktop Connector. The original method for acquiring file references (GetExternalFileReference()) is not functional for linked files on ACC/ADC. As an alternative, GetResourceReferences.GetResourceVersionStatus is used, which provides partial information about the file status, such as "Current," "Out of Date," and "Not Found." However, a limitation of this approach is the lack of an API method to retrieve the linked file status. This solution makes the check to work good enough


# Update cad_audit_check.py - Partial Compatibility with Cloud CAD Files

## Description

This PR addresses a persistent issue where the tool throws an exception when the model includes links on Autodesk Desktop Connector. The original method for acquiring file references (GetExternalFileReference()) is not functional for linked files on ACC/ADC. As an alternative, GetResourceReferences.GetResourceVersionStatus is used, which provides partial information about the file status, such as "Current," "Out of Date," and "Not Found." However, a limitation of this approach is the lack of an API method to retrieve the linked file status. This solution makes the check to work good enough

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ok ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ok ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ ok] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
