### PR TITLE
Add optional elements argument to get_value_range

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -343,7 +343,7 @@ def get_value_range(param_name, doc=None, elements=None):
     Args:
         param_name (str): The name of the parameter to retrieve values for.
         doc (Document, optional): The Revit document to search within. If None, the current document is used.
-        elements (iterable, optional): Specific elements to process. If provided, doc and get_all_elements() are ignored.
+        elements (iterable, optional): Specific elements to process. If provided, these elements are processed instead of calling get_all_elements(doc).
 
     Returns:
         set: A set of unique values for the specified parameter. The values can be of any type, but are typically strings.


### PR DESCRIPTION
## Description

Extended get_value_range to accept an optional elements iterable.

If elements is provided, the function processes only those elements instead of calling get_all_elements(doc). If not provided, existing behavior remains unchanged.

This improves flexibility (e.g., supports selection sets and filtered collectors) while maintaining full backward compatibility.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

