### PR TITLE
Fix override graphics behaviour for renumber tool

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit2.stack/ReNumber.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit2.stack/ReNumber.pushbutton/script.py
@@ -272,7 +272,7 @@ def _unmark_collected(category_name, target_views, renumbered_element_ids):
         unmark_renamed_elements(target_views, renumbered_element_ids)
 
 
-def pick_and_renumber(rnopts, starting_index):
+def pick_and_renumber(rnopts, starting_index, pb):
     """Main renumbering routine for elements of given category."""
     # all actions under one transaction
     if rnopts.bicat != BIC.OST_Viewports:
@@ -293,6 +293,7 @@ def pick_and_renumber(rnopts, starting_index):
                     message="Select {} in order".format(rnopts.name.lower())):
                 # need nested transactions to push revit to update view
                 # on each renumber task
+                pb.update_progress(int(index), int(starting_index))
                 with revit.Transaction("Renumber {}".format(rnopts.name)):
                     # record the renumbered element
                     if picked_element.Id not in renumbered_element_ids:
@@ -432,7 +433,10 @@ if isinstance(revit.active_view, ALLOWED_VIEW_CLASSES):
         else:
             starting_number = ask_for_starting_number(selected_option.name)
             if starting_number:
-                with forms.WarningBar(
-                    title='Pick {} One by One. ESCAPE to end.'.format(
-                        selected_option.name)):
-                    pick_and_renumber(selected_option, starting_number)
+                with forms.ProgressBar(
+                    title="Pick {} One by One. ESCAPE to end. Current(Last set): {{value}}. Start: {{max_value}}".format(
+                        selected_option.name
+                    )
+                ) as pb:
+                    pb.update_progress(int(starting_number), int(starting_number))
+                    pick_and_renumber(selected_option, starting_number, pb)


### PR DESCRIPTION
## Description

- add areaplan and 3d view
- change mark element to also affect open views of selected categories, like unmark
- store the current override if any to restore during unmark. previously custom per element overrides would be reset.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2951 

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
