### PR TITLE
Refactor button title handling in _PyRevitRibbonPanel

### DIFF
--- a/pyrevitlib/pyrevit/coreutils/ribbon.py
+++ b/pyrevitlib/pyrevit/coreutils/ribbon.py
@@ -1472,8 +1472,6 @@ class _PyRevitRibbonPanel(GenericPyRevitUIContainer):
                                  avail_class_name=None,
                                  update_if_exists=False,
                                  ui_title=None):
-        if ui_title:
-            self.button(button_name).set_title(ui_title)
         self.create_push_button(button_name=button_name,
                                 asm_location=asm_location,
                                 class_name=class_name,
@@ -1484,7 +1482,7 @@ class _PyRevitRibbonPanel(GenericPyRevitUIContainer):
                                 ctxhelpurl=ctxhelpurl,
                                 avail_class_name=avail_class_name,
                                 update_if_exists=update_if_exists,
-                                ui_title=None)
+                                ui_title=ui_title)
         self.set_dlglauncher(self.button(button_name))
 
 


### PR DESCRIPTION
Removed the conditional setting of the button title and streamlined the push button creation process by directly passing the ui_title parameter. This improves code clarity and consistency.
Fixes [Bug]: Panelbutton no longer working in 5.3.0 #2907

