### PR TITLE
remove runtime dependent arguments from default

### DIFF
--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -802,7 +802,7 @@ def data_exists(slot_name, this_project=True):
     return os.path.exists(data_file)
 
 
-def restore_window_position(window, command_name=EXEC_PARAMS.command_name):
+def restore_window_position(window, command_name=None):
     """
     Restore window position from saved data.
 
@@ -813,6 +813,8 @@ def restore_window_position(window, command_name=EXEC_PARAMS.command_name):
     Returns:
         bool: True if position was restored, False if centered to screen
     """
+    if not command_name:
+        command_name = EXEC_PARAMS.command_name
     storage_key = "last_window_position_" + command_name
 
     try:
@@ -847,7 +849,7 @@ def restore_window_position(window, command_name=EXEC_PARAMS.command_name):
         return False
 
 
-def save_window_position(window, command_name=EXEC_PARAMS.command_name):
+def save_window_position(window, command_name=None):
     """
     Save window position to persistent storage.
 
@@ -855,6 +857,8 @@ def save_window_position(window, command_name=EXEC_PARAMS.command_name):
         window (System.Windows.Window): WPF window instance
         command_name (str): Unique identifier for this window
     """
+    if not command_name:
+        command_name = EXEC_PARAMS.command_name
     storage_key = "last_window_position_" + command_name
     position_data = {
         "Left": window.Left,


### PR DESCRIPTION
## Description

This pull request fixes an issue where a command-related value was evaluated only once at load time and reused across executions, leading to stale command context being used. The update ensures the command context is resolved at runtime, so the correct command is used on every execution.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #3044

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
