### PR TITLE
Exposed Command Control Id in Session Manager

### DIFF
--- a/pyrevitlib/pyrevit/loader/sessionmgr.py
+++ b/pyrevitlib/pyrevit/loader/sessionmgr.py
@@ -512,6 +512,10 @@ class PyRevitExternalCommandType(object):
     def unique_id(self):
         return getattr(self._extcmd.ScriptData, 'CommandUniqueId', None)
 
+    @property
+    def control_id(self):
+        return getattr(self._extcmd.ScriptData, 'CommandControlId', None)
+
     def is_available(self, category_set, zerodoc=False):
         if self._extcmd_availtype:
             return self._extcmd_avail.IsCommandAvailable(HOST_APP.uiapp,


### PR DESCRIPTION
# Exposed Command Control Id

## Description

A bit of a selfish addition, exposing the CommandControlId (the Id used in journal files an PostCommand operations) so that I can more easily reference it

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

None

---

## Additional Notes

None

---

Thank you for contributing to pyRevit! 🎉
