### PR TITLE
Register extension hooks in C# session manager path

### DIFF
--- a/pyrevitlib/pyrevit/loader/sessionmgr.py
+++ b/pyrevitlib/pyrevit/loader/sessionmgr.py
@@ -307,8 +307,11 @@ def _new_session_csharp():
             # Register extension hooks
             # The Python session path (_new_session) registers hooks
             # after assembly creation, but the C# path was missing this
-            for ui_ext in extensionmgr.get_installed_ui_extensions():
-                hooks.register_hooks(ui_ext)
+            try:
+                for ui_ext in extensionmgr.get_installed_ui_extensions():
+                    hooks.register_hooks(ui_ext)
+            except Exception as hook_ex:
+                mlogger.error('Error registering hooks: %s', hook_ex)
         else:
             mlogger.error('C# session loading returned failure result')
             mlogger.info('Falling back to Python session creation...')


### PR DESCRIPTION
# Register Extension Hooks

## Description

The `_new_session_csharp(` path was missing `hooks.register_hooks()` calls, causing all extension event hooks (app-init, app-idling, etc.) to never fire when using the new C# loader (Rocket Mode). The Python session path (_new_session) correctly registers hooks after assembly creation, but the C# path skipped this step.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
