### PR TITLE
same postfix in reset as in get

### DIFF
--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -201,7 +201,7 @@ def reset_config(section=None):
     """
     from pyrevit.userconfig import user_config
     if not section:
-        script_cfg_postfix = 'config'
+        script_cfg_postfix = '_config'
         section = EXEC_PARAMS.command_name + script_cfg_postfix
     elif section in [PyRevit.PyRevitConsts.ConfigsCoreSection]:
         raise PyRevitException('Can not remove internal config section: {}'


### PR DESCRIPTION
## Description

Underscore added in #2798 was leading to reset no longer working. Added missing underscore there.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
