### PR TITLE
Fix SectionBoxNavigator: Levels at 0

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Section Box Navigator.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Section Box Navigator.pushbutton/script.py
@@ -549,7 +549,7 @@ class SectionBoxNavigatorForm(forms.WPFWindow):
         next_bottom_level = None
         next_level = None
 
-        if self.rbLevel.IsChecked and not elevation:
+        if self.rbLevel.IsChecked and elevation is None:  # for levels at elevation 0.0 'not elevation:' won't work
             # Level mode - snap to next level
             if target == "both":
                 if direction == "up":
@@ -635,7 +635,7 @@ class SectionBoxNavigatorForm(forms.WPFWindow):
                         self.show_status_message(1, self.get_locale_string("WouldCreateInvalidBox"), "error")
                     return None
 
-        elif elevation:
+        elif elevation is not None:  # for levels at elevation 0.0 'elif elevation:' won't work
             if target == "top":
                 top_distance = elevation - info["transformed_max"].Z
                 # Validate won't go below bottom


### PR DESCRIPTION
## Description

Fixes an issue where elevation updates failed when setting the target elevation to 0 or other falsy values.
The root cause was using `elif elevation:` which skipped valid inputs evaluated as falsy.
Replaced the condition with `elif elevation is not None:` to correctly handle zero elevations and ensure consistent box movement behavior.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.
