### PR TITLE
Fix locale-dependent date parsing and apply default date in GetValueWindow

### DIFF
--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -1489,7 +1489,6 @@ class GetValueWindow(TemplateUserInputWindow):
             self.show_element(self.datePanel_dp)
             self.datePrompt.Text = value_prompt if value_prompt else "Pick date:"
             if isinstance(value_default, datetime.datetime):
-                import System
                 self.datePicker.SelectedDate = System.DateTime(
                     value_default.year,
                     value_default.month,


### PR DESCRIPTION
## Description
### Summary

This PR fixes a culture-dependent date parsing issue in GetValueWindow.select() and resolves an existing FIXME where the default date was not being applied to the DatePicker.

### Changes

Replaced string-based date parsing (ToString("MM/dd/yyyy") + strptime) with direct conversion from .NET DateTime to Python datetime, removing locale dependency.

Applied provided default value to the DatePicker.SelectedDate when value_type == "date".

### Impact

Prevents ValueError in non-US regional settings (e.g. dd.MM.yyyy formats).

Makes date handling culture-independent.

Fixes default date not being set in the date picker.

No breaking changes.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

- Resolves #3102

