### PR TITLE
switch __shiftclick__ to EXEC_PARAMS.config_mode

### DIFF
--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
@@ -1028,7 +1028,7 @@ def __selfinit__(script_cmp, ui_button_cmp, __rvt__):
 # windows explorer
 # otherwise, will show the Settings user interface
 if __name__ == "__main__":
-    if __shiftclick__:  # pylint: disable=E0602
+    if EXEC_PARAMS.config_mode:
         script.show_file_in_explorer(user_config.config_file)
     elif user_config.is_readonly:
         forms.alert("pyRevit settings are set by your admin.", exitscript=True)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/Compare Detail Views.deprecate/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/Compare Detail Views.deprecate/script.py
@@ -1,4 +1,4 @@
-from pyrevit import revit, DB, UI
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import forms
 
 import diffutils
@@ -16,7 +16,7 @@ if len(view_list) == 2:
     comp = diffutils.compare_views(revit.doc,
                                    view_list[0],
                                    view_list[1],
-                                   compare_types=__shiftclick__,
+                                   compare_types=EXEC_PARAMS.config_mode,
                                    diff_results=res)
 
     forms.alert('Views are smiliar (not identical).'

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/LinesPerViewCounter.pushbutton/LinesPerViewCounter_script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/LinesPerViewCounter.pushbutton/LinesPerViewCounter_script.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 
 from pyrevit import script
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit.compat import get_elementid_value_func
 
 
@@ -62,7 +62,7 @@ def line_count(document=doc):
 if __name__ == '__main__':
     output.print_md("\n\n# LINES PER VIEW IN CURRENT DOCUMENT\n___\n\n")
     line_count()
-    if __shiftclick__:
+    if EXEC_PARAMS.config_mode:
         output.print_md("\n\n# LINES PER VIEW IN LINKS\n___\n\n")
         revit_links = DB.FilteredElementCollector(doc).OfClass(DB.RevitLinkInstance).ToElements()
         for link in revit_links:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
@@ -12,7 +12,7 @@ import math
 from collections import defaultdict
 from natsort import natsorted
 
-from pyrevit import HOST_APP
+from pyrevit import HOST_APP, EXEC_PARAMS
 from pyrevit import framework
 from pyrevit.framework import System
 from pyrevit import coreutils
@@ -1350,7 +1350,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
 try:
     KeynoteManagerWindow(
         xaml_file_name='KeynoteManagerWindow.xaml',
-        reset_config=__shiftclick__ #pylint: disable=undefined-variable
+        reset_config=EXEC_PARAMS.config_mode
         ).show(modal=True)
 except Exception as kmex:
     forms.alert(str(kmex), expanded="Creating keynote manager window")

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
@@ -29,7 +29,7 @@ import datetime
 import locale
 from collections import namedtuple
 
-from pyrevit import HOST_APP
+from pyrevit import HOST_APP, EXEC_PARAMS
 from pyrevit import framework
 from pyrevit.framework import Windows, Drawing, ObjectModel, Forms, List
 from pyrevit import coreutils
@@ -1690,7 +1690,7 @@ forms.check_modeldoc(exitscript=True)
 revit.selection.get_selection().clear()
 
 # TODO: add copy filenames to sheet list
-if __shiftclick__:  # pylint: disable=E0602
+if EXEC_PARAMS.config_mode:
     open_docs = forms.select_open_docs(check_more_than_one=False)
     if open_docs:
         for open_doc in open_docs:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/List TitleBlocks on Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/List TitleBlocks on Sheets.pushbutton/script.py
@@ -6,47 +6,7 @@ Select titleblocks on currently selected sheets in project browser.
 
 """
 # pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
-from pyrevit import revit
-from pyrevit import forms
-from pyrevit import script
-
-output = script.get_output()
-logger = script.get_logger()
-
-
-def get_source_sheets():
-    sheet_elements = forms.select_sheets(
-        button_name="List TitleBlocks",
-        use_selection=True,
-        include_placeholder=False,
-    )
-    if not sheet_elements:
-        script.exit()
-    return sheet_elements
-
-
-def print_titleblocks(sheets):
-    all_tblocks = []
-    for sheet in sheets:
-        tblocks = revit.query.get_sheet_tblocks(sheet)
-        all_tblocks.extend([x.Id for x in tblocks])
-        for tblock in tblocks:
-            print(
-                "SHEET: {0} - {1}\t\tTITLEBLOCK: {2} {3}".format(
-                    sheet.SheetNumber,
-                    sheet.Name,
-                    tblock.Name,
-                    output.linkify(tblock.Id),
-                )
-            )
-    print(
-        "{}".format(output.linkify(all_tblocks, title="Select All TitleBlocks"))
-    )
-
-
-"""Select title blocks on selected sheets for batch editing."""
-# pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
-from pyrevit import revit
+from pyrevit import revit, EXEC_PARAMS
 from pyrevit import forms
 from pyrevit import script
 
@@ -85,7 +45,7 @@ def print_titleblocks(sheets):
 
 
 # orchestrate
-if __shiftclick__:
+if EXEC_PARAMS.config_mode:
     selection = revit.get_selection()
     sheets = get_source_sheets()
     all_tblocks = []

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Pin All Viewports.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Pin All Viewports.pushbutton/script.py
@@ -4,7 +4,7 @@ Shift-Click:
 Pin all viewports on active sheet.
 """
 
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import script
 from pyrevit import forms
 
@@ -29,7 +29,7 @@ def pin_viewports(sheet_list):
                           alreadypinnedcount))
 
 
