### PR TITLE
Loader panel background color

### DIFF
--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/Panels/PanelStyleManager.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/Panels/PanelStyleManager.cs
@@ -78,11 +78,19 @@ namespace pyRevitAssemblyBuilder.UIManager.Panels
                 if (ribbon?.Tabs == null)
                     return null;
 
-                var tab = ribbon.Tabs.FirstOrDefault(t => t.Id == tabName);
+                var tab = ribbon.Tabs.FirstOrDefault(t =>
+                    string.Equals(t.Title, tabName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(t.Id, tabName, StringComparison.OrdinalIgnoreCase));
                 if (tab?.Panels == null)
                     return null;
 
-                return tab.Panels.FirstOrDefault(p => p.Source?.Title == revitPanel.Name);
+                var panelName = revitPanel.Name;
+                if (string.IsNullOrEmpty(panelName))
+                    return null;
+
+                return tab.Panels.FirstOrDefault(p =>
+                    string.Equals(p.Source?.Title, panelName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(p.Source?.Id, panelName, StringComparison.OrdinalIgnoreCase));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# Restore Panel Background Colors in C# Loader

## Description

This PR addresses an issue where custom panel background colors were not being applied by the C# loader. The problem stemmed from a lookup mismatch in `PanelStyleManager.cs`, where Autodesk.Windows tabs and panels were being searched for by `Id` only, while they were often identified by their `Title`.

The fix updates the lookup logic to match tabs by `Title` or `Id`, and panels by `Source.Title` or `Source.Id`. This change aligns the C# loader's behavior with the Python implementation, ensuring that panel background colors defined in `bundle.yaml` are correctly applied to the Revit UI.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide. (N/A - C#)
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
  (N/A - C#)
- [ ] Changes are tested and verified to work as expected. (Verified by addressing the reported user issue; no dedicated UI test harness in this repo.)

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

This change directly addresses a user report of missing panel background colors. While formal UI tests are not part of this repository's test suite, the fix targets the identified lookup discrepancy. Users should ensure their `bundle.yaml` defines `background` using hex `#RRGGBB` or `#AARRGGBB` values.

---

Thank you for contributing to pyRevit! 🎉

---
<a href="https://cursor.com/background-agent?bcId=bc-1cf88a05-409d-46dc-830e-6d8607ea66a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1cf88a05-409d-46dc-830e-6d8607ea66a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

