### PR TITLE
avoid accidental reuse of cached main by reloading script from path

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/XLS Export.pushbutton/config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/XLS Export.pushbutton/config.py
@@ -1,4 +1,18 @@
-from script import main
+import six
+from pyrevit import script
 
-if __name__ == "__main__":
-    main(advanced=True)
+if six.PY2:
+    import imp
+
+    def load_module_from_path(name, path):
+        return imp.load_source(name, path)
+else:
+    import importlib.util
+
+    def load_module_from_path(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    
+load_module_from_path("script", script.get_bundle_file("script.py")).main(advanced=True)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/config.py
@@ -2,9 +2,23 @@
 import io
 import json
 import os
+import six
 from pyrevit import script, forms
 from pyrevit.userconfig import user_config
-from script import main
+
+if six.PY2:
+    import imp
+
+    def load_module_from_path(name, path):
+        return imp.load_source(name, path)
+else:
+    import importlib.util
+
+    def load_module_from_path(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
 
 
 def get_translations(script_folder, script_type, locale):
@@ -107,4 +121,4 @@ if results:
         my_config.set_option("custom_prefix_dwg_value", custom_prefix_value)
 
     script.save_config()
-    main()
+    load_module_from_path("script", script.get_bundle_file("script.py")).main()


### PR DESCRIPTION
## Description

as pyrevit caches libs, they may be accidently reused. This loads them directly from path. 
alternative would be to set cleanengine to true or reload the pyrevit plugins to clear the cache.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #3042

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
