### PR TITLE
fix(ViewRange): prevent duplicate windows, close crash, and invalid values

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles3.stack/ViewRange.pushbutton/MainWindow.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles3.stack/ViewRange.pushbutton/MainWindow.xaml
@@ -41,14 +41,16 @@
                      Text="{Binding topplane_new_value, UpdateSourceTrigger=PropertyChanged}" 
                      Width="100" Height="25" Margin="5,0"
                      HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                     IsEnabled="{Binding can_modify_view}"/>
+                     IsEnabled="{Binding can_modify_view}"
+                     Background="{Binding topplane_field_bg}"/>
             <ComboBox Grid.Row="1" Grid.Column="4" x:Name="topplane_level_combo" 
                       ItemsSource="{Binding available_levels}" 
                       SelectedValue="{Binding topplane_level_id, Mode=TwoWay}"
                       DisplayMemberPath="Name" 
                       SelectedValuePath="IdValue"
                       Height="25" Margin="5,0" VerticalContentAlignment="Center"
-                      IsEnabled="{Binding can_modify_view}"/>
+                      IsEnabled="{Binding can_modify_view}"
+                      Background="{Binding topplane_field_bg}"/>
             
             <!-- Cut Plane Row -->
             <Rectangle Grid.Row="2" Grid.Column="0" Width="5" Height="20" Fill="{Binding cutplane_brush}" RadiusX="3" RadiusY="3"/>
@@ -58,7 +60,8 @@
                      Text="{Binding cutplane_new_value, UpdateSourceTrigger=PropertyChanged}" 
                      Width="100" Height="25" Margin="5,0"
                      HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                     IsEnabled="{Binding can_modify_view}"/>
+                     IsEnabled="{Binding can_modify_view}"
+                     Background="{Binding cutplane_field_bg}"/>
             <TextBlock Grid.Row="2" Grid.Column="4" Text="{Binding cutplane_level_name}" 
                        VerticalAlignment="Center" Margin="5,0" 
                        Background="#E8E8E8" Padding="8,5" FontStyle="Italic" TextAlignment="Center"/>
@@ -71,14 +74,16 @@
                      Text="{Binding bottomplane_new_value, UpdateSourceTrigger=PropertyChanged}" 
                      Width="100" Height="25" Margin="5,0"
                      HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                     IsEnabled="{Binding can_modify_view}"/>
+                     IsEnabled="{Binding can_modify_view}"
+                     Background="{Binding bottomplane_field_bg}"/>
             <ComboBox Grid.Row="3" Grid.Column="4" x:Name="bottomplane_level_combo" 
                       ItemsSource="{Binding available_levels}" 
                       SelectedValue="{Binding bottomplane_level_id, Mode=TwoWay}"
                       DisplayMemberPath="Name" 
                       SelectedValuePath="IdValue"
                       Height="25" Margin="5,0" VerticalContentAlignment="Center"
-                      IsEnabled="{Binding can_modify_view}"/>
+                      IsEnabled="{Binding can_modify_view}"
+                      Background="{Binding bottomplane_field_bg}"/>
             
             <!-- View Depth Row -->
             <Rectangle Grid.Row="4" Grid.Column="0" Width="5" Height="20" Fill="{Binding viewdepth_brush}" RadiusX="3" RadiusY="3"/>
@@ -88,14 +93,16 @@
                      Text="{Binding viewdepth_new_value, UpdateSourceTrigger=PropertyChanged}" 
                      Width="100" Height="25" Margin="5,0"
                      HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                     IsEnabled="{Binding can_modify_view}"/>
+                     IsEnabled="{Binding can_modify_view}"
+                     Background="{Binding viewdepth_field_bg}"/>
             <ComboBox Grid.Row="4" Grid.Column="4" x:Name="viewdepth_level_combo" 
                       ItemsSource="{Binding available_levels}" 
                       SelectedValue="{Binding viewdepth_level_id, Mode=TwoWay}"
                       DisplayMemberPath="Name" 
                       SelectedValuePath="IdValue"
                       Height="25" Margin="5,0" VerticalContentAlignment="Center"
-                      IsEnabled="{Binding can_modify_view}"/>
+                      IsEnabled="{Binding can_modify_view}"
+                      Background="{Binding viewdepth_field_bg}"/>
         </Grid>
         
         <Separator Margin="0,10"/>
@@ -108,7 +115,17 @@
         </StackPanel>
         
         <!-- Warning/Status Messages -->
-        <TextBlock x:Name="warning" Text="{Binding warning_message}" Foreground="Red" 
-                   TextWrapping="Wrap" HorizontalAlignment="Center" Margin="0,5" FontSize="11"/>
+        <Border x:Name="warning_banner" Background="{Binding warning_bg}" 
+                CornerRadius="4" Padding="10,6" Margin="0,8,0,0">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <TextBlock Text="{Binding warning_icon}" FontSize="14" 
+                           Foreground="{Binding warning_fg}"
+                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <TextBlock Text="{Binding warning_message}" 
+                           Foreground="{Binding warning_fg}"
+                           TextWrapping="Wrap" VerticalAlignment="Center" 
+                           FontSize="11" FontWeight="SemiBold"/>
+            </StackPanel>
+        </Border>
     </StackPanel>
 </Window>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles3.stack/ViewRange.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles3.stack/ViewRange.pushbutton/bundle.yaml
