### PR TITLE
Fix Regressions cause by Copilot Auto Fix

### DIFF
--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
@@ -57,19 +57,20 @@ def _ensure_path_registered(dest_path):
     # Read the raw configured list to avoid silently dropping offline paths.
     # get_thirdparty_ext_root_dirs() filters by op.exists(), which would
     # remove temporarily-offline network shares when writing back.
+    from pyrevit.userconfig import CONSTS
     try:
-        from pyrevit.userconfig import CONSTS
         raw_dirs = list(user_config.core.get_option(
             CONSTS.ConfigsUserExtensionsKey, default_value=[]))
-    except Exception:
-        # Fallback: use existing helper (may filter non-existent).
+    except Exception as read_err:
+        logger.debug('Error reading raw extension dirs, falling back to helper. | %s', read_err)
         raw_dirs = user_config.get_thirdparty_ext_root_dirs(include_default=False)
 
     normalized_existing = [os.path.normcase(os.path.normpath(d)) for d in raw_dirs]
     if norm_dest not in normalized_existing:
         raw_dirs.append(dest_path)
+        # Write directly to preserve offline paths; set_thirdparty_ext_root_dirs
+        # would reject any path that doesn't currently exist on disk.
         try:
-            from pyrevit.userconfig import CONSTS
             user_config.core.set_option(
                 CONSTS.ConfigsUserExtensionsKey,
                 [os.path.normpath(x) for x in raw_dirs]

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
@@ -68,8 +68,15 @@ def _ensure_path_registered(dest_path):
     normalized_existing = [os.path.normcase(os.path.normpath(d)) for d in raw_dirs]
     if norm_dest not in normalized_existing:
         raw_dirs.append(dest_path)
-        user_config.set_thirdparty_ext_root_dirs(raw_dirs)
-        user_config.save_changes()
+        try:
+            from pyrevit.userconfig import CONSTS
+            user_config.core.set_option(
+                CONSTS.ConfigsUserExtensionsKey,
+                [os.path.normpath(x) for x in raw_dirs]
+            )
+            user_config.save_changes()
+        except Exception as write_err:
+            logger.error('Error saving extension path. | %s', write_err)
 
 def _get_default_ext_dir():
     """Return the best default extension installation directory."""

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
@@ -12,7 +12,7 @@ from pyrevit import EXEC_PARAMS
 from pyrevit import extensions as exts
 import pyrevit.extensions.extpackages as extpkgs
 
-from pyrevit.userconfig import user_config
+from pyrevit.userconfig import user_config, CONSTS
 
 import pyrevitcore_globals
 
@@ -57,10 +57,9 @@ def _ensure_path_registered(dest_path):
     # Read the raw configured list to avoid silently dropping offline paths.
     # get_thirdparty_ext_root_dirs() filters by op.exists(), which would
     # remove temporarily-offline network shares when writing back.
-    from pyrevit.userconfig import CONSTS
     try:
-        raw_dirs = list(user_config.core.get_option(
-            CONSTS.ConfigsUserExtensionsKey, default_value=[]))
+        raw_dirs = [os.path.expandvars(d) for d in user_config.core.get_option(
+            CONSTS.ConfigsUserExtensionsKey, default_value=[])]
     except Exception as read_err:
         logger.debug('Error reading raw extension dirs, falling back to helper. | %s', read_err)
         raw_dirs = user_config.get_thirdparty_ext_root_dirs(include_default=False)

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Extensions.smartbutton/script.py
@@ -54,11 +54,15 @@ def _ensure_path_registered(dest_path):
         # fall back to normal registration logic.
         pass
 
-    # Prefer the raw configured list to avoid silently dropping offline paths.
+    # Read the raw configured list to avoid silently dropping offline paths.
+    # get_thirdparty_ext_root_dirs() filters by op.exists(), which would
+    # remove temporarily-offline network shares when writing back.
     try:
-        raw_dirs = list(user_config.thirdparty_ext_root_dirs or [])
-    except AttributeError:
-        # Fallback for older configs: use existing helper (may filter non-existent).
+        from pyrevit.userconfig import CONSTS
+        raw_dirs = list(user_config.core.get_option(
+            CONSTS.ConfigsUserExtensionsKey, default_value=[]))
+    except Exception:
+        # Fallback: use existing helper (may filter non-existent).
         raw_dirs = user_config.get_thirdparty_ext_root_dirs(include_default=False)
 
     normalized_existing = [os.path.normcase(os.path.normpath(d)) for d in raw_dirs]
@@ -170,8 +174,7 @@ class ExtensionsWindow(forms.WPFWindow):
     def __init__(self, xaml_file_name):
         forms.WPFWindow.__init__(self, xaml_file_name)
         self._setup_ext_pkg_ui(extpkgs.get_ext_packages())
-        default_path = user_config.get_thirdparty_ext_root_dirs(include_default=True)[0]
-        self.custom_ext_install_path_tb.Text = default_path
+        self.custom_ext_install_path_tb.Text = _get_default_ext_dir()
         if self.selected_pkg:
             self._update_add_custom_section_for_selection(self.selected_pkg)
         else:
@@ -427,8 +430,7 @@ class ExtensionsWindow(forms.WPFWindow):
         if getattr(self, "custom_ext_name_tb", None):
             self.custom_ext_name_tb.IsReadOnly = False
         self.path_custom_ext_b.IsEnabled = True
-        default_path = user_config.get_thirdparty_ext_root_dirs(include_default=True)[0]
-        self.custom_ext_install_path_tb.Text = default_path
+        self.custom_ext_install_path_tb.Text = _get_default_ext_dir()
         self.show_element(self.install_custom_ext_b)
         self._update_ext_info_from_git_fields()
 
@@ -488,8 +490,7 @@ class ExtensionsWindow(forms.WPFWindow):
             if self.selected_pkg and not self.selected_pkg.ext_pkg.is_installed:
                 dest_path = self.custom_ext_install_path_tb.Text
                 if not dest_path:
-                    ext_dirs = user_config.get_thirdparty_ext_root_dirs(include_default=True)
-                    dest_path = ext_dirs[0]
+                    dest_path = _get_default_ext_dir()
                 token = self.custom_token_pb.Password.strip()
                 if token:
                     self.selected_pkg.ext_pkg.config.private_repo = True
@@ -541,8 +542,7 @@ class ExtensionsWindow(forms.WPFWindow):
             # Get default extension directory
             dest_path = self.custom_ext_install_path_tb.Text
             if not dest_path:
-                ext_dirs = user_config.get_thirdparty_ext_root_dirs(include_default=True)
-                dest_path = ext_dirs[0]  # Use the default directory
+                dest_path = _get_default_ext_dir()
 
             logger.info('Installing extension "{}" from {}'.format(ext_name, git_url))
             logger.info("Destination: {}".format(dest_path))


### PR DESCRIPTION
Copilot Hallucinated when Auto fixed previous PR,

Five changes from the merged version:

_ensure_path_registered() line 59 — Replaced user_config.thirdparty_ext_root_dirs (doesn't exist) with user_config.core.get_option(CONSTS.ConfigsUserExtensionsKey, ...) which reads the raw config without filtering by op.exists()
__init__() line 174 — _get_default_ext_dir() instead of raw [0]
_update_add_custom_section_for_new() line 430 — same
install_custom_extension() catalog path, line 490 — same
install_custom_extension() Git URL path, line 542 — same