### PR TITLE
Fix Splasher Create View Filters for View Templates

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/ColorSplasher.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/ColorSplasher.pushbutton/script.py
@@ -496,7 +496,9 @@ class CreateFilters(UI.IExternalEventHandler):
                 # Redirect to template if one exists
                 template_id = view.ViewTemplateId
                 if template_id != DB.ElementId.InvalidElementId:
-                    view = new_doc.GetElement(template_id)
+                    template_view = new_doc.GetElement(template_id)
+                    if template_view:
+                        view = template_view
 
                 dict_filters = {}
                 for filt_id in view.GetFilters():
@@ -631,6 +633,7 @@ class CreateFilters(UI.IExternalEventHandler):
 
     def GetName(self):
         return "Create Filters"
+
 
 
 class ValuesInfo:


### PR DESCRIPTION



# Fix Splasher Create View Filters for View Templates

## Description

Fixed issue where "Create View Filters" would not work when being applied to a view template. Previously the overrides would be applied <By Filter> but the filter would not appear in the view templates Filters list - and would be unable to be adjusted / removed.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---
