### PR TITLE
Fix incorrect exception reference for ResourceReferenceKeyNotFoundException in IronPython WPF handling

### DIFF
--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -680,7 +680,7 @@ class TemplateUserInputWindow(WPFWindow):
         else:
             try:
                 localized_title = self.get_locale_string(self.default_title_key)
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 localized_title = None
             self.Title = localized_title if isinstance(localized_title, str) else "User Input"
         self.Width = width
@@ -911,7 +911,7 @@ class SelectFromList(TemplateUserInputWindow):
             # Use localized default, falling back to generic text if resource is missing
             try:
                 self.select_b.Content = self.get_locale_string("SelectFromList.Select.Button")
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 self.select_b.Content = "Select"
 
         # attribute to use as name?
@@ -953,7 +953,7 @@ class SelectFromList(TemplateUserInputWindow):
                 self.ctx_groups_title = self.get_locale_string(
                     "SelectFromList.GroupSelector.Label"
                 )
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 mlogger.warning("Missing resource key for group selector title.")
                 self.ctx_groups_title = "Groups"
 
@@ -1074,15 +1074,15 @@ class SelectFromList(TemplateUserInputWindow):
         if option_filter:
             try:
                 self.checkall_b.Content = self.get_locale_string("SelectFromList.Check.Button")
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 self.checkall_b.Content = "Check"
             try:
                 self.uncheckall_b.Content = self.get_locale_string("SelectFromList.Uncheck.Button")
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 self.uncheckall_b.Content = "Uncheck"
             try:
                 self.toggleall_b.Content = self.get_locale_string("SelectFromList.Toggle.Button")
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 self.toggleall_b.Content = "Toggle"
             # get a match score for every item and sort high to low
             fuzzy_matches = sorted(
@@ -1107,15 +1107,15 @@ class SelectFromList(TemplateUserInputWindow):
         else:
             try:
                 self.checkall_b.Content = self.get_locale_string("SelectFromList.CheckAll.Button")
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 self.checkall_b.Content = "Check All"
             try:
                 self.uncheckall_b.Content = self.get_locale_string("SelectFromList.UncheckAll.Button")
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 self.uncheckall_b.Content = "Uncheck All"
             try:
                 self.toggleall_b.Content = self.get_locale_string("SelectFromList.ToggleAll.Button")
-            except wpf.ResourceReferenceKeyNotFoundException:
+            except System.Windows.ResourceReferenceKeyNotFoundException:
                 self.toggleall_b.Content = "Toggle All"
 
             self.list_lb.ItemsSource = ObservableCollection[TemplateListItem](


### PR DESCRIPTION
## Description

#### Summary

This PR fixes an AttributeError caused by incorrectly referencing ResourceReferenceKeyNotFoundException from the wpf module.

The exception was previously caught using:

except wpf.ResourceReferenceKeyNotFoundException:


However, ResourceReferenceKeyNotFoundException is not defined in IronPython.Wpf. It belongs to the System.Windows namespace.

Under the new C# loader, the incorrect namespace reference results in:

AttributeError: 'module' object has no attribute 'ResourceReferenceKeyNotFoundException'

#### Root Cause

ResourceReferenceKeyNotFoundException is defined in:

System.Windows


and not in the wpf helper module.

The previous behavior likely worked due to differences in assembly loading or namespace exposure in the older loader. The new loader exposes the issue correctly by not surfacing WPF exceptions through the wpf module.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #3067 

---
