### PR TITLE
SCCM / SYSTEM — run all admin installer steps as installer account

### DIFF
--- a/release/pyrevit-admin.iss
+++ b/release/pyrevit-admin.iss
@@ -78,14 +78,14 @@ Source: "..\pyRevitfile"; DestDir: "{app}"; Flags: ignoreversion; Components: co
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\bin"
 
 [Run]
-Filename: "{app}\bin\pyrevit.exe"; Description: "Clearning caches..."; Parameters: "caches clear --all"; Flags: runhidden runascurrentuser
-Filename: "{app}\bin\pyrevit.exe"; Description: "Detach existing clones..."; Parameters: "detach --all"; Flags: runhidden runascurrentuser
-Filename: "{app}\bin\pyrevit.exe"; Description: "Registering this clone..."; Parameters: "clones add this master --force"; Flags: runhidden runascurrentuser
+Filename: "{app}\bin\pyrevit.exe"; Description: "Clearning caches..."; Parameters: "caches clear --all"; Flags: runhidden
+Filename: "{app}\bin\pyrevit.exe"; Description: "Detach existing clones..."; Parameters: "detach --all"; Flags: runhidden
+Filename: "{app}\bin\pyrevit.exe"; Description: "Registering this clone..."; Parameters: "clones add this master --force"; Flags: runhidden
 Filename: "{app}\bin\pyrevit.exe"; Description: "Attaching this clone..."; Parameters: "attach master default --installed --allusers"; Flags: runhidden
 
 [UninstallRun]
-Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches clear --all"; Flags: runhidden runascurrentuser
-Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden runascurrentuser
+Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches clear --all"; Flags: runhidden
+Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden
 
 [Code]
 procedure CurStepChanged(CurStep: TSetupStep);


### PR DESCRIPTION
## What

Admin installer: run **all** post-install and uninstall steps as the installing account (no `runascurrentuser`), so when deployed as SYSTEM (e.g. SCCM) every step can succeed and write to all-users / ProgramData.

**File:** `release/pyrevit-admin.iss`  
**Change:** Remove `runascurrentuser` from all `[Run]` and `[UninstallRun]` entries (keep `runhidden`). Aligns with the per-user installer (`pyrevit.iss`), which uses only `runhidden` for these steps.

## Why

Fixes #2923 — pyRevit installed via SCCM (Windows System account) should show as attached for all users.

Under SCCM the installer runs as SYSTEM; there is no interactive "current user." With `runascurrentuser`, every step (caches clear, detach, clones add, attach) could skip or run in a broken context. Running all steps as the installer (SYSTEM) ensures:

- **clones add** registers the master in ProgramData (all-users config).
- **attach** creates the `.addin` in the all-users Revit Addins folder so every user sees the pyRevit tab.
- **Uninstall:** caches clear and detach run as SYSTEM so SCCM uninstall cleans up correctly.

## Verification

- **SCCM / psexec -s:** Run admin installer as SYSTEM. As a normal user run `pyrevit attached` — should list the attachment (master | AllUsers | path). Revit should show the pyRevit tab. Uninstall as SYSTEM; all-users .addin and caches should be cleaned.
- **Interactive admin:** Run admin installer as administrator. All steps run as admin; normal users should see the attachment.
- **Per-user installer:** Unchanged; no edits to `release/pyrevit.iss`.
