### PR TITLE
added loop to tooltip playback

### DIFF
--- a/pyrevitlib/pyrevit/coreutils/ribbon.py
+++ b/pyrevitlib/pyrevit/coreutils/ribbon.py
@@ -781,6 +781,17 @@ class _PyRevitRibbonButton(GenericPyRevitUIContainer):
                 _StackPanel = System.Windows.Controls.StackPanel()
                 _video = System.Windows.Controls.MediaElement()
                 _video.Source = Uri(tooltip_video)
+                _video.LoadedBehavior = System.Windows.Controls.MediaState.Manual
+                _video.UnloadedBehavior = System.Windows.Controls.MediaState.Manual
+
+                def on_media_ended(sender, args):
+                    sender.Position = System.TimeSpan.Zero
+                    sender.Play()
+                _video.MediaEnded += on_media_ended
+
+                def on_loaded(sender, args):
+                    sender.Play()
+                _video.Loaded += on_loaded
                 _StackPanel.Children.Add(_video)
                 adwindows_obj.ToolTip.ExpandedContent = _StackPanel
                 adwindows_obj.ResolveToolTip()


### PR DESCRIPTION
## Description

Added video looping functionality to ribbon button tooltip videos. When a tooltip video is set using `set_tooltip_video()`, it will now automatically loop continuously instead of stopping after playing once. This enhances the user experience by providing persistent visual guidance in tooltips without requiring manual replay.

The implementation uses `MediaElement`'s manual playback control with event handlers to reset and restart the video when it reaches the end, creating a seamless looping effect.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2863

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
