### PR TITLE
Add element addition and deletion triggers to UpdaterListener

### DIFF
--- a/dev/pyRevitLabs.PyRevit.Runtime/EventHandling.cs
+++ b/dev/pyRevitLabs.PyRevit.Runtime/EventHandling.cs
@@ -278,10 +278,11 @@ namespace PyRevitLabs.PyRevit.Runtime {
             if (updaterListener == null) {
                 updaterListener = new UpdaterListener();
                 UpdaterRegistry.RegisterUpdater(updaterListener);
-                UpdaterRegistry.AddTrigger(
-                    updaterListener.GetUpdaterId(),
-                    new ElementCategoryFilter(BuiltInCategory.INVALID, inverted: true),
-                    Element.GetChangeTypeAny());
+                var updaterId = updaterListener.GetUpdaterId();
+                var categoryFilter = new ElementCategoryFilter(BuiltInCategory.INVALID, inverted: true);
+                UpdaterRegistry.AddTrigger(updaterId, categoryFilter, Element.GetChangeTypeAny());
+                UpdaterRegistry.AddTrigger(updaterId, categoryFilter, Element.GetChangeTypeElementAddition());
+                UpdaterRegistry.AddTrigger(updaterId, categoryFilter, Element.GetChangeTypeElementDeletion());
             }
         }
 


### PR DESCRIPTION
# Updater Listener enhancements

## Description

The existing UpdaterListener only registered GetChangeTypeAny which fires for modifications to existing elements. This adds separate triggers for GetChangeTypeElementAddition and GetChangeTypeElementDeletion so that doc-updater hooks can detect newly placed and deleted elements.

Link to official documentation https://docs.pyrevitlabs.io/reference/pyrevit/versionmgr/updater/#pyrevit.versionmgr.updater.update_pyrevit

### Before
![pyRevit - updater - before](https://github.com/user-attachments/assets/789ae71a-7240-4f92-9ff3-f4ff20f11c14)


### After
![pyRevit - updater - after](https://github.com/user-attachments/assets/b03be4a1-d3f2-4046-b5cb-6246d6330087)


---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Credits go to:
@gokul-pascalls

FYI
@WaynePatrickDalton

---

Thank you for contributing to pyRevit! 🎉
