### PR TITLE
Print Sheets: using Revit Internal Printer is now optional

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
@@ -809,9 +809,17 @@ class PrintSheetsWindow(forms.WPFWindow):
 
     def _setup_printers(self):
         printers = list(Drawing.Printing.PrinterSettings.InstalledPrinters)
+
+        if IS_REVIT_2022_OR_NEWER:
+            printers.insert(0, "Revit Internal Printer")
+            
         self.printers_cb.ItemsSource = printers
-        print_mgr = self._get_printmanager()
-        self.printers_cb.SelectedItem = print_mgr.PrinterName
+        
+        if IS_REVIT_2022_OR_NEWER and "Revit Internal Printer" in printers:
+            self.printers_cb.SelectedItem = "Revit Internal Printer"
+        else:
+            print_mgr = self._get_printmanager()
+            self.printers_cb.SelectedItem = print_mgr.PrinterName
 
     def _get_psetting_items(self, doc,
                             psettings=None, include_varsettings=False):
@@ -1058,7 +1066,8 @@ class PrintSheetsWindow(forms.WPFWindow):
                 if not per_sheet_psettings:
                     print_mgr.PrintSetup.CurrentPrintSetting = \
                         self.selected_print_setting.print_settings
-                print_mgr.SelectNewPrintDriver(self.selected_printer)
+                if not (IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer"):
+                    print_mgr.SelectNewPrintDriver(self.selected_printer)
                 print_mgr.PrintRange = DB.PrintRange.Current
             except Exception as cpSetEx:
                 forms.alert(
@@ -1090,7 +1099,7 @@ class PrintSheetsWindow(forms.WPFWindow):
                                             try:
                                                 pb1.update_progress(pbCount1, pbTotal1)
                                                 pbCount1 += 1
-                                                if IS_REVIT_2022_OR_NEWER:
+                                                if IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer":
                                                     optspdf = PrintUtils.pdf_opts()
                                                     PrintUtils.export_sheet_pdf(dirPath, sheet.revit_sheet, optspdf, doc, sheet.print_filename)
                                                 else:
@@ -1139,7 +1148,7 @@ class PrintSheetsWindow(forms.WPFWindow):
                                             try:
                                                 pb1.update_progress(pbCount1, pbTotal1)
                                                 pbCount1 += 1
-                                                if IS_REVIT_2022_OR_NEWER:
+                                                if IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer":
                                                     optspdf = PrintUtils.pdf_opts()
                                                     PrintUtils.export_sheet_pdf(dirPath, sheet.revit_sheet, optspdf, doc, sheet.print_filename)
                                                 else:
@@ -1161,7 +1170,8 @@ class PrintSheetsWindow(forms.WPFWindow):
         # make sure we can access the print config
         print_mgr = self._get_printmanager()
         print_mgr.PrintToFile = True
-        print_mgr.SelectNewPrintDriver(self.selected_printer)
+        if not (IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer"):
+            print_mgr.SelectNewPrintDriver(self.selected_printer)
         print_mgr.PrintRange = DB.PrintRange.Current
 
 
@@ -1193,7 +1203,7 @@ class PrintSheetsWindow(forms.WPFWindow):
                                     try:
                                         pb1.update_progress(pbCount1, pbTotal1)
                                         pbCount1 += 1
-                                        if IS_REVIT_2022_OR_NEWER:
+                                        if IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer":
                                             optspdf = PrintUtils.pdf_opts()
                                             PrintUtils.export_sheet_pdf(dirPath, sheet.revit_sheet, optspdf, doc, sheet.print_filename)
                                         else:
@@ -1476,6 +1486,10 @@ class PrintSheetsWindow(forms.WPFWindow):
 
     def printers_changed(self, sender, args):
         print_mgr = self._get_printmanager()
+
+        if self.selected_printer == "Revit Internal Printer":
+            return
+    
         print_mgr.SelectNewPrintDriver(self.selected_printer)
         self._setup_print_settings()
 


### PR DESCRIPTION
# Print Sheets: using Revit Internal Printer is now optional

## Description

Previously, the user selected printer was ignored and 'Revit Internal Printer' was always used if Revit version = 2022+.

Now, 'Revit Internal Printer' is the default option in the printer list, but the user can choose an alternative printer (e.g., PDF24).

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2929
---


