### PR TITLE
unify API change handling 

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Sum.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Sum.pushbutton/script.py
@@ -17,7 +17,7 @@ ParamDef = namedtuple("ParamDef", ["name", "type", "spec"])
 
 
 def is_calculable_param(param):
-    if HOST_APP.is_newer_than(2022) and not param.Definition.GetDataType().TypeId:
+    if HOST_APP.is_newer_than(2021) and not param.Definition.GetDataType().TypeId:
         return False
 
     if param.StorageType == DB.StorageType.Double:
@@ -32,14 +32,14 @@ def is_calculable_param(param):
 
 
 def get_definition_type(definition):
-    if HOST_APP.is_newer_than(2022):
+    if HOST_APP.is_newer_than(2021):
         return definition.GetDataType()
     else:
         return definition.ParameterType
 
 
 def get_definition_spec(definition):
-    if HOST_APP.is_newer_than(2022):
+    if HOST_APP.is_newer_than(2021):
         return DB.LabelUtils.GetLabelForSpec(definition.GetDataType())
     else:
         return definition.ParameterType
@@ -76,12 +76,12 @@ def calc_param_total(element_list, param_name):
 
 def format_value(total, unit_type):
     format_options = revit.doc.GetUnits().GetFormatOptions(unit_type)
-    try:
-        units = format_options.DisplayUnits
-        label = DB.LabelUtils.GetLabelFor(units)
-    except AttributeError:
+    if HOST_APP.is_newer_than(2021):
         units = format_options.GetUnitTypeId()
         label = DB.LabelUtils.GetLabelForUnit(units)
+    else:
+        units = format_options.DisplayUnits
+        label = DB.LabelUtils.GetLabelFor(units)
     return "{} {}".format(DB.UnitUtils.ConvertFromInternalUnits(total, units), label)
 
 


### PR DESCRIPTION

## Description

to always use .is_newer_than instead of tr-catch, also use correct version (2022 was the last version where both APIs where supported)

This fixes the missing unit label in the output window. Was always printed in internal units without a label (only version 2022 affected)

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2934 

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
