### PR TITLE
Fix PATH for correct user when per-user installer is run as administrator

### DIFF
--- a/release/pyrevit-cli.iss
+++ b/release/pyrevit-cli.iss
@@ -54,7 +54,7 @@ Source: "..\bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion
 ; When run as admin, HKCU would be the elevated user's; PATH is set in CurStepChanged via ExecAsOriginalUser instead.
 ; https://stackoverflow.com/a/3431379/2350244
 ; https://stackoverflow.com/a/9962307/2350244 (mod path module)
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\bin"; Check: NotAdmin
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\bin"; Check: NotAdminAndPathNotExists
 
 [Run]
 Filename: "{app}\bin\pyrevit.exe"; Description: "Clearning caches..."; Parameters: "caches clear --all"; Flags: runhidden
@@ -65,23 +65,43 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden
 
 [Code]
-function NotAdmin: Boolean;
+function NotAdminAndPathNotExists: Boolean;
+var
+  OrigPath: String;
+  AppPath: String;
 begin
   Result := not IsAdmin;
+  if Result then
+  begin
+    AppPath := ExpandConstant('{app}\bin');
+    if RegQueryStringValue(HKCU, 'Environment', 'Path', OrigPath) then
+      Result := Pos(';' + Uppercase(AppPath) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
+  end;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   Params: String;
+  InstallPathEscaped: String;
   ResultCode: Integer;
 begin
   if (CurStep = ssPostInstall) and IsAdmin then
   begin
-    Params := '-NoProfile -ExecutionPolicy Bypass -Command ''[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", "User") + ";' + ExpandConstant('{app}\bin') + '", "User")''';
+    InstallPathEscaped := ExpandConstant('{app}\bin');
+    StringChangeEx(InstallPathEscaped, '''', '''''', True);
+    Params := '-NoProfile -ExecutionPolicy Bypass -Command "' +
+      '$appPath = ''' + InstallPathEscaped + ''';' +
+      '$userPath = [Environment]::GetEnvironmentVariable(''Path'', ''User'');' +
+      'if ($userPath -notlike "' + '"*$appPath*"' + '") {' +
+      '  [Environment]::SetEnvironmentVariable(''Path'', $userPath + '';'' + $appPath, ''User'')' +
+      '}"';
     if ExecAsOriginalUser(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'), Params, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
       Log('Added install path to original user PATH')
     else
+    begin
       Log('ExecAsOriginalUser failed or non-zero exit when adding PATH');
+      MsgBox('pyRevit CLI could not update your user PATH environment variable.' + #13#10 + #13#10 + 'You may need to add the install directory to PATH manually:' + #13#10 + '  ' + ExpandConstant('{app}\bin') + #13#10 + #13#10 + 'Alternatively, re-run this installer without elevation so PATH can be updated automatically.', mbError, MB_OK);
+    end;
   end;
 end;
 

--- a/release/pyrevit.iss
+++ b/release/pyrevit.iss
@@ -76,7 +76,7 @@ Source: "..\pyRevitfile"; DestDir: "{app}"; Flags: ignoreversion; Components: co
 ; When run as admin, HKCU would be the elevated user's; PATH is set in CurStepChanged via ExecAsOriginalUser instead.
 ; https://stackoverflow.com/a/3431379/2350244
 ; https://stackoverflow.com/a/9962307/2350244 (mod path module)
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\bin"; Check: NotAdmin
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\bin"; Check: NotAdminAndPathNotExists
 
 [Run]
 Filename: "{app}\bin\pyrevit.exe"; Description: "Clearning caches..."; Parameters: "caches clear --all"; Flags: runhidden
@@ -89,23 +89,43 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden
 
 [Code]
-function NotAdmin: Boolean;
+function NotAdminAndPathNotExists: Boolean;
+var
+  OrigPath: String;
+  AppPath: String;
 begin
   Result := not IsAdmin;
+  if Result then
+  begin
+    AppPath := ExpandConstant('{app}\bin');
+    if RegQueryStringValue(HKCU, 'Environment', 'Path', OrigPath) then
+      Result := Pos(';' + Uppercase(AppPath) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
+  end;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   Params: String;
+  InstallPathEscaped: String;
   ResultCode: Integer;
 begin
   if (CurStep = ssPostInstall) and IsAdmin then
   begin
-    Params := '-NoProfile -ExecutionPolicy Bypass -Command ''[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", "User") + ";' + ExpandConstant('{app}\bin') + '", "User")''';
+    InstallPathEscaped := ExpandConstant('{app}\bin');
+    StringChangeEx(InstallPathEscaped, '''', '''''', True);
+    Params := '-NoProfile -ExecutionPolicy Bypass -Command "' +
+      '$appPath = ''' + InstallPathEscaped + ''';' +
+      '$userPath = [Environment]::GetEnvironmentVariable(''Path'', ''User'');' +
+      'if ($userPath -notlike "' + '"*$appPath*"' + '") {' +
+      '  [Environment]::SetEnvironmentVariable(''Path'', $userPath + '';'' + $appPath, ''User'')' +
+      '}"';
     if ExecAsOriginalUser(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'), Params, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
       Log('Added install path to original user PATH')
     else
+    begin
       Log('ExecAsOriginalUser failed or non-zero exit when adding PATH');
+      MsgBox('pyRevit was installed, but the installer could not update the original user PATH environment variable.' + #13#10 + #13#10 + 'You may need to manually add the following folder to your user PATH, or re-run the installer without administrative privileges:' + #13#10 + '  ' + ExpandConstant('{app}\bin'), mbError, MB_OK);
+    end;
   end;
 end;
 


### PR DESCRIPTION
Per-user installers (`pyRevit_*_signed.exe` and `pyRevit_CLI_*_signed.exe`) write the install path to `HKCU\Environment\Path`. When the user runs the installer "Run as administrator", the process runs elevated and HKCU refers to the elevated user's registry, so PATH is updated only for the admin account and `pyrevit` is not found in a normal (non-admin) command prompt.

## Changes
- **pyrevit.iss** and **pyrevit-cli.iss**: Added `Check: NotAdmin` to the `[Registry]` PATH entry so the HKCU write runs only when the installer is not elevated. When the installer *is* elevated (`IsAdmin`), `CurStepChanged(ssPostInstall)` uses `ExecAsOriginalUser` to run PowerShell and append `{app}\bin` to the original (logged-in) user's PATH. Added a short comment in the Registry section explaining this.

## Result
Running the per-user CLI or full pyRevit installer as administrator now updates PATH for the user who started the installer, so `pyrevit` works in a regular (non-admin) cmd. Normal (non-elevated) installs are unchanged.

- Added logic to conditionally update the user PATH variable only when not running as an admin.
- Implemented a new function to execute PowerShell commands as the original user to ensure proper PATH updates.
- Updated registry settings to prevent multiple installations from incorrectly modifying the PATH for elevated users.

