### PR TITLE
wrap editfamily in try except to catch non revit errors

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/ListFamilySizeCreator.pushbutton/ListFamilySizeCreator_script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/ListFamilySizeCreator.pushbutton/ListFamilySizeCreator_script.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from pyrevit import revit, forms, script, DB, HOST_APP
 
 output = script.get_output()
+logger = script.get_logger()
 
 FIELDS = ["Size", "Name", "Category", "Creator", "Count"]
 # temporary path for saving families
@@ -155,7 +156,7 @@ with forms.ProgressBar(title="List family sizes", cancellable=True) as pb:
                 except Exception as ex:
                     logger.warning(
                         "Skipping family '%s': could not open for edit: %s",
-                        fam, ex
+                        fam.Name, ex
                     )
                     continue
                 fam_path = fam_doc.PathName
@@ -163,8 +164,6 @@ with forms.ProgressBar(title="List family sizes", cancellable=True) as pb:
                 #  only if the wasn't opened when the script was started
                 if fam_doc.Title not in opened_families and (
                         not fam_path or not os.path.exists(fam_path)):
-                    # edit family
-                    fam_doc = revit.doc.EditFamily(fam)
                     # save with temporary path, to know family size
                     fam_path = os.path.join(temp_dir, fam_doc.Title)
                     fam_doc.SaveAs(fam_path, save_as_options)


### PR DESCRIPTION
## Description

This PR improves the family-parameter comparison routine by making it more robust against failures when opening families for editing. Previously, `EditFamily` exceptions (e.g., *Loaded Family Editing failed*) caused the entire script to stop.

The updated logic safely wraps `EditFamily` in a `try/except`, logs descriptive messages, skips problematic families, and continues processing the rest. It also ensures family documents are closed properly and keeps the existing `ErrorSwallower` handling for internal Revit failures.

Overall, this change prevents crashes, improves error visibility, and makes the batch-processing workflow more reliable.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2949

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
