### PR TITLE
Fix StaticResource crash in forms loader

### DIFF
--- a/pyrevitlib/pyrevit/forms/_ipy.py
+++ b/pyrevitlib/pyrevit/forms/_ipy.py
@@ -242,7 +242,6 @@ class WPFWindow(framework.Windows.Window):
             return english_xaml_file
 
         # otherwise look for .ResourceDictionary files and merge after load
-        # (must merge after LoadComponent so XAML does not replace Resources)
         if os.path.isfile(localized_xaml_resfile):
             self._pending_resource_merge = localized_xaml_resfile
         elif os.path.isfile(english_xaml_resfile):


### PR DESCRIPTION
## Description
#### Problem

Some tools (e.g. Print Sheets) failed to load with:

Provide value on 'System.Windows.StaticResourceExtension' threw an exception.

This occurred because pending resource dictionaries were merged after wpf.LoadComponent().

Since StaticResource is resolved at XAML load time, any referenced resources must already be present in the window's resource tree. If the merge happens later, WPF fails during parsing.

#### Solution

Merge _pending_resource_merge before calling wpf.LoadComponent() so that all required resources are available during XAML parsing.
```python
if getattr(self, '_pending_resource_merge', None):
    self.merge_resource_dict(self._pending_resource_merge)
    self._pending_resource_merge = None

wpf.LoadComponent(self, xaml)
```
#### Result

Fixes StaticResourceExtension exceptions

Restores correct loading of tools relying on merged resource dictionaries

Aligns resource initialization with WPF load-time requirements

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #3113
