### PR TITLE
Fix Inno Setup installer GUIDs (RFC #2519)

### DIFF
--- a/dev/_release.py
+++ b/dev/_release.py
@@ -120,10 +120,6 @@ def set_product_data(_: Dict[str, str]):
     pyrevit_pc = _get_new_product_code()
     pyrevitcli_pc = _get_new_product_code()
 
-    # update product info on installer files
-    _installer_set_uuid(pyrevit_pc, configs.PYREVIT_INSTALLER_FILES)
-    _installer_set_uuid(pyrevitcli_pc, configs.PYREVIT_CLI_INSTALLER_FILES)
-
     # update product info on MSI installer files
     _msi_set_uuid(
         pyrevit_pc,


### PR DESCRIPTION
## Issue

Addresses **RFC #2519**: "installers GUID must stay the same in order to detect versions of the same app."

Previously, `set_product_data` (run via `pyrevit set products` in CI) generated a **new UUID** for pyRevit and pyRevit CLI on every run and wrote it into the Inno Setup scripts (`.iss` files) as `MyAppUUID`. As a result:

- Each build was treated by Windows as a **different application**
- Multiple entries for "pyRevit" and "pyRevit CLI" appeared in Add/Remove Programs
- Upgrade (install new version over old) and uninstall behavior were broken

## Change

**File:** `dev/_release.py`

In `set_product_data`, the two calls that overwrote the Inno Setup AppId were **removed**:

- `_installer_set_uuid(pyrevit_pc, configs.PYREVIT_INSTALLER_FILES)`
- `_installer_set_uuid(pyrevitcli_pc, configs.PYREVIT_CLI_INSTALLER_FILES)`

The `.iss` files already define stable GUIDs; they are no longer overwritten on each build:

- **pyRevit** (pyrevit.iss, pyrevit-admin.iss): `f2a3da53-6f34-41d5-abbd-389ffa7f4d5f`
- **pyRevit CLI** (pyrevit-cli.iss, pyrevit-cli-admin.iss): `9557b432-cf79-4ece-91cf-b8f996c88b47`

**Unchanged:**

- MSI installer UUID handling (`_msi_set_uuid`) is unchanged
- Product data file updates (`_update_product_data_file`) are unchanged
- The `_installer_set_uuid` helper remains in the codebase for possible future use

## Result

- Inno Setup AppIds stay constant across versions
- Windows sees one application per product; Add/Remove Programs shows a single entry for pyRevit and one for pyRevit CLI
- Upgrading to a new build replaces the previous install instead of creating a duplicate entry