@@ -25,6 +25,6 @@ tooltip:
 author: Tamás Déri
 min_revit_version: 2023
 engine:
-  clean: true
+  clean: false
   full_frame: false
   persistent: true

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles3.stack/ViewRange.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles3.stack/ViewRange.pushbutton/script.py
@@ -1,15 +1,36 @@
 # -*- coding: UTF-8 -*-
+# ── Duplicate-window guard ──────────────────────────────────────────
+# With engine: { persistent: true, clean: false }, the same IronPython
+# engine and scope persist across clicks. script.exit() is safe here —
+# it raises SystemExit which the runner catches without disposing the
+# engine. No new .NET objects created, no engine disposal side effects.
+from pyrevit import script
 
-from pyrevit import script, forms, revit, HOST_APP, DB, UI
+logger = script.get_logger()
+
+VIEWRANGE_WINDOW_KEY = "PYREVIT_VIEWRANGE_WINDOW"
+VIEWRANGE_EXECID_KEY = "PYREVIT_VIEWRANGE_EXECID"
+
+_existing = script.get_envvar(VIEWRANGE_WINDOW_KEY)
+if _existing:
+    try:
+        if _existing.IsVisible:
+            script.exit()
+    except SystemExit:
+        raise
+    except Exception:
+        script.set_envvar(VIEWRANGE_WINDOW_KEY, None)
+        script.set_envvar(VIEWRANGE_EXECID_KEY, None)
+
+# ── Full imports ────────────────────────────────────────────────────
+from pyrevit import forms, revit, HOST_APP, DB, UI, EXEC_PARAMS
 from pyrevit.revit import events
 from pyrevit.framework import Convert, List, Color, SolidColorBrush
 from pyrevit.compat import get_elementid_value_func
 from collections import OrderedDict
 
-
 doc = HOST_APP.doc
 uidoc = HOST_APP.uidoc
