### PR TITLE
Preserve view title position and extent when copying sheets

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Sheets to Open Documents.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Sheets.pulldown/Copy Sheets to Open Documents.pushbutton/script.py
@@ -408,19 +408,23 @@ def get_source_vport_data(doc, vport, sheet_view):
     }
     try:
         data["label_offset"] = vport.LabelOffset
-    except Exception:
-        pass
+    except AttributeError:
+        logger.debug("LabelOffset not available (requires Revit 2022+)")
+    except Exception as e:
+        logger.debug("Could not read LabelOffset: {}".format(e))
     try:
         data["label_line_length"] = vport.LabelLineLength
-    except Exception:
-        pass
+    except AttributeError:
+        logger.debug("LabelLineLength not available (requires Revit 2022+)")
+    except Exception as e:
+        logger.debug("Could not read LabelLineLength: {}".format(e))
     try:
         bb = vport.get_BoundingBox(sheet_view)
         if bb:
             data["bbox_min"] = bb.Min
             data["bbox_max"] = bb.Max
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Could not read BoundingBox: {}".format(e))
     return data
 
 
@@ -438,9 +442,15 @@ def apply_vport_label_props(dest_doc, nvport_id, src_data):
         ):
             vp = dest_doc.GetElement(nvport_id)
             if label_offset is not None:
-                vp.LabelOffset = label_offset
+                try:
+                    vp.LabelOffset = label_offset
+                except AttributeError:
+                    logger.debug("LabelOffset not available (requires Revit 2022+)")
             if label_line_len is not None:
-                vp.LabelLineLength = label_line_len
+                try:
+                    vp.LabelLineLength = label_line_len
+                except AttributeError:
+                    logger.debug("LabelLineLength not available (requires Revit 2022+)")
     except Exception as e:
         logger.warning("Label property set failed: {}".format(e))
 
@@ -456,23 +466,24 @@ def correct_vport_by_bbox(dest_doc, nvport_id, src_data, dest_sheet):
     if src_bb_min is None:
         return
     try:
+        vp = dest_doc.GetElement(nvport_id)
+        dst_bb = vp.get_BoundingBox(dest_sheet)
+        if dst_bb is None:
+            return
+        dx = src_bb_min.X - dst_bb.Min.X
+        dy = src_bb_min.Y - dst_bb.Min.Y
+        if abs(dx) <= 1e-9 and abs(dy) <= 1e-9:
+            return
         with revit.Transaction(
             "Align View Title Position",
             doc=dest_doc,
             swallow_errors=True,
         ):
-            vp = dest_doc.GetElement(nvport_id)
-            dst_bb = vp.get_BoundingBox(dest_sheet)
-            if dst_bb is None:
-                return
-            dx = src_bb_min.X - dst_bb.Min.X
-            dy = src_bb_min.Y - dst_bb.Min.Y
-            if abs(dx) > 1e-9 or abs(dy) > 1e-9:
-                DB.ElementTransformUtils.MoveElement(
-                    dest_doc,
-                    nvport_id,
-                    DB.XYZ(dx, dy, 0),
-                )
+            DB.ElementTransformUtils.MoveElement(
+                dest_doc,
+                nvport_id,
+                DB.XYZ(dx, dy, 0),
+            )
     except Exception as e:
         logger.warning("BBox position correction failed: {}".format(e))
 


### PR DESCRIPTION
Added functions to capture and apply viewport properties, including label offsets and bounding box corrections for viewports when copying sheets to open documents.


# Name of your PR
Preserve view title position and extent when copying sheets

## Description

When copying sheets to other open documents, the view title (label) for each viewport was placed at Revit's default offset instead of matching the source sheet. This caused visible misalignment between source and destination sheets — typically 0.3" to 2.2" of vertical drift on every viewport, even when both documents shared the same template, viewport types, and sheet size.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

Problem
The original copy_sheet_viewports function placed viewports using Viewport.Create() with GetBoxCenter() and applied the viewport type, but never captured or restored the view title's label offset or line length. Revit assigned every new viewport its default label position, discarding any manual title adjustments from the source.
Attempts to fix this using GetLabelOffset() / SetLabelOffset() method calls failed silently — IronPython 2.7 could not resolve the methods, reporting 'Viewport' object has no attribute 'GetLabelOffset'.
Root Cause
LabelOffset and LabelLineLength on Autodesk.Revit.DB.Viewport are .NET properties (backed by get_/set_ accessors), not standalone methods. IronPython 2.7 exposes .NET properties as Python attributes — method-style calls like vport.GetLabelOffset() fail, while property-style access like vport.LabelOffset works correctly.
Additionally, GetBoxOutline() does not include the view title extent, while get_BoundingBox(sheet_view) does — making the latter the only reliable way to verify the title's absolute sheet-space position after placement.
Modified copy_sheet_viewports now follows a 5-step pipeline per viewport:

Capture source viewport data (center, label offset, line length, sheet bbox)
Viewport.Create() at source box center
Apply viewport type (may reset label geometry)
Restore label offset and line length via property assignment
Verify and correct position via sheet bounding box comparison