-if __shiftclick__:
+if EXEC_PARAMS.config_mode:
     if isinstance(revit.active_view, DB.ViewSheet):
         sel_sheets = [revit.active_view]
     else:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Rename PDF Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Rename PDF Sheets.pushbutton/script.py
@@ -5,7 +5,7 @@ import re
 
 from pathlib import Path
 
-from pyrevit import forms
+from pyrevit import forms, EXEC_PARAMS
 
 
 def renamepdf(old_name):
@@ -19,7 +19,7 @@ def renamepdf(old_name):
 
 # if user shift-clicks, default to user desktop,
 # otherwise ask for a folder containing the PDF files
-if __shiftclick__:
+if EXEC_PARAMS.config_mode:
     basefolder = op.expandvars(r"%userprofile%\desktop")
 else:
     basefolder = forms.pick_folder()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Schedules.pulldown/Export Schedules To CSV.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Schedules.pulldown/Export Schedules To CSV.pushbutton/script.py
@@ -9,7 +9,7 @@ import os.path as op
 
 from pyrevit import forms
 from pyrevit import coreutils
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import script
 
 from pyrevit.userconfig import user_config
@@ -24,7 +24,7 @@ incl_headers = False
 basefolder = ''
 # if user shift-clicks, default to user desktop,
 # otherwise ask for a folder containing the PDF files
