### PR TITLE
[C# loader] Layout allowlist + F1 help parity with Python loader

### DIFF
--- a/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionParser.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionParser.cs
@@ -510,14 +510,8 @@ namespace pyRevitExtensionParser
                     }
                 }
 
-                // Add any components not in layout order at the end
-                foreach (var child in component.Children)
-                {
-                    if (child != null && !reorderedChildren.Contains(child))
-                    {
-                        reorderedChildren.Add(child);
-                    }
-                }
+                // Layout is a strict allowlist: only layout-listed items are shown (parity with Python loader).
+                // Do not append unlisted children.
 
                 // Apply layout directives (before, after, beforeall, afterall)
                 // External directives (where target is not found) are stored for post-UI-build sorting
@@ -1165,10 +1159,23 @@ namespace pyRevitExtensionParser
                     ? bundleInComponent.Highlight 
                     : scriptHighlight;
 
-                // Determine final help URL: bundle helpurl takes precedence over script helpurl
-                string finalHelpUrl = !string.IsNullOrEmpty(bundleInComponent?.HelpUrl)
-                    ? bundleInComponent.HelpUrl
+                // Determine final help URL: bundle helpurl takes precedence over script helpurl.
+                // Apply template substitution to bundle scalar help_url (parity with Python loader).
+                var bundleHelpUrlRaw = bundleInComponent?.HelpUrl;
+                var bundleHelpUrlSubstituted = SubstituteTemplates(bundleHelpUrlRaw, mergedTemplates);
+                string finalHelpUrl = !string.IsNullOrEmpty(bundleHelpUrlSubstituted)
+                    ? bundleHelpUrlSubstituted
                     : scriptHelpUrl;
+                // Auto-discover help file in bundle directory when no help_url set (parity with Python loader).
+                if (string.IsNullOrEmpty(finalHelpUrl))
+                {
+                    finalHelpUrl = DiscoverHelpFileInBundleDirectory(dir);
+                }
+                // Resolve relative help_url (e.g. "help.html") against bundle directory to file:// URL.
+                if (!string.IsNullOrEmpty(finalHelpUrl))
+                {
+                    finalHelpUrl = ResolveHelpUrlIfRelative(finalHelpUrl, dir);
+                }
 
                 // Determine final help URL: bundle hyperlink takes precedence over script helpurl
                 string finalHyperlink = !string.IsNullOrEmpty(hyperlink) ? hyperlink : scriptHelpUrl;
@@ -1353,6 +1360,80 @@ namespace pyRevitExtensionParser
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Discovers a help file in the bundle directory (parity with Python loader).
+        /// Matches pattern .*help\..+ (e.g. help.html, help.pdf, myhelp.html).
+        /// </summary>
+        /// <param name="bundleDir">The bundle directory to scan</param>
+        /// <returns>file:// URL of the first matching file, or null if none found</returns>
+        private static string DiscoverHelpFileInBundleDirectory(string bundleDir)
+        {
+            if (string.IsNullOrEmpty(bundleDir) || !Directory.Exists(bundleDir))
+                return null;
+            try
+            {
+                // Match Python HELP_FILE_PATTERN: .*help\..+
+                foreach (var file in Directory.GetFiles(bundleDir))
+                {
+                    var fileName = Path.GetFileName(file);
+                    if (string.IsNullOrEmpty(fileName) || fileName.IndexOf("help.", StringComparison.OrdinalIgnoreCase) < 0)
+                        continue;
+                    var ext = Path.GetExtension(fileName);
+                    if (string.IsNullOrEmpty(ext) || ext.Length < 2)
+                        continue;
+                    // Must be "help.<something>" (e.g. help.html)
+                    var nameWithoutExt = Path.GetFileNameWithoutExtension(fileName);
+                    if (nameWithoutExt.EndsWith("help", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return PathToFileUri(file);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                LogWarning($"Error discovering help file in bundle directory: {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Converts an absolute file path to a file:// URI for Revit contextual help.
+        /// </summary>
+        private static string PathToFileUri(string absolutePath)
+        {
+            if (string.IsNullOrEmpty(absolutePath))
+                return null;
+            try
+            {
+                var uri = new Uri(Path.GetFullPath(absolutePath));
+                return uri.AbsoluteUri;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// If helpUrl looks like a relative path (no scheme, not rooted), resolves it against bundleDir
+        /// and returns a file:// URL if the file exists. Otherwise returns the original string.
+        /// </summary>
+        private static string ResolveHelpUrlIfRelative(string helpUrl, string bundleDir)
+        {
+            if (string.IsNullOrEmpty(helpUrl) || string.IsNullOrEmpty(bundleDir))
+                return helpUrl;
+            // Already an absolute URL (http/https/file)
+            if (helpUrl.IndexOf("://", StringComparison.Ordinal) >= 0)
+                return helpUrl;
+            // Already an absolute path
+            if (Path.IsPathRooted(helpUrl))
+                return FileExists(helpUrl) ? PathToFileUri(helpUrl) : helpUrl;
+            var resolvedPath = Path.GetFullPath(Path.Combine(bundleDir, helpUrl));
+            if (FileExists(resolvedPath))
+                return PathToFileUri(resolvedPath);
+            return helpUrl;
         }
 
         private static string SanitizeClassName(string name)


### PR DESCRIPTION
# C# loader: parity with Python loader — layout allowlist and F1 help

## Description

This PR brings the C# extension parser (6.x) in line with the Python-based loader for two behaviors:

1. **Layout as strict allowlist**  
   `layout` in `bundle.yaml` is now treated as an allowlist: only items listed in `layout` are shown. Children not in the list are no longer appended at the end. This matches the Python loader (`genericcomps.py`), where `__iter__` only yields layout-listed components.

2. **F1 help (help.html and relative help_url)**  
   - **Template substitution:** The bundle’s scalar `help_url` is run through `SubstituteTemplates`, so values like `{{docpath}}/help.html` work when templates are defined.  
   - **Auto-discover:** If no `help_url` is set in YAML or script, the bundle directory is scanned for a help file matching `.*help\..+` (e.g. `help.html`). If found, its `file://` URL is used for F1.  
   - **Relative path:** If `help_url` is a relative path (e.g. `help.html`), it is resolved against the bundle directory and converted to a `file://` URL so F1 opens the local file.

**Files changed:**  
- `dev/pyRevitLoader/pyRevitExtensionParser/ExtensionParser.cs`  
  - `ReorderByLayout`: removed appending of unlisted children.  
  - Help URL: substitute bundle scalar, then discover help file if still empty, then resolve relative path to `file://`.  
  - New helpers: `DiscoverHelpFileInBundleDirectory`, `PathToFileUri`, `ResolveHelpUrlIfRelative`.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the project’s C# / .NET style conventions.
- [x] Changes are tested and verified to work as expected.  
  (`dotnet test dev\pyRevitLoader\pyRevitExtensionParserTester\pyRevitExtensionParserTest.csproj` — 179 tests pass; one existing failure is unrelated (Dynamo custom script name).)

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

*(Add the issue number when you open or link the issue from `docs/ISSUE_LOADER_BEHAVIOR.md`.)*

---

## Additional Notes

- Full analysis of C# vs Python loader differences is in `docs/ISSUE_LOADER_BEHAVIOR.md` (layout filter, F1 help, bundle filename, scalar help_url substitution, etc.). This PR implements the two main parity fixes (layout + F1 help).
- Optional follow-ups from that doc: accept `*.bundle.yaml` and/or run scalar `help_url` through templates in additional code paths if desired.

---

Thank you for contributing to pyRevit!