-logger = script.get_logger()
 output = script.get_output()
 
 PLANES = OrderedDict(
@@ -30,7 +51,6 @@ PLANES = OrderedDict(
 get_elementid_value = get_elementid_value_func()
 INVALID_ID_VALUE = get_elementid_value(DB.ElementId.InvalidElementId)
 
-
 class Context(object):
     def __new__(cls, *args, **kwargs):
         if not hasattr(cls, "instance"):
@@ -49,7 +69,6 @@ class Context(object):
         self.original_offset_data = {}
         self.original_level_data = {}
         self.view_model = view_model
-        self._ordered_levels = []
         self._levels_populated = False  # Track if levels have been populated
         view_model.unit_label = DB.LabelUtils.GetLabelForUnit(self.length_unit)
 
@@ -75,8 +94,6 @@ class Context(object):
     def source_view(self, value):
         if not compare_views(self._source_view, value):
             self._source_view = value
-            if not self._ordered_levels:
-                self.collect_levels(self._source_view.Document)
             self._levels_populated = False  # Reset when view changes
 
             self._source_template = None
@@ -98,7 +115,7 @@ class Context(object):
 
     def update_view_range(self, new_values, new_levels=None):
         if not self.source_view or not isinstance(self.source_view, DB.ViewPlan):
-            self.view_model.warning_message = "No valid plan view selected"
+            self.view_model.show_error("No valid plan view selected")
             return False
 
         if self._source_template is not None:
@@ -117,202 +134,147 @@ class Context(object):
         return True
 
     def _update_view_range_internal(self, new_values, new_levels=None):
+        self.view_model.clear_field_errors()
+
+        # ── Build the PlanViewRange in memory (no transaction needed) ──
         try:
-            if not self._validate_view_range_order(new_values, new_levels):
-                return False
-
-            if self._source_template is not None:
-                view = self._source_template
-            else:
-                view = self._source_view
-
-            with revit.Transaction("Update View Range", doc=revit.doc):
-                view_range = view.GetViewRange()
-
-                # First, update levels if provided
-                if new_levels:
-                    for plane, new_level_id in new_levels.items():
-                        current_level_id = view_range.GetLevelId(plane)
-
-                        # Handle Unlimited (InvalidElementId)
-                        if new_level_id == DB.ElementId.InvalidElementId:
-                            # For View Depth, Unlimited is common - set to InvalidElementId
-                            if current_level_id != DB.ElementId.InvalidElementId:
-                                try:
-                                    # Note: Not all planes support InvalidElementId
-                                    # View Depth typically does, others may not
-                                    view_range.SetLevelId(
-                                        plane, DB.ElementId.InvalidElementId
-                                    )
-                                except Exception:
-                                    pass
-                        # Handle regular level changes
-                        elif new_level_id and current_level_id != new_level_id:
-                            try:
-                                view_range.SetLevelId(plane, new_level_id)
-                            except Exception:
-                                pass
-
-                # Then, update offsets (only for planes that have valid levels)
-                for plane, offset_str in new_values.items():
-                    # Skip offset update if level is set to Unlimited
-                    level_id = view_range.GetLevelId(plane)
-                    if not level_id or level_id == DB.ElementId.InvalidElementId:
-                        continue
-
-                    if (
-                        offset_str
-                        and offset_str.strip()
-                        and offset_str != "-"
-                        and offset_str.upper() != "N/A"
-                    ):
-                        try:
-                            offset_display = float(offset_str)
-                            offset_internal = DB.UnitUtils.ConvertToInternalUnits(
-                                offset_display, self.length_unit
-                            )
-                            current_offset = view_range.GetOffset(plane)
-
-                            # Only update if different
-                            if abs(current_offset - offset_internal) > 0.0001:
-                                view_range.SetOffset(plane, offset_internal)
-                        except ValueError:
-                            return False
-
-                # Apply the view range back to the view
-                view.SetViewRange(view_range)
-                self.context_changed()
-                self.view_model.warning_message = "View range updated successfully"
-                return True
-
+            view_range = self.source_view.GetViewRange()
         except Exception as e:
-            self.view_model.warning_message = "Error updating view range: {}".format(
-                str(e)
+            self.view_model.show_error(
+                "Error reading view range: {}".format(e)
             )
             return False
 
-    def _validate_view_range_order(self, new_values, new_levels=None):
-        try:
-            elevations = {}
-            offset_values = {}
-
-            for plane, offset_str in new_values.items():
-                # Skip validation for N/A values (Unlimited levels)
-                if offset_str and offset_str.upper() == "N/A":
-                    continue
-
-                if offset_str and offset_str.strip() and offset_str != "-":
-                    try:
-                        offset_value = float(offset_str)
-                        offset_values[plane] = offset_value
-
-                        # Use new level if provided, otherwise use current level
-                        level = None
-                        if new_levels and plane in new_levels:
-                            level_id = new_levels[plane]
-                            # Skip validation for Unlimited (InvalidElementId)
-                            if (
-                                not level_id
-                                or level_id == DB.ElementId.InvalidElementId
-                            ):
-                                continue
-                            level = self.source_view.Document.GetElement(level_id)
-
-                        if not level:
-                            level = self.level_data.get(plane)
-
-                        if level:
-                            level_elevation = DB.UnitUtils.ConvertFromInternalUnits(
-                                level.ProjectElevation, self.length_unit
+        # Update levels
+        if new_levels:
+            for plane, new_level_id in new_levels.items():
+                current_level_id = view_range.GetLevelId(plane)
+                if new_level_id == DB.ElementId.InvalidElementId:
+                    if current_level_id != DB.ElementId.InvalidElementId:
+                        try:
+                            view_range.SetLevelId(
+                                plane, DB.ElementId.InvalidElementId
                             )
-                            elevations[plane] = level_elevation + offset_value
-                    except ValueError:
-                        forms.alert(
-                            "Invalid Input Format!\n\nThe value '{}' for {} is not a valid number.\n\n"
-                            "Please enter a numeric value (e.g., 4.5, -2.0, 0)".format(
-                                offset_str, PLANES[plane][1]
-                            ),
-                            title="Invalid Number Format",
-                            warn_icon=True,
-                        )
-                        self.view_model.warning_message = (
-                            "Invalid number format: {}".format(offset_str)
-                        )
-                        return False
+                        except Exception:
+                            pass
+                elif new_level_id and current_level_id != new_level_id:
+                    try:
+                        view_range.SetLevelId(plane, new_level_id)
+                    except Exception:
+                        pass
 
-            # If any plane is set to Unlimited, skip full validation
-            if len(elevations) < 4:
-                return True
-
-            # Check order: Top >= Cut >= Bottom >= ViewDepth
-            checks = [
-                (
-                    DB.PlanViewPlane.TopClipPlane,
-                    DB.PlanViewPlane.CutPlane,
-                    "Top Clip Plane",
-                    "Cut Plane",
-                ),
-                (
-                    DB.PlanViewPlane.CutPlane,
-                    DB.PlanViewPlane.BottomClipPlane,
-                    "Cut Plane",
-                    "Bottom Clip Plane",
-                ),
-                (
-                    DB.PlanViewPlane.BottomClipPlane,
-                    DB.PlanViewPlane.ViewDepthPlane,
-                    "Bottom Clip Plane",
-                    "View Depth Plane",
-                ),
-            ]
-
-            for higher_plane, lower_plane, higher_name, lower_name in checks:
-                higher_elev = elevations.get(higher_plane)
-                lower_elev = elevations.get(lower_plane)
-
-                if (
-                    higher_elev is not None
-                    and lower_elev is not None
-                    and higher_elev < lower_elev
-                ):
-                    forms.alert(
-                        "View Range Order Error!\n\n{} (offset: {:.2f}') must be greater than or equal to {} "
-                        "(offset: {:.2f}').\n\nNote: These are offset values from the associated level.\n\n"
-                        "Correct order (top to bottom):\n1. Top Clip Plane (highest offset)\n2. Cut Plane\n"
-                        "3. Bottom Clip Plane\n4. View Depth Plane (lowest offset)".format(
-                            higher_name,
-                            offset_values.get(higher_plane, 0),
-                            lower_name,
-                            offset_values.get(lower_plane, 0),
-                        ),
-                        title="Invalid View Range",
-                        warn_icon=True,
+        # Update offsets
+        for plane, offset_str in new_values.items():
+            level_id = view_range.GetLevelId(plane)
+            if not level_id or level_id == DB.ElementId.InvalidElementId:
+                continue
+            if (
+                offset_str
+                and offset_str.strip()
+                and offset_str != "-"
+                and offset_str.upper() != "N/A"
+            ):
+                try:
+                    offset_display = float(offset_str)
+                    offset_internal = DB.UnitUtils.ConvertToInternalUnits(
+                        offset_display, self.length_unit
                     )
-                    self.view_model.warning_message = "{} must be >= {}".format(
-                        higher_name, lower_name
+                    current_offset = view_range.GetOffset(plane)
+                    if abs(current_offset - offset_internal) > 0.0001:
+                        view_range.SetOffset(plane, offset_internal)
+                except ValueError:
+                    _, _, prefix = PLANES[plane]
+                    self.view_model.set_field_error(prefix)
+                    self.view_model.show_error(
+                        "Invalid number format in {} field".format(
+                            PLANES[plane][1]
+                        )
                     )
                     return False
 
-            return True
-
-        except Exception as e:
-            self.view_model.warning_message = "Error validating view range: {}".format(
-                str(e)
+        # ── Validate assembled view range (internal units, single pass) ──
+        error_prefixes = self._find_elevation_violations(view_range)
+        if error_prefixes:
+            self.view_model.set_field_error(*error_prefixes)
+            self.view_model.show_error(
+                "Invalid view range: plane elevations must be ordered "
+                "Top \u2265 Cut \u2265 Bottom \u2265 View Depth"
             )
             return False
 
-    def collect_levels(self, doc):
-        # Get all levels in the project
-        level_collector = DB.FilteredElementCollector(doc).OfClass(DB.Level)
-        levels = list(level_collector)
+        # ── Apply to the model inside a transaction ──
+        # try/except wraps the with block so the exception propagates to
+        # revit.Transaction.__exit__ for proper rollback (no ghost Undo).
+        apply_error = None
+        try:
+            with revit.Transaction("Update View Range", doc=revit.doc):
+                self.source_view.SetViewRange(view_range)
+        except Exception as e:
+            apply_error = e
 
-        # Sort levels by elevation
-        levels.sort(key=lambda x: x.ProjectElevation)
-        self._ordered_levels = levels
+        if apply_error:
+            all_prefixes = [p for _, _, p in PLANES.values()]
+            self.view_model.set_field_error(*all_prefixes)
+            self.view_model.show_error(
+                "Invalid view range: the combination of levels and "
+                "offsets is not allowed by Revit"
+            )
+            return False
 
-    def _populate_level_items(self):
+        self.context_changed()
+        self.view_model.show_success("View range updated successfully")
+        return True
+
+    def _find_elevation_violations(self, view_range):
+        """Check the assembled view_range for ordering violations.
+
+        Returns a list of prefixes (e.g. ['topplane', 'cutplane']) for
+        planes that are out of order.  Empty list means valid.
+        """
+        ordered_planes = [
+            DB.PlanViewPlane.TopClipPlane,
+            DB.PlanViewPlane.CutPlane,
+            DB.PlanViewPlane.BottomClipPlane,
+            DB.PlanViewPlane.ViewDepthPlane,
+        ]
+        elevations = {}
+        for plane in ordered_planes:
+            level_id = view_range.GetLevelId(plane)
+            if not level_id or level_id == DB.ElementId.InvalidElementId:
+                continue
+            level = self.source_view.Document.GetElement(level_id)
+            if not level:
+                continue
+            elevations[plane] = level.ProjectElevation + view_range.GetOffset(plane)
+
+        # Check each adjacent pair
+        error_planes = set()
+        checks = [
+            (DB.PlanViewPlane.TopClipPlane, DB.PlanViewPlane.CutPlane),
+            (DB.PlanViewPlane.CutPlane, DB.PlanViewPlane.BottomClipPlane),
+            (DB.PlanViewPlane.BottomClipPlane, DB.PlanViewPlane.ViewDepthPlane),
+        ]
+        for higher, lower in checks:
+            if higher in elevations and lower in elevations:
+                if elevations[higher] < elevations[lower] - 0.001:
+                    error_planes.add(higher)
+                    error_planes.add(lower)
+
+        # Map PlanViewPlane enums to prefixes
+        return [PLANES[p][2] for p in error_planes if p in PLANES]
+
+    def _populate_available_levels(self):
         """Populate the list of available levels in the project"""
         try:
+            # Get all levels in the project
+            level_collector = DB.FilteredElementCollector(
+                self.source_view.Document
+            ).OfClass(DB.Level)
+            levels = list(level_collector)
+
+            # Sort levels by elevation
+            levels.sort(key=lambda x: x.ProjectElevation)
+
             # Create a simple class for level items that WPF can bind to
             class LevelItem(object):
                 def __init__(self, name, element_id, elevation=None, is_special=False):
@@ -329,44 +291,27 @@ class Context(object):
             # Create level items
             level_items = []
 
-            if self._source_template is not None:
-                # Get relative levels
-                level_items.append(
-                    LevelItem("Current", DB.ElementId(-3), None, True)
-                )
-                level_items.append(
-                    LevelItem("Level Above", DB.ElementId(-2), None, True)
-                )
-                level_items.append(
-                    LevelItem("Level Below", DB.ElementId(-4), None, True)
-                )
-            else:
-                # Add actual levels
-                for level in self._ordered_levels:
-                    level_item = LevelItem(
-                        level.Name, level.Id, level.ProjectElevation, False
-                    )
-                    level_items.append(level_item)
-
             # Add special "Unlimited" option (uses InvalidElementId)
             level_items.append(
                 LevelItem("Unlimited", DB.ElementId.InvalidElementId, None, True)
             )
 
+            # Add actual levels
+            for level in levels:
+                level_item = LevelItem(
+                    level.Name, level.Id, level.ProjectElevation, False
+                )
+                level_items.append(level_item)
+
             self.view_model.available_levels = level_items
             self._levels_populated = True
 
         except Exception as e:
-            self.view_model.warning_message = "Error loading levels: {}".format(str(e))
+            self.view_model.show_error("Error loading levels: {}".format(str(e)))
 
-    def _set_current_level_selections(self):
+    def _set_current_level_selections(self, view_range):
         """Set the current level selections based on the view range"""
         try:
-            if self._source_template is None:
-                view_range = self._source_view.GetViewRange()
-            else:
-                view_range = self._source_template.GetViewRange()
-
             # Store current selections
             stored_selections = {}
 
@@ -382,15 +327,13 @@ class Context(object):
 
                 elif plane == DB.PlanViewPlane.CutPlane:
                     # For Cut Plane, show the level name as read-only text
-                    if not level_id or level_id == DB.ElementId.InvalidElementId:
-                        self.view_model.cutplane_level_name = "Unlimited"
-                    elif level_id == DB.PlanViewRange.Current:
-                        self.view_model.cutplane_level_name = "Current"
-                    else:
+                    if level_id and level_id != DB.ElementId.InvalidElementId:
                         level = self.source_view.Document.GetElement(level_id)
                         self.view_model.cutplane_level_name = (
                             level.Name if level else "Unknown"
                         )
+                    else:
+                        self.view_model.cutplane_level_name = "Unlimited"
 
                 elif plane == DB.PlanViewPlane.BottomClipPlane:
                     if level_id and level_id != DB.ElementId.InvalidElementId:
@@ -421,7 +364,7 @@ class Context(object):
             )
 
         except Exception as e:
-            self.view_model.warning_message = (
+            self.view_model.show_error(
                 "Error setting level selections: {}".format(str(e))
             )
 
@@ -441,10 +384,15 @@ class Context(object):
             setattr(self.view_model, prefix + "_elevation", "-")
             setattr(self.view_model, prefix + "_new_value", "")
 
-        self.view_model.warning_message = ""
+        self.view_model.clear_warning()
+        self.view_model.clear_field_errors()
 
         if not self.is_valid():
-            server.meshes = None
+            try:
+                server.remove_server()
+            except Exception:
+                pass
+            server.meshes = []
             events.execute_in_revit_context(refresh_active_view)
             return
 
@@ -452,11 +400,6 @@ class Context(object):
             edges, triangles = [], []
 
             if isinstance(self.source_view, DB.ViewPlan):
-                if self._source_template is None:
-                    view_range = self.source_view.GetViewRange()
-                else:
-                    view_range = self._source_template.GetViewRange()
-
                 if (
                     self.active_view.get_Parameter(
                         DB.BuiltInParameter.VIEWER_MODEL_CLIP_BOX_ACTIVE
@@ -467,12 +410,11 @@ class Context(object):
                 else:
                     corners = corners_from_bb(self.source_view.CropBox)
 
+                view_range = self.source_view.GetViewRange()
+
                 # Only populate levels if not already populated
                 if not self._levels_populated:
-                    self._populate_level_items()
-
-                view_level_id = self.source_view.GenLevel.Id
-                ordered_level_ids = [l.Id for l in self._ordered_levels]
+                    self._populate_available_levels()
 
                 for plane in PLANES:
                     _, _, prefix = PLANES[plane]
@@ -485,23 +427,7 @@ class Context(object):
                         self.level_data[plane] = None
                         continue
 
-                    # above
-                    elif get_elementid_value(level_id) == -2:
-                        plane_level = self._ordered_levels[
-                            ordered_level_ids.index(view_level_id) + 1
-                        ]
-                    # current
-                    elif get_elementid_value(level_id) == -3:
-                        plane_level = self._ordered_levels[
-                            ordered_level_ids.index(view_level_id)
-                        ]
-                    # below
-                    elif get_elementid_value(level_id) == -4:
-                        plane_level = self._ordered_levels[
-                            ordered_level_ids.index(view_level_id) - 1
-                        ]
-                    else:
-                        plane_level = self.source_view.Document.GetElement(level_id)
+                    plane_level = self.source_view.Document.GetElement(level_id)
 
                     if not plane_level:
                         self.height_data[plane] = "N/A"
@@ -558,7 +484,7 @@ class Context(object):
                     )
 
                 # Set current level selections AFTER ensuring levels are populated
-                self._set_current_level_selections()
+                self._set_current_level_selections(view_range)
 
             else:
                 crop_bbox = self.source_view.CropBox
@@ -581,7 +507,17 @@ class Context(object):
                             view_dir_transform.OfPoint(pt) for pt in cut_plane_vertices
                         ]
 
+            # Swap meshes with server removed to prevent Draw Thread
+            # from calling GetBoundingBox during the transition.
+            try:
+                server.remove_server()
+            except Exception:
+                pass
             server.meshes = [revit.dc3dserver.Mesh(edges, triangles)]
+            try:
+                server.add_server()
+            except Exception:
+                pass
             events.execute_in_revit_context(refresh_active_view)
 
         except Exception as ex:
@@ -625,11 +561,38 @@ class Context(object):
                 )
             return True
 
-
 class MainViewModel(forms.Reactive):
+    # Brushes for field error highlighting
+    _DEFAULT_FIELD_BG = SolidColorBrush(Color.FromArgb(
+        Convert.ToByte(0), Convert.ToByte(255),
+        Convert.ToByte(255), Convert.ToByte(255)))  # Transparent
+    _ERROR_FIELD_BG = SolidColorBrush(Color.FromArgb(
+        Convert.ToByte(255), Convert.ToByte(255),
+        Convert.ToByte(200), Convert.ToByte(200)))  # Light red
+
+    # Warning banner brushes
+    _TRANSPARENT_BG = SolidColorBrush(Color.FromArgb(
+        Convert.ToByte(0), Convert.ToByte(0),
+        Convert.ToByte(0), Convert.ToByte(0)))
+    _ERROR_BANNER_BG = SolidColorBrush(Color.FromArgb(
+        Convert.ToByte(255), Convert.ToByte(254),
+        Convert.ToByte(235), Convert.ToByte(235)))  # Soft red bg
+    _ERROR_BANNER_FG = SolidColorBrush(Color.FromRgb(
+        Convert.ToByte(180), Convert.ToByte(30),
+        Convert.ToByte(30)))  # Dark red text
+    _SUCCESS_BANNER_BG = SolidColorBrush(Color.FromArgb(
+        Convert.ToByte(255), Convert.ToByte(235),
+        Convert.ToByte(250), Convert.ToByte(235)))  # Soft green bg
+    _SUCCESS_BANNER_FG = SolidColorBrush(Color.FromRgb(
+        Convert.ToByte(30), Convert.ToByte(120),
+        Convert.ToByte(30)))  # Dark green text
+
     def __init__(self):
         self._message = None
         self._warning_message = ""
+        self._warning_icon = ""
+        self._warning_bg = self._TRANSPARENT_BG
+        self._warning_fg = self._ERROR_BANNER_FG
         self._can_modify_view = False
 
         # Initialize level-related properties - use INTEGER values for WPF binding
@@ -650,6 +613,49 @@ class MainViewModel(forms.Reactive):
             )
             setattr(self, "_" + prefix + "_elevation", "-")
             setattr(self, "_" + prefix + "_new_value", "")
+            # Per-field error background (bound to TextBox/ComboBox Background)
+            setattr(self, "_" + prefix + "_field_bg", self._DEFAULT_FIELD_BG)
+
+    def clear_field_errors(self):
+        """Reset all field backgrounds to default (no error)."""
+        for _, _, prefix in PLANES.values():
+            setattr(self, prefix + "_field_bg", self._DEFAULT_FIELD_BG)
+
+    def set_field_error(self, *prefixes):
+        """Set the specified field(s) to error highlight."""
+        for prefix in prefixes:
+            setattr(self, prefix + "_field_bg", self._ERROR_FIELD_BG)
+
+    def show_error(self, msg):
+        """Show an error banner with warning icon."""
+        self._warning_icon = "\u26A0"  # ⚠
+        self._warning_bg = self._ERROR_BANNER_BG
+        self._warning_fg = self._ERROR_BANNER_FG
+        # Trigger all bindings
+        self.warning_icon = self._warning_icon
+        self.warning_bg = self._warning_bg
+        self.warning_fg = self._warning_fg
+        self.warning_message = msg
+
+    def show_success(self, msg):
+        """Show a success banner with check icon."""
+        self._warning_icon = "\u2714"  # ✔
+        self._warning_bg = self._SUCCESS_BANNER_BG
+        self._warning_fg = self._SUCCESS_BANNER_FG
+        self.warning_icon = self._warning_icon
+        self.warning_bg = self._warning_bg
+        self.warning_fg = self._warning_fg
+        self.warning_message = msg
+
+    def clear_warning(self):
+        """Hide the warning banner."""
+        self._warning_icon = ""
+        self._warning_bg = self._TRANSPARENT_BG
+        self._warning_fg = self._ERROR_BANNER_FG
+        self.warning_icon = self._warning_icon
+        self.warning_bg = self._warning_bg
+        self.warning_fg = self._warning_fg
+        self.warning_message = ""
 
     @forms.reactive
     def message(self):
@@ -666,6 +672,30 @@ class MainViewModel(forms.Reactive):
     @warning_message.setter
     def warning_message(self, value):
         self._warning_message = value
+
+    @forms.reactive
+    def warning_icon(self):
+        return self._warning_icon
+
+    @warning_icon.setter
+    def warning_icon(self, value):
+        self._warning_icon = value
+
+    @forms.reactive
+    def warning_bg(self):
+        return self._warning_bg
+
+    @warning_bg.setter
+    def warning_bg(self, value):
+        self._warning_bg = value
+
+    @forms.reactive
+    def warning_fg(self):
+        return self._warning_fg
+
+    @warning_fg.setter
+    def warning_fg(self, value):
+        self._warning_fg = value
 
     @forms.reactive
     def can_modify_view(self):
@@ -782,6 +812,38 @@ class MainViewModel(forms.Reactive):
     def viewdepth_new_value(self, value):
         self._viewdepth_new_value = value
 
+    # Per-field error background properties (bound to TextBox/ComboBox Background)
+    @forms.reactive
+    def topplane_field_bg(self):
+        return self._topplane_field_bg
+
+    @topplane_field_bg.setter
+    def topplane_field_bg(self, value):
+        self._topplane_field_bg = value
+
+    @forms.reactive
+    def cutplane_field_bg(self):
+        return self._cutplane_field_bg
+
+    @cutplane_field_bg.setter
+    def cutplane_field_bg(self, value):
+        self._cutplane_field_bg = value
+
+    @forms.reactive
+    def bottomplane_field_bg(self):
+        return self._bottomplane_field_bg
+
+    @bottomplane_field_bg.setter
+    def bottomplane_field_bg(self, value):
+        self._bottomplane_field_bg = value
+
+    @forms.reactive
+    def viewdepth_field_bg(self):
+        return self._viewdepth_field_bg
+
+    @viewdepth_field_bg.setter
+    def viewdepth_field_bg(self, value):
+        self._viewdepth_field_bg = value
 
 class MainWindow(forms.WPFWindow):
     def __init__(self):
@@ -793,13 +855,11 @@ class MainWindow(forms.WPFWindow):
 
     def window_closed(self, sender, args):
         script.save_window_position(self)
-        server.remove_server()
-        events.execute_in_revit_context(refresh_active_view)
-        # Stop all registered events using the events API
-        events.stop_events()
+        events.execute_in_revit_context(_on_close_cleanup)
 
     def apply_changes_click(self, sender, e):
         try:
+            self.DataContext.clear_field_errors()
             new_values = {
                 plane: getattr(self.DataContext, prefix + "_new_value")
                 for plane, (_, _, prefix) in PLANES.items()
@@ -843,8 +903,8 @@ class MainWindow(forms.WPFWindow):
 
             context.update_view_range(new_values, new_levels)
         except Exception as ex:
-            self.DataContext.warning_message = "Error applying changes: {}".format(
-                str(ex)
+            self.DataContext.show_error("Error applying changes: {}".format(
+                str(ex))
             )
 
     def reset_values_click(self, sender, e):
@@ -920,74 +980,16 @@ class MainWindow(forms.WPFWindow):
             else:
                 # Fallback: Reset level selections to current view range levels if no original data
                 if hasattr(context, "source_view") and context.source_view:
-                    context._set_current_level_selections()
+                    view_range = context.source_view.GetViewRange()
+                    context._set_current_level_selections(view_range)
 
-            self.DataContext.warning_message = ""
+            self.DataContext.clear_warning()
         except Exception as ex:
-            self.DataContext.warning_message = "Error resetting values: {}".format(
-                str(ex)
+            self.DataContext.show_error("Error resetting values: {}".format(
+                str(ex))
             )
 
-
-# Event handlers are now registered via @events.handle decorators below
-# Old manual subscribe/unsubscribe functions removed in favor of events API
-
-
-def refresh_active_view():
-    try:
-        uidoc = revit.uidoc
-        if not compare_views(uidoc.ActiveView, context.active_view):
-            uidoc.ActiveView = context.active_view
-        uidoc.RefreshActiveView()
-        if context.source_view:
-            uidoc.Selection.SetElementIds(List[DB.ElementId]([context.source_view.Id]))
-    except Exception as ex:
-        logger.exception(ex)
-
-
-@events.handle("view-activated")
-def view_activated(sender, args):
-    try:
-        context.active_view = args.CurrentActiveView
-    except Exception as ex:
-        logger.exception(ex)
-
-
-@events.handle("selection-changed")
-def selection_changed(sender, args):
-    if not args.GetDocument().ActiveView.ViewType == DB.ViewType.ProjectBrowser:
-        return
-
-    try:
-        doc = args.GetDocument()
-        sel_ids = list(args.GetSelectedElements())
-        if len(sel_ids) == 1:
-            sel = doc.GetElement(sel_ids[0])
-            if can_use_view_as_source(sel):
-                context.source_view = sel
-                return
-        context.source_view = None
-    except Exception as ex:
-        logger.exception(ex)
-
-
-@events.handle("doc-changed")
-def doc_changed(sender, args):
-    try:
-        context.collect_levels(args.Document)
-        affected_ids = list(args.GetModifiedElementIds()) + list(
-            args.GetDeletedElementIds()
-        )
-        if any(
-            view.Id in affected_ids
-            for view in [context.source_view, context.active_view]
-        ):
-            context.context_changed()
-    except AttributeError:
-        context.context_changed()
-    except Exception as ex:
-        logger.exception(ex)
-
+# ── Helper functions ────────────────────────────────────────────────
 
 def compare_views(view1, view2):
     if not view1 and not view2:
@@ -999,10 +1001,8 @@ def compare_views(view1, view2):
         and view1.Id == view2.Id
     )
 
-
 def can_use_view_as_source(view):
     return isinstance(view, (DB.ViewPlan, DB.ViewSection))
-
 
 def corners_from_bb(bbox):
     transform = bbox.Transform
@@ -1016,13 +1016,11 @@ def corners_from_bb(bbox):
     ]
     return [transform.OfPoint(c) for c in corners]
 
-
 def create_edges(vertices, color):
     return [
         revit.dc3dserver.Edge(vertices[i - 1], vertices[i], color)
         for i in range(len(vertices))
     ]
-
 
 def create_triangles(vertices, color):
     return [
@@ -1046,11 +1044,96 @@ def create_triangles(vertices, color):
         ),
     ]
 
-
 def get_color_from_plane(plane):
     rgb = PLANES[plane][0]
     return DB.ColorWithTransparency(rgb[0], rgb[1], rgb[2], 180)
 
+def refresh_active_view():
+    try:
+        uidoc = revit.uidoc
+        if not compare_views(uidoc.ActiveView, context.active_view):
+            uidoc.ActiveView = context.active_view
+        uidoc.RefreshActiveView()
+        if context.source_view:
+            uidoc.Selection.SetElementIds(
+                List[DB.ElementId]([context.source_view.Id])
+            )
+    except Exception as ex:
+        logger.exception(ex)
+
+def _on_close_cleanup():
+    """Deferred cleanup in valid Revit API context.
+
+    Order matters:
+    1. Unregister event handlers (using stored exec_id)
+    2. Remove DC3D server (stops Draw Thread calls)
+    3. Refresh view (clears stale rendering)
+    4. Clear window envvar (allows reopening)
+    """
+    try:
+        stored_exec_id = script.get_envvar(VIEWRANGE_EXECID_KEY)
+        if stored_exec_id:
+            events.unregister_exec_handlers(stored_exec_id)
+            script.set_envvar(VIEWRANGE_EXECID_KEY, None)
+    except Exception as ex:
+        logger.error("Error stopping events: {}".format(ex))
+    try:
+        server.remove_server()
+    except Exception as ex:
+        logger.error("Error removing DC3D server: {}".format(ex))
+    try:
+        uidoc = revit.uidoc
+        uidoc.RefreshActiveView()
+    except Exception as ex:
+        logger.error("Error refreshing view: {}".format(ex))
+    # Clear window key AFTER all cleanup is complete, so the guard
+    # blocks re-entry until the server is fully removed.
+    script.set_envvar(VIEWRANGE_WINDOW_KEY, None)
+
+# ── Event handlers & initialization ─────────────────────────────────
+# This code is ONLY reached on the first click. Subsequent clicks
+# hit script.exit() at the top of the file before even importing
+# pyrevit.revit.events, so no .NET ExternalEvent objects are created
+# and no event handlers are re-registered.
+
+@events.handle("view-activated")
+def view_activated(sender, args):
+    try:
+        context.active_view = args.CurrentActiveView
+    except Exception as ex:
+        logger.exception(ex)
+
+@events.handle("selection-changed")
+def selection_changed(sender, args):
+    if not args.GetDocument().ActiveView.ViewType == DB.ViewType.ProjectBrowser:
+        return
+    try:
+        doc = args.GetDocument()
+        sel_ids = list(args.GetSelectedElements())
+        if len(sel_ids) == 1:
+            sel = doc.GetElement(sel_ids[0])
+            if can_use_view_as_source(sel):
+                context.source_view = sel
+                return
+        context.source_view = None
+    except Exception as ex:
+        logger.exception(ex)
+
+@events.handle("doc-changed")
+def doc_changed(sender, args):
+    try:
+        affected_ids = list(args.GetModifiedElementIds()) + list(
+            args.GetDeletedElementIds()
+        )
+        if any(
+            view.Id in affected_ids
+            for view in [context.source_view, context.active_view]
+        ):
+            context.context_changed()
+    except AttributeError:
+        context.context_changed()
+    except Exception as ex:
+        logger.exception(ex)
 
 # Initialize
 server = revit.dc3dserver.Server(register=False)
@@ -1060,4 +1143,6 @@ context.active_view = uidoc.ActiveGraphicalView
 
 main_window = MainWindow()
 main_window.DataContext = vm
+script.set_envvar(VIEWRANGE_WINDOW_KEY, main_window)
+script.set_envvar(VIEWRANGE_EXECID_KEY, EXEC_PARAMS.exec_id)
 main_window.show()


### PR DESCRIPTION
# fix(ViewRange): prevent duplicate windows, close crash, and invalid range errors (#3205)

- Add early envvar guard to prevent duplicate DC3D servers
- Change engine config to clean:false to prevent engine disposal crashes
- Remove server before clearing meshes (prevents GetBoundingBox→None→SEH)
- Re-add server only after meshes are populated
- Defer all close cleanup to Revit API context via ExternalEvent
- Pre-validate view range before SetViewRange to suppress transaction errors
- Add warning banner with field-level error highlighting in XAML




## Description

Fixes the Show View Range tool crashing Revit when the window is closed, and prevents duplicate windows from being opened when the button is clicked multiple times. The crash was caused by the DirectContext3D server's GetBoundingBox() returning null to .NET when meshes were cleared while the server was still registered — a race condition on the Draw Thread. The fix ensures the server is always unregistered before meshes are cleared and only re-registered after new meshes are populated. Additionally, the engine config is changed from clean: true to clean: false to prevent IronPython engine disposal from corrupting shared CLR state on repeated clicks. Invalid view range inputs are now caught before the transaction and surfaced to the user through per-field error highlighting and a warning banner instead of producing unhandled transaction rollback errors in the log.
---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ok] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ ok] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #3205 



---

Thank you for contributing to pyRevit! 🎉