-if __shiftclick__:  #pylint: disable=E0602
+if EXEC_PARAMS.config_mode:
     destopt, switches = forms.CommandSwitchWindow.show(
         ["My Desktop", "Where Revit Model Is", "My Downloads", "User Select"],
         switches=["Open CSV File","Include Headers"],

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit1.stack/Match.splitpushbutton/Match Properties.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit1.stack/Match.splitpushbutton/Match Properties.pushbutton/script.py
@@ -7,7 +7,7 @@ Reapply the previous matched properties.
 #pylint: disable=import-error,invalid-name,broad-except
 import pickle
 
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import forms
 from pyrevit import script
 from pyrevit.compat import get_elementid_value_func
@@ -133,7 +133,7 @@ def remember(src_props):
 
 # main
 source_props = []
-if __shiftclick__:    #pylint: disable=undefined-variable
+if EXEC_PARAMS.config_mode:
     target_type, source_props = recall()
     logger.debug("Recalled data: %s", source_props)
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Groups.pulldown/Select Topmost Groups.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Groups.pulldown/Select Topmost Groups.pushbutton/script.py
@@ -5,8 +5,7 @@ Shift+Click:
 Include not-grouped elements
 """
 #pylint: disable=import-error,invalid-name,broad-except
-from pyrevit import revit, DB
-from pyrevit import forms
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import script
 
 
@@ -35,7 +34,7 @@ for selected_element in selection:
     if higher_group:
         logger.debug("Found group: %s", higher_group.Id)
         parent_group_ids.add(higher_group.Id)
-    elif __shiftclick__:    #pylint: disable=undefined-variable
+    elif EXEC_PARAMS.config_mode:
         ungrouped_element_ids.append(selected_element.Id)
 
 parent_group_ids.update(ungrouped_element_ids)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/Wipe.pulldown/Wipe Empty Tags.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/Wipe.pulldown/Wipe Empty Tags.pushbutton/script.py
@@ -5,11 +5,11 @@ Remove tags in selected views
 """
 #pylint: disable=C0103,E0401
 from pyrevit import framework
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import forms
 
 
-if __shiftclick__:  #pylint: disable=undefined-variable
+if EXEC_PARAMS.config_mode:
     selected_views = \
         forms.select_views(filterfunc=lambda x: isinstance(x, DB.ViewPlan),
                            use_selection=True)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Family QuickCheck.pushbutton/FamilyQuickcheck_script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Family.pulldown/Family QuickCheck.pushbutton/FamilyQuickcheck_script.py
@@ -7,7 +7,7 @@ github.com/frederic-beaupere
 PR731 https://github.com/pyrevitlabs/pyRevit/pull/731
 """
 #pylint: disable=invalid-name,import-error,superfluous-parens,broad-except
-from pyrevit import revit
+from pyrevit import revit, EXEC_PARAMS
 from pyrevit import forms
 from pyrevit import script
 
@@ -25,7 +25,7 @@ count_families_with_warnings = 0
 all_families = revit.query.get_families(revit.doc, only_editable=True)
 editable_families = []
 
-if __shiftclick__: #pylint: disable=E0602
+if EXEC_PARAMS.config_mode:
     family_dict = {}
     for family in all_families:
         if family.FamilyCategory:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools2.stack/Get Central Path.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools2.stack/Get Central Path.pushbutton/script.py
@@ -6,14 +6,14 @@ Open central model path in file browser
 #pylint: disable=E0401,invalid-name
 import os.path as op
 
-from pyrevit import revit
+from pyrevit import revit, EXEC_PARAMS
 from pyrevit import forms
 from pyrevit import script
 
 
 if forms.check_workshared(doc=revit.doc):
     central_path = revit.query.get_central_path(doc=revit.doc)
-    if __shiftclick__:  #pylint: disable=E0602
+    if EXEC_PARAMS.config_mode:
         script.show_folder_in_explorer(op.dirname(central_path))
     else:
         print(central_path)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/Next.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/Next.pushbutton/script.py
@@ -5,5 +5,6 @@ Shift+Click +10
 """
 
 import iter_selection
+from pyrevit import EXEC_PARAMS
 
-iter_selection.iterate('+', 10 if __shiftclick__ else 1)
+iter_selection.iterate('+', 10 if EXEC_PARAMS.config_mode else 1)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/Prev.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/Memory.pulldown/Prev.pushbutton/script.py
@@ -5,6 +5,6 @@ Shift+Click +10
 """
 
 import iter_selection
+from pyrevit import EXEC_PARAMS
 
-
-iter_selection.iterate('-', 10 if __shiftclick__ else 1)
+iter_selection.iterate('-', 10 if EXEC_PARAMS.config_mode else 1)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/memo.stack/lib/copypastestate/actions.py
@@ -4,7 +4,7 @@
 import math
 
 from pyrevit import PyRevitException
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit.framework import List
 from pyrevit.coreutils import logger
 from pyrevit.coreutils import moduleutils
@@ -579,7 +579,7 @@ class ViewportPlacementAction(basetypes.CopyPasteStateAction):
 
         viewports = revit.get_selection().include(DB.Viewport)
         align_axis = None
-        if __shiftclick__:  # pylint: disable=undefined-variable
+        if EXEC_PARAMS.config_mode:
             align_axis = forms.CommandSwitchWindow.show(
                 ["X", "Y", "XY"], message="Align specific axis?"
             )

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Invert Selection.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Invert Selection.pushbutton/script.py
@@ -4,7 +4,7 @@ Shift-Click:
 Select group members instead of parent group elements.
 """
 #pylint: disable=import-error,invalid-name,broad-except
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit.compat import get_elementid_value_func
 
 get_elementid_value = get_elementid_value_func()
@@ -29,7 +29,7 @@ invert_ids = view_element_ids.difference(selected_element_ids)
 # if shiftclick, select all the invert elements
 # otherwise do not select elements inside a group
 filtered_invert_ids = invert_ids.copy()
-if not __shiftclick__: #pylint: disable=undefined-variable
+if not EXEC_PARAMS.config_mode:
     # collect ids of elements inside a group
     grouped_element_ids = \
         [get_elementid_value(x.Id) for x in viewelements

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Of Selected Type.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Of Selected Type.pushbutton/script.py
@@ -6,7 +6,7 @@ Shift-Click:
 Show Results
 """
 #pylint: disable=import-error,invalid-name,unused-argument,broad-except,superfluous-parens
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import script
 from pyrevit import forms
 
@@ -75,7 +75,7 @@ for selected_element in selection:
                 model_items.append(sim_element)
 
 # print results if requested
-if __shiftclick__:  #pylint: disable=undefined-variable
+if EXEC_PARAMS.config_mode:
     if is_viewspecific:
         for ovname, items in viewspecific_items.items():
             print('OWNER VIEW: {0}'.format(ovname))

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Vertical Reveals.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Vertical Reveals.pushbutton/script.py
@@ -4,7 +4,7 @@ Shift-Click:
 Select horizontal reveals.
 """
 #pylint: disable=import-error,invalid-name
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 
 
 reveal_ids = []
@@ -13,7 +13,7 @@ for el in DB.FilteredElementCollector(revit.doc)\
             .OfCategory(DB.BuiltInCategory.OST_Reveals)\
             .WhereElementIsNotElementType()\
             .ToElements():
-    if el.GetWallSweepInfo().IsVertical != __shiftclick__:      #pylint: disable=undefined-variable
+    if el.GetWallSweepInfo().IsVertical != EXEC_PARAMS.config_mode:
         reveal_ids.append(el.Id)
 
 revit.get_selection().set_to(reveal_ids)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select Similar Elements In Active View.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select Similar Elements In Active View.pushbutton/script.py
@@ -3,12 +3,12 @@ selected elements in the active view.
 
 Shift-Click: select in whole project"""
 #pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
-from pyrevit import revit, DB
+from pyrevit import revit, DB, EXEC_PARAMS
 from pyrevit import forms
 from pyrevit.framework import List
 
 
-if not __shiftclick__:
+if not EXEC_PARAMS.config_mode:
     # ensure active view is a graphical view
     forms.check_graphicalview(revit.active_view, exitscript=True)
 
@@ -28,7 +28,7 @@ if not sel_cat_ids:
 mc_filter = DB.ElementMulticategoryFilter(List[DB.ElementId](sel_cat_ids))
 
 # collect from whole model
-if __shiftclick__:
+if EXEC_PARAMS.config_mode:
     cl = DB.FilteredElementCollector(revit.doc)\
         .WhereElementIsNotElementType()
 # collect from a view

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles1.stack/Tab Coloring.smartbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles1.stack/Tab Coloring.smartbutton/script.py
@@ -1,9 +1,6 @@
 """Does its best at visually separating open documents."""
 #pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
-import re
-
-from pyrevit import HOST_APP
-from pyrevit.runtime.types import DocumentTabEventUtils
+from pyrevit import EXEC_PARAMS
 from pyrevit.coreutils.ribbon import ICON_MEDIUM
 from pyrevit import script
 from pyrevit.userconfig import user_config
@@ -64,7 +61,7 @@ def reset_slots():
 
 
 if __name__ == '__main__':
-    if __shiftclick__: #pylint: disable=undefined-variable
+    if EXEC_PARAMS.config_mode:
         selected_option = forms.CommandSwitchWindow.show(
             ["List Document Colors", "Reset Theme"],
             message="Select option:"


### PR DESCRIPTION
## Description

As per https://pyrevitlabs.notion.site/Python-Runtime-Variables-1ae28b25faca48ff8c291d68e8010541 `__shiftclick__` should be avoided.
This PR moves all tools in pyRevit.tab to the exec_params approach to set a good example and make code consistent.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Additional Notes

I did not test all tools, only random samples.

