### PR TITLE
fix: restore WndProc pre-cached .NET types to prevent IronPython crash

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
@@ -525,9 +525,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
         # Pre-cache .NET types — IronPython cannot resolve System.IntPtr
         # or System.Action from inside a Win32 WndProc callback
         # (LookupGlobalInstruction crash in HwndSubclass.SubclassWndProc).
-        self._INTPTR_ZERO = System.IntPtr.Zero
-        self._INTPTR_MA_NOACTIVATE = System.IntPtr(self.MA_NOACTIVATE)
-        self._BG_PRIORITY = Windows.Threading.DispatcherPriority.Background
+        self._intptr_zero = System.IntPtr.Zero
+        self._intptr_ma_noactivate = System.IntPtr(self.MA_NOACTIVATE)
+        self._bg_priority = Windows.Threading.DispatcherPriority.Background
         self.SourceInitialized += self._on_source_initialized
 
         self._kfile = None
@@ -696,14 +696,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
                     self._activation_pending = True
                     try:
                         self.Dispatcher.BeginInvoke(
-                            self._activate_action, self._BG_PRIORITY
+                            self._activate_action, self._bg_priority
                         )
                     except Exception:
                         self._activation_pending = False
-                return self._INTPTR_MA_NOACTIVATE
+                return self._intptr_ma_noactivate
         except Exception:
             pass  # WndProc must NEVER throw
-        return self._INTPTR_ZERO
+        return self._intptr_zero
 
     def _safe_activate(self):
         """Deferred activation — runs when Revit's message loop is idle."""

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
@@ -685,9 +685,10 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def _wnd_proc(self, hwnd, msg, wParam, lParam, handled):
         """Win32 WndProc hook — intercept activation messages.
-        CRITICAL: Only use pre-cached instance variables here.
-        IronPython cannot resolve .NET types (System.IntPtr, etc.)
-        from inside a native Win32 callback."""
+        CRITICAL: Do not resolve .NET types/delegates by name here
+        (for example System.IntPtr or System.Action); use cached
+        members/delegates instead. Callback parameters and constants
+        are safe to use inside this native Win32 callback."""
         try:
             if msg == self.WM_MOUSEACTIVATE:
                 handled.Value = True

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
@@ -12,8 +12,9 @@ Features:
 Shift+Click:
 Reset window configurations and open.
 """
-#pylint: disable=E0401,W0613,C0111,C0103,C0302,W0703
-#pylint: disable=raise-missing-from
+
+# pylint: disable=E0401,W0613,C0111,C0103,C0302,W0703
+# pylint: disable=raise-missing-from
 import os
 import os.path as op
 import shutil
@@ -55,6 +56,7 @@ output = script.get_output()
 # .NET Framework 4.x (Revit 2023/2024) because IronPython can't subscript
 # ReadOnlyList[T] with [].  The fix: iterate or use .Item[0] / LINQ First().
 
+
 def _safe_first(collection):
     """Safely get first element from a .NET collection that may not
     support Python [] subscripting (ReadOnlyList, IList, etc.)."""
@@ -82,6 +84,7 @@ def _safe_first(collection):
 def _patched_get_item(adc_svc, path):
     """Patched version of adc._get_item that handles ReadOnlyList."""
     import os.path as _op
+
     path = adc._ensure_local_path(adc_svc, path)
     if not _op.isfile(path):
         raise Exception("Path does not point to a file")
@@ -123,14 +126,14 @@ def _patched_get_item_property_id_value(adc_svc, drive, item, prop_id):
 
 
 # Apply patches (only on .NET Framework, only once per engine session)
-if not HOST_APP.is_newer_than("2024") \
-        and not getattr(adc, '_readonlylist_patched', False):
+if not HOST_APP.is_newer_than("2024") and not getattr(
+    adc, "_readonlylist_patched", False
+):
     adc._get_item = _patched_get_item
     adc._get_item_lockstatus = _patched_get_item_lockstatus
     adc._get_item_property_value = _patched_get_item_property_value
     adc._get_item_property_id_value = _patched_get_item_property_id_value
     adc._readonlylist_patched = True
-
 
 
 # =============================================================================
@@ -139,6 +142,7 @@ if not HOST_APP.is_newer_than("2024") \
 # Modeless WPF windows cannot start Revit transactions directly.
 # All write operations (transactions, PostCommand) are queued here and
 # executed on Revit's main thread via ExternalEvent.
+
 
 class RevitActionHandler(UI.IExternalEventHandler):
     """Queues callables and runs them inside Revit's valid API context."""
@@ -157,15 +161,14 @@ class RevitActionHandler(UI.IExternalEventHandler):
             try:
                 action()
             except Exception as ex:
-                logger.error('RevitActionHandler | %s' % ex)
+                logger.error("RevitActionHandler | %s" % ex)
                 try:
                     if window and window.IsLoaded:
                         window.Dispatcher.Invoke(
-                            System.Action(
-                                lambda e=str(ex): forms.alert(e)))
+                            System.Action(lambda e=str(ex): forms.alert(e))
+                        )
                 except Exception as disp_ex:
-                    logger.debug(
-                        'Failed to display error in window | %s' % disp_ex)
+                    logger.debug("Failed to display error in window | %s" % disp_ex)
             if callback:
                 try:
                     if window and window.IsLoaded:
@@ -173,7 +176,7 @@ class RevitActionHandler(UI.IExternalEventHandler):
                     else:
                         callback()
                 except Exception as cbex:
-                    logger.debug('Callback failed | %s' % cbex)
+                    logger.debug("Callback failed | %s" % cbex)
 
     def GetName(self):
         return "KeynoteManagerHandler"
@@ -191,17 +194,25 @@ _active_window = None
 # HELPERS
 # =============================================================================
 
+
 def get_keynote_pcommands():
-    return list(reversed(
-        [x for x in coreutils.get_enum_values(UI.PostableCommand)
-         if str(x).endswith('Keynote')]))
+    return list(
+        reversed(
+            [
+                x
+                for x in coreutils.get_enum_values(UI.PostableCommand)
+                if str(x).endswith("Keynote")
+            ]
+        )
+    )
 
 
 def _find_siblings(flat_keynotes, target_parent_key):
     """Return natsorted list of keynotes sharing the same parent_key."""
     return natsorted(
         [k for k in flat_keynotes if k.parent_key == target_parent_key],
-        key=lambda x: x.key)
+        key=lambda x: x.key,
+    )
 
 
 def _find_parent_of(all_categories, all_keynotes, child):
@@ -222,12 +233,14 @@ def _find_parent_of(all_categories, all_keynotes, child):
 # EDIT RECORD WINDOW (unchanged from pyRevit — works with EditRecord.xaml)
 # =============================================================================
 
+
 class EditRecordWindow(forms.WPFWindow):
     """Dialog for adding/editing a single keynote or category record."""
 
-    def __init__(self, owner, conn, mode,
-                 rkeynote=None, rkey=None, text=None, pkey=None):
-        forms.WPFWindow.__init__(self, 'EditRecord.xaml')
+    def __init__(
+        self, owner, conn, mode, rkeynote=None, rkey=None, text=None, pkey=None
+    ):
+        forms.WPFWindow.__init__(self, "EditRecord.xaml")
         self.Owner = owner
         self._res = None
         self._commited = False
@@ -290,7 +303,7 @@ class EditRecordWindow(forms.WPFWindow):
 
     @property
     def active_key(self):
-        if self.recordKey.Content and u'\u25CF' not in self.recordKey.Content:
+        if self.recordKey.Content and "\u25cf" not in self.recordKey.Content:
             return self.recordKey.Content
 
     @active_key.setter
@@ -316,55 +329,73 @@ class EditRecordWindow(forms.WPFWindow):
     def commit(self):
         if self._mode == kdb.EDIT_MODE_ADD_CATEG:
             if not self.active_key:
-                forms.alert("Please provide a unique key."); return False
+                forms.alert("Please provide a unique key.")
+                return False
             if not self.active_text.strip():
-                forms.alert("Please provide a title."); return False
+                forms.alert("Please provide a title.")
+                return False
             try:
                 self._res = kdb.add_category(
-                    self._conn, self.active_key, self.active_text)
+                    self._conn, self.active_key, self.active_text
+                )
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message); return False
+                forms.alert(toutex.Message)
+                return False
 
         elif self._mode == kdb.EDIT_MODE_EDIT_CATEG:
             if not self.active_text:
-                forms.alert("Title cannot be empty."); return False
+                forms.alert("Title cannot be empty.")
+                return False
             try:
                 if self.active_text != self._rkeynote.text:
                     kdb.update_category_title(
-                        self._conn, self.active_key, self.active_text)
+                        self._conn, self.active_key, self.active_text
+                    )
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message); return False
+                forms.alert(toutex.Message)
+                return False
 
         elif self._mode == kdb.EDIT_MODE_ADD_KEYNOTE:
             if not self.active_key:
-                forms.alert("Please provide a unique key."); return False
+                forms.alert("Please provide a unique key.")
+                return False
             if not self.active_text:
-                forms.alert("Please provide keynote text."); return False
+                forms.alert("Please provide keynote text.")
+                return False
             if not self.active_parent_key:
-                forms.alert("Please select a parent."); return False
+                forms.alert("Please select a parent.")
+                return False
             try:
                 self._res = kdb.add_keynote(
-                    self._conn, self.active_key,
-                    self.active_text, self.active_parent_key)
+                    self._conn,
+                    self.active_key,
+                    self.active_text,
+                    self.active_parent_key,
+                )
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message); return False
+                forms.alert(toutex.Message)
+                return False
 
         elif self._mode == kdb.EDIT_MODE_EDIT_KEYNOTE:
             if not self.active_text:
-                forms.alert("Keynote text cannot be empty."); return False
+                forms.alert("Keynote text cannot be empty.")
+                return False
             try:
                 if self.active_text != self._rkeynote.text:
                     kdb.update_keynote_text(
-                        self._conn, self.active_key, self.active_text)
+                        self._conn, self.active_key, self.active_text
+                    )
                 if self.active_parent_key != self._rkeynote.parent_key:
                     kdb.move_keynote(
-                        self._conn, self.active_key, self.active_parent_key)
+                        self._conn, self.active_key, self.active_parent_key
+                    )
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message); return False
+                forms.alert(toutex.Message)
+                return False
 
         return True
 
@@ -375,28 +406,32 @@ class EditRecordWindow(forms.WPFWindow):
     def pick_key(self, sender, args):
         if self._reserved_key:
             try:
-                kdb.release_key(self._conn, self._reserved_key,
-                                category=self._cat)
+                kdb.release_key(self._conn, self._reserved_key, category=self._cat)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message); return
+                forms.alert(toutex.Message)
+                return
         try:
             categories = kdb.get_categories(self._conn)
             keynotes = kdb.get_keynotes(self._conn)
             locks = kdb.get_locks(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return
+            forms.alert(toutex.Message)
+            return
         reserved_keys = [x.key for x in categories]
         reserved_keys.extend([x.key for x in keynotes])
         reserved_keys.extend([x.LockTargetRecordKey for x in locks])
         new_key = forms.ask_for_unique_string(
             prompt="Enter a unique key:",
             title=self.Title,
-            reserved_values=reserved_keys, owner=self)
+            reserved_values=reserved_keys,
+            owner=self,
+        )
         if new_key:
             try:
                 kdb.reserve_key(self._conn, new_key, category=self._cat)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message); return
+                forms.alert(toutex.Message)
+                return
             self._reserved_key = new_key
             self.active_key = new_key
 
@@ -408,13 +443,14 @@ class EditRecordWindow(forms.WPFWindow):
         if self.active_key in available:
             available.remove(self.active_key)
         new_parent = forms.SelectFromList.show(
-            natsorted(available), title='Select Parent', multiselect=False)
+            natsorted(available), title="Select Parent", multiselect=False
+        )
         if new_parent:
             try:
-                kdb.reserve_key(self._conn, self.active_key,
-                                category=self._cat)
+                kdb.reserve_key(self._conn, self.active_key, category=self._cat)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message); return
+                forms.alert(toutex.Message)
+                return
             self._reserved_key = self.active_key
             self.active_parent_key = new_parent
 
@@ -432,8 +468,8 @@ class EditRecordWindow(forms.WPFWindow):
 
     def select_template(self, sender, args):
         template = forms.SelectFromList.show(
-            ["RESERVED", "DO NOT USE"],
-            title="Select Template", owner=self)
+            ["RESERVED", "DO NOT USE"], title="Select Template", owner=self
+        )
         if template:
             self.active_text = template
 
@@ -452,8 +488,7 @@ class EditRecordWindow(forms.WPFWindow):
         if not self._commited:
             if self._reserved_key:
                 try:
-                    kdb.release_key(self._conn, self._reserved_key,
-                                    category=self._cat)
+                    kdb.release_key(self._conn, self._reserved_key, category=self._cat)
                 except Exception:
                     pass
             try:
@@ -465,6 +500,7 @@ class EditRecordWindow(forms.WPFWindow):
 # =============================================================================
 # MAIN KEYNOTE MANAGER WINDOW
 # =============================================================================
+
 
 class KeynoteManagerWindow(forms.WPFWindow):
     """Keynote manager with unified tree and hierarchy controls."""
@@ -479,7 +515,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             wih = WindowInteropHelper(self)
             wih.Owner = SysProcess.GetCurrentProcess().MainWindowHandle
         except Exception as ex:
-            logger.debug('WindowInteropHelper failed | %s' % ex)
+            logger.debug("WindowInteropHelper failed | %s" % ex)
 
         # Hook WndProc to intercept WM_MOUSEACTIVATE — prevents the
         # re-entrant activation crash when clicking between Revit and
@@ -490,7 +526,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         # or System.Action from inside a Win32 WndProc callback
         # (LookupGlobalInstruction crash in HwndSubclass.SubclassWndProc).
         self._INTPTR_ZERO = System.IntPtr.Zero
-        self._INTPTR_MA_NOACTIVATE = System.IntPtr(3)
+        self._INTPTR_MA_NOACTIVATE = System.IntPtr(self.MA_NOACTIVATE)
         self._BG_PRIORITY = Windows.Threading.DispatcherPriority.Background
         self.SourceInitialized += self._on_source_initialized
 
@@ -515,7 +551,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         self._close_pending = False
 
         self._search_timer = DispatcherTimer()
-        self._search_timer.Interval = TimeSpan.FromMilliseconds(300) # Wait 300ms after last keystroke
+        # Wait 300ms after last keystroke before filtering.
+        self._search_timer.Interval = TimeSpan.FromMilliseconds(300)
         self._search_timer.Tick += self._on_search_timer_tick
 
         self.load_config(reset_config)
@@ -553,8 +590,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     @property
     def postcmd_options(self):
-        return [self.userknote_rb, self.materialknote_rb,
-                self.elementknote_rb]
+        return [self.userknote_rb, self.materialknote_rb, self.elementknote_rb]
 
     @property
     def postcmd_idx(self):
@@ -580,14 +616,16 @@ class KeynoteManagerWindow(forms.WPFWindow):
         try:
             return kdb.get_categories(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return []
+            forms.alert(toutex.Message)
+            return []
 
     @property
     def all_keynotes(self):
         try:
             return kdb.get_keynotes(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return []
+            forms.alert(toutex.Message)
+            return []
 
     # =========================================================================
     # STATUS BAR
@@ -596,9 +634,10 @@ class KeynoteManagerWindow(forms.WPFWindow):
     def _update_status_bar(self):
         if self._kfile:
             fname = op.basename(self._kfile)
-            handler = ' ( ACC / FORMA )' if self._kfile_handler == 'adc' else ''
-            self.statusLeft.Text = u"{}{} \u2014 {}".format(
-                fname, handler, op.dirname(self._kfile))
+            handler = " ( ACC / FORMA )" if self._kfile_handler == "adc" else ""
+            self.statusLeft.Text = "{}{} \u2014 {}".format(
+                fname, handler, op.dirname(self._kfile)
+            )
         else:
             self.statusLeft.Text = "No keynote file loaded"
 
@@ -606,9 +645,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
             cats = self.all_categories if self._conn else []
             knotes = self.all_keynotes if self._conn else []
             used = len(self._used_keysdict)
-            self.statusRight.Text = \
-                u"{} groups \u00B7 {} keynotes \u00B7 {} in use".format(
-                    len(cats), len(knotes), used)
+            self.statusRight.Text = (
+                "{} groups \u00b7 {} keynotes \u00b7 {} in use".format(
+                    len(cats), len(knotes), used
+                )
+            )
         except Exception:
             self.statusRight.Text = ""
 
@@ -640,7 +681,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 self._activate_action = System.Action(self._safe_activate)
                 self._hwnd_source.AddHook(self._wnd_proc)
         except Exception as ex:
-            logger.debug('HwndSource hook failed | %s' % ex)
+            logger.debug("HwndSource hook failed | %s" % ex)
 
     def _wnd_proc(self, hwnd, msg, wParam, lParam, handled):
         """Win32 WndProc hook — intercept activation messages.
@@ -652,9 +693,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 handled.Value = True
                 if not self._activation_pending:
                     self._activation_pending = True
-                    self.Dispatcher.BeginInvoke(
-                        self._activate_action,
-                        self._BG_PRIORITY)
+                    try:
+                        self.Dispatcher.BeginInvoke(
+                            self._activate_action, self._BG_PRIORITY
+                        )
+                    except Exception:
+                        self._activation_pending = False
                 return self._INTPTR_MA_NOACTIVATE
         except Exception:
             pass  # WndProc must NEVER throw
@@ -667,7 +711,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             if self.IsLoaded and self.IsVisible:
                 self.Activate()
         except Exception as ex:
-            logger.debug('Deferred activation failed | %s' % ex)
+            logger.debug("Deferred activation failed | %s" % ex)
 
     # =========================================================================
     # TREE STATE PRESERVATION
@@ -712,13 +756,15 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def _set_scroll_offset(self, offset):
         """Restore the vertical scroll offset after a tree rebuild."""
+
         def _do_scroll():
             sv = self._get_scroll_viewer()
             if sv:
                 sv.ScrollToVerticalOffset(offset)
+
         self.Dispatcher.BeginInvoke(
-            System.Action(_do_scroll),
-            Windows.Threading.DispatcherPriority.Loaded)
+            System.Action(_do_scroll), Windows.Threading.DispatcherPriority.Loaded
+        )
 
     def _select_keynote_by_key(self, key):
         """Find and select the node with the given key in the new tree."""
@@ -730,16 +776,19 @@ class KeynoteManagerWindow(forms.WPFWindow):
             container = None
             parent_container = self.keynotes_tv
             for node in path:
-                if container and hasattr(container, 'IsExpanded'):
+                if container and hasattr(container, "IsExpanded"):
                     container.IsExpanded = True
                     container.UpdateLayout()
                 idx = None
                 items = parent_container.ItemContainerGenerator
-                src = parent_container.Items if hasattr(parent_container, 'Items') \
+                src = (
+                    parent_container.Items
+                    if hasattr(parent_container, "Items")
                     else parent_container.ItemsSource
+                )
                 if src:
                     for i, item in enumerate(src):
-                        if hasattr(item, 'key') and item.key == node.key:
+                        if hasattr(item, "key") and item.key == node.key:
                             idx = i
                             break
                 if idx is not None:
@@ -747,7 +796,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 else:
                     container = items.ContainerFromItem(node)
                 if container is None:
-                    if hasattr(parent_container, 'UpdateLayout'):
+                    if hasattr(parent_container, "UpdateLayout"):
                         parent_container.UpdateLayout()
                     if idx is not None:
                         container = items.ContainerFromIndex(idx)
@@ -757,13 +806,13 @@ class KeynoteManagerWindow(forms.WPFWindow):
                     return
                 parent_container = container
 
-            if container and hasattr(container, 'IsSelected'):
+            if container and hasattr(container, "IsSelected"):
                 container.IsSelected = True
                 container.BringIntoView()
 
         self.Dispatcher.BeginInvoke(
-            System.Action(_do_select),
-            Windows.Threading.DispatcherPriority.Loaded)
+            System.Action(_do_select), Windows.Threading.DispatcherPriority.Loaded
+        )
 
     def _find_node_path(self, roots, target_key):
         """Return the path [root, ..., target] from roots to the node
@@ -795,7 +844,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                     if key:
                         used[key].append(kn.Id)
         except Exception as ex:
-            logger.debug('get_used_keynotes failed | %s' % ex)
+            logger.debug("get_used_keynotes failed | %s" % ex)
         return used
 
     # =========================================================================
@@ -804,46 +853,43 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def save_config(self):
         wg = {}
-        for k, v in self._config.get_option('last_window_geom', {}).items():
+        for k, v in self._config.get_option("last_window_geom", {}).items():
             if op.exists(k):
                 wg[k] = v
         wg[self._kfile] = self.window_geom
-        self._config.set_option('last_window_geom', wg)
+        self._config.set_option("last_window_geom", wg)
 
         pc = {}
-        for k, v in self._config.get_option('last_postcmd_idx', {}).items():
+        for k, v in self._config.get_option("last_postcmd_idx", {}).items():
             if op.exists(k):
                 pc[k] = v
         pc[self._kfile] = self.postcmd_idx
-        self._config.set_option('last_postcmd_idx', pc)
+        self._config.set_option("last_postcmd_idx", pc)
 
         st = {}
         if self.search_term:
             st[self._kfile] = self.search_term
-        self._config.set_option('last_search_term', st)
+        self._config.set_option("last_search_term", st)
 
         script.save_config()
 
     def load_config(self, reset):
-        wg = {} if reset else self._config.get_option(
-            'last_window_geom', {})
+        wg = {} if reset else self._config.get_option("last_window_geom", {})
         if wg and self._kfile in wg:
             w, h, t, l = wg[self._kfile]
         else:
             w, h, t, l = (None, None, None, None)
-        if all([w, h, t, l]) \
-                and coreutils.is_box_visible_on_screens(l, t, w, h):
+        if all([w, h, t, l]) and coreutils.is_box_visible_on_screens(l, t, w, h):
             self.window_geom = (w, h, t, l)
         else:
-            self.WindowStartupLocation = \
+            self.WindowStartupLocation = (
                 framework.Windows.WindowStartupLocation.CenterScreen
+            )
 
-        pc = {} if reset else self._config.get_option(
-            'last_postcmd_idx', {})
+        pc = {} if reset else self._config.get_option("last_postcmd_idx", {})
         self.postcmd_idx = pc.get(self._kfile, 0)
 
-        st = {} if reset else self._config.get_option(
-            'last_search_term', {})
+        st = {} if reset else self._config.get_option("last_search_term", {})
         self.search_term = st.get(self._kfile, "")
 
     # =========================================================================
@@ -867,9 +913,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if self._kfile:
             return
 
-        self._kfile_ext = \
-            revit.query.get_external_keynote_file(doc=revit.doc)
-        self._kfile_handler = 'unknown'
+        self._kfile_ext = revit.query.get_external_keynote_file(doc=revit.doc)
+        self._kfile_handler = "unknown"
 
         if not self._kfile_ext:
             return
@@ -877,7 +922,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         # CRITICAL: call is_available() FIRST on a clean AppDomain.
         # No legacy DLL probing before this point.
         if adc.is_available():
-            self._kfile_handler = 'adc'
+            self._kfile_handler = "adc"
             self._resolve_adc_keynote()
             return
 
@@ -885,7 +930,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
             "{} is not available.\n\n"
             "Please ensure Desktop Connector is running "
             "in the system tray.".format(adc.ADC_NAME),
-            exitscript=True)
+            exitscript=True,
+        )
 
     def _resolve_adc_keynote(self):
         """Resolve cloud keynote path to local file via ADC."""
@@ -895,15 +941,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
             if not local_kfile:
                 forms.alert(
                     "Cannot resolve local path via {}.".format(adc.ADC_NAME),
-                    exitscript=True)
+                    exitscript=True,
+                )
                 return
 
             try:
                 locked, owner = adc.is_locked(self._kfile_ext)
                 if locked:
-                    forms.alert(
-                        "File locked by {}.".format(owner),
-                        exitscript=True)
+                    forms.alert("File locked by {}.".format(owner), exitscript=True)
                     return
             except Exception:
                 pass
@@ -915,15 +960,13 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 pass
 
             self._kfile = local_kfile
-            self.Title += ' ( ACC / FORMA )'
+            self.Title += " ( ACC / FORMA )"
 
         except Exception as adcex:
-            forms.alert(
-                "ADC communication failed.\n{}".format(adcex),
-                exitscript=True)
+            forms.alert("ADC communication failed.\n{}".format(adcex), exitscript=True)
 
     def _change_kfile(self):
-        kfile = forms.pick_file('txt')
+        kfile = forms.pick_file("txt")
         if kfile:
             try:
                 with revit.Transaction("Set Keynote File"):
@@ -946,11 +989,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         except System.TimeoutException as toutex:
             forms.alert(toutex.Message, exitscript=True)
         except Exception as ex:
-            logger.debug('Connection failed | %s' % ex)
+            logger.debug("Connection failed | %s" % ex)
             res = forms.alert(
                 "Cannot connect to keynote file.\n"
                 "It may need conversion to the new format.",
-                options=["Convert", "Select Other", "Help"])
+                options=["Convert", "Select Other", "Help"],
+            )
             if res == "Convert":
                 try:
                     self._convert_existing()
@@ -958,21 +1002,21 @@ class KeynoteManagerWindow(forms.WPFWindow):
                     if not self._conn:
                         forms.alert("Relaunch required.", exitscript=True)
                 except Exception as convex:
-                    forms.alert("Conversion failed: %s" % convex,
-                                exitscript=True)
+                    forms.alert("Conversion failed: %s" % convex, exitscript=True)
             elif res == "Select Other":
                 self._change_kfile()
                 self._determine_kfile()
             elif res == "Help":
                 script.open_url(
                     "https://www.notion.so/pyrevitlabs/"
-                    "Manage-Keynotes-6f083d6f66fe43d68dc5d5407c8e19da")
+                    "Manage-Keynotes-6f083d6f66fe43d68dc5d5407c8e19da"
+                )
                 script.exit()
             else:
                 forms.alert("No valid keynote file.", exitscript=True)
 
     def _convert_existing(self):
-        temp = script.get_data_file(op.basename(self._kfile), 'bak')
+        temp = script.get_data_file(op.basename(self._kfile), "bak")
         if op.exists(temp):
             script.remove_data_file(temp)
         try:
@@ -980,7 +1024,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         except Exception:
             raise Exception("Backup failed.")
         try:
-            with open(self._kfile, 'w'):
+            with open(self._kfile, "w"):
                 pass
         except Exception:
             raise Exception("File preparation failed.")
@@ -1008,8 +1052,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             forms.alert(toutex.Message)
             return []
         except Exception as ex:
-            forms.alert("Error loading keynotes:\n%s" % ex,
-                        exitscript=True)
+            forms.alert("Error loading keynotes:\n%s" % ex, exitscript=True)
             return []
 
         # Build parent -> children map from keynotes
@@ -1022,7 +1065,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         # Recursive child population
         def _populate(node):
             node_children = natsorted(
-                children_map.get(node.key, []), key=lambda x: x.key)
+                children_map.get(node.key, []), key=lambda x: x.key
+            )
             # Replace the children list (clear first to avoid dupes)
             while node.children:
                 node.children.pop()
@@ -1057,11 +1101,10 @@ class KeynoteManagerWindow(forms.WPFWindow):
         keynote_filter = self.search_term if self.search_term else None
 
         # Update view-only filter keys
-        if keynote_filter \
-                and kdb.RKeynoteFilters.ViewOnly.code in keynote_filter:
+        if keynote_filter and kdb.RKeynoteFilters.ViewOnly.code in keynote_filter:
             visible_keys = [
-                x.TagText for x in
-                revit.query.get_visible_keynotes(revit.active_view)]
+                x.TagText for x in revit.query.get_visible_keynotes(revit.active_view)
+            ]
             kdb.RKeynoteFilters.ViewOnly.set_keys(visible_keys)
 
         if fast_filter and keynote_filter:
@@ -1102,12 +1145,19 @@ class KeynoteManagerWindow(forms.WPFWindow):
         """Enable/disable toolbar buttons based on selection."""
         sel = self.selected_keynote
         if not sel or sel.locked:
-            for btn in [self.editKeynoteBtn, self.dupKeynoteBtn,
-                        self.rekeyBtn, self.removeBtn,
-                        self.findBtn, self.placeBtn,
-                        self.indentBtn, self.outdentBtn,
-                        self.moveUpBtn, self.moveDownBtn,
-                        self.caseBtn]:
+            for btn in [
+                self.editKeynoteBtn,
+                self.dupKeynoteBtn,
+                self.rekeyBtn,
+                self.removeBtn,
+                self.findBtn,
+                self.placeBtn,
+                self.indentBtn,
+                self.outdentBtn,
+                self.moveUpBtn,
+                self.moveDownBtn,
+                self.caseBtn,
+            ]:
                 btn.IsEnabled = False
             return
 
@@ -1130,11 +1180,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         can_down = False
 
         if is_kn:
-            siblings = _find_siblings(
-                self.all_keynotes, sel.parent_key)
-            idx = next(
-                (i for i, s in enumerate(siblings) if s.key == sel.key),
-                -1)
+            siblings = _find_siblings(self.all_keynotes, sel.parent_key)
+            idx = next((i for i, s in enumerate(siblings) if s.key == sel.key), -1)
             can_indent = idx > 0  # has a sibling above
             # Can outdent if parent is a keynote (not a category)
             cats = self.all_categories
@@ -1145,8 +1192,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             can_down = idx < len(siblings) - 1
         elif is_cat:
             cats = natsorted(self.all_categories, key=lambda x: x.key)
-            idx = next(
-                (i for i, c in enumerate(cats) if c.key == sel.key), -1)
+            idx = next((i for i, c in enumerate(cats) if c.key == sel.key), -1)
             can_up = idx > 0
             can_down = idx < len(cats) - 1
 
@@ -1167,8 +1213,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             return
 
         siblings = _find_siblings(self.all_keynotes, sel.parent_key)
-        idx = next(
-            (i for i, s in enumerate(siblings) if s.key == sel.key), -1)
+        idx = next((i for i, s in enumerate(siblings) if s.key == sel.key), -1)
         if idx <= 0:
             return
 
@@ -1177,9 +1222,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
             kdb.move_keynote(self._conn, sel.key, new_parent.key)
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return
+            forms.alert(toutex.Message)
+            return
         except Exception as ex:
-            forms.alert("Indent failed: %s" % ex); return
+            forms.alert("Indent failed: %s" % ex)
+            return
 
         self._update_full_tree()
         self._update_status_bar()
@@ -1202,13 +1249,13 @@ class KeynoteManagerWindow(forms.WPFWindow):
             forms.alert(
                 "Already at the top keynote level.\n"
                 "To make this a top-level group, use the Re-Key as "
-                "category workflow.")
+                "category workflow."
+            )
             return
 
         # Parent is a keynote — find grandparent
         all_kn = self.all_keynotes
-        parent = next(
-            (k for k in all_kn if k.key == current_parent_key), None)
+        parent = next((k for k in all_kn if k.key == current_parent_key), None)
         if not parent:
             return
 
@@ -1220,9 +1267,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
             kdb.move_keynote(self._conn, sel.key, grandparent_key)
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return
+            forms.alert(toutex.Message)
+            return
         except Exception as ex:
-            forms.alert("Outdent failed: %s" % ex); return
+            forms.alert("Outdent failed: %s" % ex)
+            return
 
         self._update_full_tree()
         self._update_status_bar()
@@ -1248,21 +1297,19 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
         is_cat = sel.is_category
         if is_cat:
-            siblings = natsorted(
-                self.all_categories, key=lambda x: x.key)
+            siblings = natsorted(self.all_categories, key=lambda x: x.key)
         else:
-            siblings = _find_siblings(
-                self.all_keynotes, sel.parent_key)
+            siblings = _find_siblings(self.all_keynotes, sel.parent_key)
 
-        idx = next(
-            (i for i, s in enumerate(siblings) if s.key == sel.key), -1)
+        idx = next((i for i, s in enumerate(siblings) if s.key == sel.key), -1)
         target_idx = idx + direction
         if target_idx < 0 or target_idx >= len(siblings):
             return
 
         other = siblings[target_idx]
         if other.locked:
-            forms.alert("Adjacent item is locked."); return
+            forms.alert("Adjacent item is locked.")
+            return
 
         # Swap keys
         sel_key = sel.key
@@ -1278,11 +1325,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 with kdb.BulkAction(self._conn):
                     for child in self.all_keynotes:
                         if child.parent_key == sel_key:
-                            kdb.move_keynote(
-                                self._conn, child.key, other_key)
+                            kdb.move_keynote(self._conn, child.key, other_key)
                         elif child.parent_key == other_key:
-                            kdb.move_keynote(
-                                self._conn, child.key, sel_key)
+                            kdb.move_keynote(self._conn, child.key, sel_key)
             else:
                 kdb.update_keynote_key(self._conn, sel_key, temp_key)
                 kdb.update_keynote_key(self._conn, other_key, sel_key)
@@ -1291,20 +1336,20 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 with kdb.BulkAction(self._conn):
                     for child in self.all_keynotes:
                         if child.parent_key == sel_key:
-                            kdb.move_keynote(
-                                self._conn, child.key, other_key)
+                            kdb.move_keynote(self._conn, child.key, other_key)
                         elif child.parent_key == other_key:
-                            kdb.move_keynote(
-                                self._conn, child.key, sel_key)
+                            kdb.move_keynote(self._conn, child.key, sel_key)
 
             # Update references in Revit model (async via ExternalEvent)
             sk, ok = sel_key, other_key
             self._revit_run(lambda: self._swap_keynote_refs(sk, ok))
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return
+            forms.alert(toutex.Message)
+            return
         except Exception as ex:
-            forms.alert("Swap failed: %s" % ex); return
+            forms.alert("Swap failed: %s" % ex)
+            return
 
         self._update_full_tree()
         self._update_status_bar()
@@ -1342,25 +1387,29 @@ class KeynoteManagerWindow(forms.WPFWindow):
             kns = kdb.get_keynotes(self._conn)
             locks = kdb.get_locks(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return
+            forms.alert(toutex.Message)
+            return
         reserved = [x.key for x in cats]
         reserved.extend([x.key for x in kns])
         reserved.extend([x.LockTargetRecordKey for x in locks])
         return forms.ask_for_unique_string(
             prompt="Enter a unique key:",
             title="Choose Unique Key",
-            reserved_values=reserved, owner=self)
+            reserved_values=reserved,
+            owner=self,
+        )
 
     def _pick_parent(self):
         """Pick any node (category or keynote) as a parent."""
         cats = self.all_categories
         kns = self.all_keynotes
         items = natsorted(
-            ["{} — {}".format(x.key, x.text) for x in cats] +
-            ["{} — {}".format(x.key, x.text) for x in kns],
+            ["{} — {}".format(x.key, x.text) for x in cats]
+            + ["{} — {}".format(x.key, x.text) for x in kns],
         )
         chosen = forms.SelectFromList.show(
-            items, title="Select Parent", multiselect=False, owner=self)
+            items, title="Select Parent", multiselect=False, owner=self
+        )
         if chosen:
             return chosen.split(" — ")[0].strip()
         return None
@@ -1370,14 +1419,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
     # =========================================================================
 
     def search_txt_changed(self, sender, args):
-        if self.search_tb.Text == '':
+        if self.search_tb.Text == "":
             self.clrsearch_b.Visibility = Windows.Visibility.Collapsed
         else:
             self.clrsearch_b.Visibility = Windows.Visibility.Visible
-            
-        # Stop and restart the timer on every keystroke. 
+
+        # Stop and restart the timer on every keystroke.
         # The filter won't run until the typing pauses for 300ms.
-        if hasattr(self, '_search_timer'):
+        if hasattr(self, "_search_timer"):
             self._search_timer.Stop()
             self._search_timer.Start()
 
@@ -1387,7 +1436,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         self._update_full_tree(fast_filter=True)
 
     def clear_search(self, sender, args):
-        self.search_tb.Text = '' # Removed the space to ensure clean empty string
+        self.search_tb.Text = ""
         self.search_tb.Clear()
         self.search_tb.Focus()
         self._update_full_tree(fast_filter=True)
@@ -1395,7 +1444,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
     def custom_filter(self, sender, args):
         sfilter = forms.SelectFromList.show(
             kdb.RKeynoteFilters.get_available_filters(),
-            title="Select Filter", owner=self)
+            title="Select Filter",
+            owner=self,
+        )
         if sfilter:
             self.search_term = sfilter.format_term(self.search_term)
 
@@ -1417,28 +1468,40 @@ class KeynoteManagerWindow(forms.WPFWindow):
         shift = Windows.Input.ModifierKeys.Shift
 
         if key == Windows.Input.Key.F5:
-            self.refresh(sender, args); args.Handled = True
+            self.refresh(sender, args)
+            args.Handled = True
         elif key == Windows.Input.Key.F2:
             if self.selected_keynote:
-                self.edit_keynote(sender, args); args.Handled = True
+                self.edit_keynote(sender, args)
+                args.Handled = True
         elif key == Windows.Input.Key.Delete:
             if self.selected_keynote:
-                self.remove_keynote(sender, args); args.Handled = True
+                self.remove_keynote(sender, args)
+                args.Handled = True
         elif key == Windows.Input.Key.N and mods == ctrl:
-            self.add_keynote(sender, args); args.Handled = True
+            self.add_keynote(sender, args)
+            args.Handled = True
         elif key == Windows.Input.Key.D and mods == ctrl:
             if self.selected_keynote:
-                self.duplicate_keynote(sender, args); args.Handled = True
+                self.duplicate_keynote(sender, args)
+                args.Handled = True
         elif key == Windows.Input.Key.I and mods == ctrl:
-            self.import_keynotes(sender, args); args.Handled = True
+            self.import_keynotes(sender, args)
+            args.Handled = True
         elif key == Windows.Input.Key.Tab and mods == shift:
-            self.outdent_keynote(sender, args); args.Handled = True
-        elif key == Windows.Input.Key.Tab and mods == getattr(Windows.Input.ModifierKeys, "None"):
-            self.indent_keynote(sender, args); args.Handled = True
+            self.outdent_keynote(sender, args)
+            args.Handled = True
+        elif key == Windows.Input.Key.Tab and mods == getattr(
+            Windows.Input.ModifierKeys, "None"
+        ):
+            self.indent_keynote(sender, args)
+            args.Handled = True
         elif key == Windows.Input.Key.Up and mods == ctrl:
-            self.move_up(sender, args); args.Handled = True
+            self.move_up(sender, args)
+            args.Handled = True
         elif key == Windows.Input.Key.Down and mods == ctrl:
-            self.move_down(sender, args); args.Handled = True
+            self.move_down(sender, args)
+            args.Handled = True
         elif key == Windows.Input.Key.Escape:
             if self.search_term:
                 self.clear_search(sender, args)
@@ -1457,22 +1520,25 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if self._drag_start_point is None:
             return
         if args.LeftButton != Windows.Input.MouseButtonState.Pressed:
-            self._drag_start_point = None; return
+            self._drag_start_point = None
+            return
 
         pt = args.GetPosition(sender)
         diff = self._drag_start_point - pt
-        if abs(diff.X) > System.Windows.SystemParameters.MinimumHorizontalDragDistance \
-                or abs(diff.Y) > System.Windows.SystemParameters.MinimumVerticalDragDistance:
+        if (
+            abs(diff.X) > System.Windows.SystemParameters.MinimumHorizontalDragDistance
+            or abs(diff.Y) > System.Windows.SystemParameters.MinimumVerticalDragDistance
+        ):
             sel = self.selected_keynote
             if sel and not sel.locked:
                 self._is_dragging = True
                 try:
                     data = Windows.DataObject("keynote", sel)
                     Windows.DragDrop.DoDragDrop(
-                        self.keynotes_tv, data,
-                        Windows.DragDropEffects.Move)
+                        self.keynotes_tv, data, Windows.DragDropEffects.Move
+                    )
                 except Exception as ex:
-                    logger.debug('Drag failed | %s' % ex)
+                    logger.debug("Drag failed | %s" % ex)
                 finally:
                     self._is_dragging = False
                     self._drag_start_point = None
@@ -1494,14 +1560,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if args.Data.GetDataPresent("keynote"):
             args.Effects = Windows.DragDropEffects.Move
             # Visual feedback
-            if hasattr(sender, 'Background'):
-                sender.Background = \
-                    Windows.Media.SolidColorBrush(
-                        Windows.Media.Color.FromArgb(40, 43, 87, 154))
+            if hasattr(sender, "Background"):
+                sender.Background = Windows.Media.SolidColorBrush(
+                    Windows.Media.Color.FromArgb(40, 43, 87, 154)
+                )
             args.Handled = True
 
     def tree_item_drag_leave(self, sender, args):
-        if hasattr(sender, 'Background'):
+        if hasattr(sender, "Background"):
             sender.Background = None
 
     def tree_drop(self, sender, args):
@@ -1509,7 +1575,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def tree_item_drop(self, sender, args):
         """Drop handler — reparent the dragged node under the target."""
-        if hasattr(sender, 'Background'):
+        if hasattr(sender, "Background"):
             sender.Background = None
 
         if not args.Data.GetDataPresent("keynote"):
@@ -1518,7 +1584,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if not dragged:
             return
 
-        target = getattr(sender, 'DataContext', None)
+        target = getattr(sender, "DataContext", None)
         if target is None or target == dragged:
             return
 
@@ -1547,7 +1613,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
             return False
 
         if dragged.parent_key and _is_descendant(
-                new_parent_key, dragged.key, self.all_keynotes):
+            new_parent_key, dragged.key, self.all_keynotes
+        ):
             forms.alert("Cannot drop a parent onto its own descendant.")
             return
 
@@ -1555,7 +1622,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if dragged.is_category:
             forms.alert(
                 "Drag top-level groups is not supported.\n"
-                "Use Move Up / Move Down to reorder groups.")
+                "Use Move Up / Move Down to reorder groups."
+            )
             return
 
         if new_parent_key == dragged.parent_key:
@@ -1579,12 +1647,15 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def refresh(self, sender, args):
         if self._conn:
+
             def _query_used():
                 self._used_keysdict = self.get_used_keynote_elements()
+
             def _on_done():
                 self._update_full_tree()
                 self._update_status_bar()
                 self.search_tb.Focus()
+
             self._revit_run(_query_used, callback=_on_done)
         else:
             self.search_tb.Focus()
@@ -1595,8 +1666,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def add_category(self, sender, args):
         try:
-            new_cat = EditRecordWindow(
-                self, self._conn, kdb.EDIT_MODE_ADD_CATEG).show()
+            new_cat = EditRecordWindow(self, self._conn, kdb.EDIT_MODE_ADD_CATEG).show()
             if new_cat:
                 self._needs_update = True
         except Exception as ex:
@@ -1611,9 +1681,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if sel and sel.is_category and not sel.locked:
             try:
                 EditRecordWindow(
-                    self, self._conn,
-                    kdb.EDIT_MODE_EDIT_CATEG,
-                    rkeynote=sel).show()
+                    self, self._conn, kdb.EDIT_MODE_EDIT_CATEG, rkeynote=sel
+                ).show()
                 self._needs_update = True
             except Exception as ex:
                 forms.alert(str(ex))
@@ -1635,9 +1704,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if parent_key:
             try:
                 EditRecordWindow(
-                    self, self._conn,
-                    kdb.EDIT_MODE_ADD_KEYNOTE,
-                    pkey=parent_key).show()
+                    self, self._conn, kdb.EDIT_MODE_ADD_KEYNOTE, pkey=parent_key
+                ).show()
                 self._needs_update = True
             except Exception as ex:
                 forms.alert(str(ex))
@@ -1650,9 +1718,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if sel and sel.parent_key:
             try:
                 EditRecordWindow(
-                    self, self._conn,
+                    self,
+                    self._conn,
                     kdb.EDIT_MODE_ADD_KEYNOTE,
-                    text=sel.text, pkey=sel.parent_key).show()
+                    text=sel.text,
+                    pkey=sel.parent_key,
+                ).show()
                 self._needs_update = True
             except Exception as ex:
                 forms.alert(str(ex))
@@ -1669,9 +1740,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
             return
         try:
             EditRecordWindow(
-                self, self._conn,
-                kdb.EDIT_MODE_EDIT_KEYNOTE,
-                rkeynote=sel).show()
+                self, self._conn, kdb.EDIT_MODE_EDIT_KEYNOTE, rkeynote=sel
+            ).show()
             self._needs_update = True
         except Exception as ex:
             forms.alert(str(ex))
@@ -1686,15 +1756,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if sel.is_category:
             # Removing a category
             if sel.has_children():
-                forms.alert(
-                    "Group '%s' has children. Remove them first."
-                    % sel.key)
+                forms.alert("Group '%s' has children. Remove them first." % sel.key)
                 return
             if sel.used:
                 forms.alert("Group '%s' is in use." % sel.key)
                 return
-            if forms.alert("Delete group '%s'?" % sel.key,
-                           yes=True, no=True):
+            if forms.alert("Delete group '%s'?" % sel.key, yes=True, no=True):
                 try:
                     kdb.remove_category(self._conn, sel.key)
                     self._needs_update = True
@@ -1703,15 +1770,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         else:
             # Removing a keynote
             if sel.children:
-                forms.alert(
-                    "Keynote '%s' has children. Remove them first."
-                    % sel.key)
+                forms.alert("Keynote '%s' has children. Remove them first." % sel.key)
                 return
             if sel.used:
                 forms.alert("Keynote '%s' is in use." % sel.key)
                 return
-            if forms.alert("Delete keynote '%s'?" % sel.key,
-                           yes=True, no=True):
+            if forms.alert("Delete keynote '%s'?" % sel.key, yes=True, no=True):
                 try:
                     kdb.remove_keynote(self._conn, sel.key)
                     self._needs_update = True
@@ -1733,21 +1797,17 @@ class KeynoteManagerWindow(forms.WPFWindow):
             to_key = self._pick_new_key()
             if to_key and to_key != from_key:
                 if sel.is_category:
-                    kdb.update_category_key(
-                        self._conn, from_key, to_key)
+                    kdb.update_category_key(self._conn, from_key, to_key)
                     with kdb.BulkAction(self._conn):
                         for child in self.all_keynotes:
                             if child.parent_key == from_key:
-                                kdb.move_keynote(
-                                    self._conn, child.key, to_key)
+                                kdb.move_keynote(self._conn, child.key, to_key)
                 else:
-                    kdb.update_keynote_key(
-                        self._conn, from_key, to_key)
+                    kdb.update_keynote_key(self._conn, from_key, to_key)
                     with kdb.BulkAction(self._conn):
                         for child in self.all_keynotes:
                             if child.parent_key == from_key:
-                                kdb.move_keynote(
-                                    self._conn, child.key, to_key)
+                                kdb.move_keynote(self._conn, child.key, to_key)
                 # Update Revit element refs (async via ExternalEvent)
                 fk, tk = from_key, to_key
                 self._revit_run(lambda: self._rekey_refs(fk, tk))
@@ -1791,9 +1851,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 kdb.update_keynote_text(self._conn, sel.key, new_text)
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message); return
+            forms.alert(toutex.Message)
+            return
         except Exception as ex:
-            forms.alert("Case change failed: %s" % ex); return
+            forms.alert("Case change failed: %s" % ex)
+            return
         self._update_full_tree()
 
     def to_upper(self, sender, args):
@@ -1821,11 +1883,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         used_snapshot = dict(self._used_keysdict)
         kids = used_snapshot.get(key, [])
         if not kids:
-            self.statusLeft.Text = u"Keynote '{}' — not placed in model".format(key)
+            self.statusLeft.Text = "Keynote '{}' — not placed in model".format(key)
             return
+
         def _do():
             for kid in kids:
-                source = viewname = ''
+                source = viewname = ""
                 kel = revit.doc.GetElement(kid)
                 if kel is None:
                     continue
@@ -1837,14 +1900,17 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 if vel:
                     viewname = revit.query.get_name(vel)
                 report = "Keynote: {} | Source: {} | View: {}".format(
-                    output.linkify(kid), source, viewname)
+                    output.linkify(kid), source, viewname
+                )
                 if ehist:
                     report += " | Last edit: %s" % ehist.last_changed_by
                 print(report)
+
         def _update_status():
-            self.statusLeft.Text = \
-                u"Keynote '{}' — {} placements shown in output".format(
-                    key, len(kids))
+            self.statusLeft.Text = (
+                "Keynote '{}' — {} placements shown in output".format(key, len(kids))
+            )
+
         self._revit_run(_do, callback=_update_status)
 
     def place_keynote(self, sender, args):
@@ -1854,18 +1920,21 @@ class KeynoteManagerWindow(forms.WPFWindow):
         sel_key = sel.key
         postcmd = self.postable_keynote_command
         self.Close()
+
         def _do():
-            keynotes_cat = \
-                revit.query.get_category(DB.BuiltInCategory.OST_KeynoteTags)
+            keynotes_cat = revit.query.get_category(DB.BuiltInCategory.OST_KeynoteTags)
             if keynotes_cat:
                 def_id = revit.doc.GetDefaultFamilyTypeId(keynotes_cat.Id)
                 if revit.doc.GetElement(def_id):
-                    DocumentEventUtils \
-                        .PostCommandAndUpdateNewElementProperties(
-                            HOST_APP.uiapp, revit.doc,
-                            postcmd,
-                            "Update Keynotes",
-                            DB.BuiltInParameter.KEY_VALUE, sel_key)
+                    DocumentEventUtils.PostCommandAndUpdateNewElementProperties(
+                        HOST_APP.uiapp,
+                        revit.doc,
+                        postcmd,
+                        "Update Keynotes",
+                        DB.BuiltInParameter.KEY_VALUE,
+                        sel_key,
+                    )
+
         self._revit_run(_do)
 
     # =========================================================================
@@ -1873,12 +1942,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
     # =========================================================================
 
     def change_keynote_file(self, sender, args):
-        kfile = forms.pick_file('txt')
+        kfile = forms.pick_file("txt")
         if not kfile:
             return
+
         def _set_file():
             with revit.Transaction("Set Keynote File"):
                 revit.update.set_keynote_file(kfile, doc=revit.doc)
+
         def _reload():
             self._determine_kfile()
             self._connect_kfile()
@@ -1886,22 +1957,21 @@ class KeynoteManagerWindow(forms.WPFWindow):
             try:
                 self._used_keysdict = self.get_used_keynote_elements()
             except Exception as ex:
-                logger.debug('Refresh used keys failed | %s' % ex)
+                logger.debug("Refresh used keys failed | %s" % ex)
             self._update_full_tree()
             self._update_status_bar()
+
         self._revit_run(_set_file, callback=_reload)
 
     def show_keynote_file(self, sender, args):
         coreutils.show_entry_in_explorer(self._kfile)
 
     def import_keynotes(self, sender, args):
-        kfile = forms.pick_file('txt')
+        kfile = forms.pick_file("txt")
         if kfile:
-            res = forms.alert("Skip duplicate entries?",
-                              yes=True, no=True)
+            res = forms.alert("Skip duplicate entries?", yes=True, no=True)
             try:
-                kdb.import_legacy_keynotes(
-                    self._conn, kfile, skip_dup=res)
+                kdb.import_legacy_keynotes(self._conn, kfile, skip_dup=res)
             except Exception as ex:
                 forms.alert("Import failed: %s" % ex)
             finally:
@@ -1909,7 +1979,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 self._update_status_bar()
 
     def export_keynotes(self, sender, args):
-        kfile = forms.save_file('txt')
+        kfile = forms.save_file("txt")
         if kfile:
             try:
                 kdb.export_legacy_keynotes(self._conn, kfile)
@@ -1917,14 +1987,13 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 forms.alert(str(ex))
 
     def export_visible_keynotes(self, sender, args):
-        kfile = forms.save_file('txt')
+        kfile = forms.save_file("txt")
         if kfile:
             include = set()
-            for rk in (self.current_keynotes or []):
+            for rk in self.current_keynotes or []:
                 include.update(rk.collect_keys())
             try:
-                kdb.export_legacy_keynotes(
-                    self._conn, kfile, include_keys=include)
+                kdb.export_legacy_keynotes(self._conn, kfile, include_keys=include)
             except Exception as ex:
                 forms.alert(str(ex))
 
@@ -1935,10 +2004,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
     def update_model(self, sender, args):
         """Queue keynote update transaction and keep window open."""
         if self._needs_update:
+
             def _do_update():
                 with revit.Transaction("Update Keynotes"):
                     revit.update.update_linked_keynotes(doc=revit.doc)
-            
+
             def _on_update_complete():
                 self._needs_update = False
                 forms.alert("Revit model updated successfully.", title="Success")
@@ -1961,12 +2031,16 @@ class KeynoteManagerWindow(forms.WPFWindow):
             res = forms.alert(
                 "Keynote file has been modified.\n"
                 "Sync changes to the Revit model before closing?",
-                yes=True, no=True)
+                yes=True,
+                no=True,
+            )
             if res:
                 args.Cancel = True
+
                 def _do_update():
                     with revit.Transaction("Update Keynotes"):
                         revit.update.update_linked_keynotes(doc=revit.doc)
+
                 self._close_pending = True
                 self._revit_run(_do_update, callback=self._finalize_close)
                 return
@@ -1980,7 +2054,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 pass
             self._hwnd_source = None
 
-        if self._kfile_handler == 'adc':
+        if self._kfile_handler == "adc":
             try:
                 adc.unlock_file(self._kfile_ext)
             except Exception:
@@ -1988,7 +2062,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         try:
             self.save_config()
         except Exception as ex:
-            logger.debug('Save config failed | %s' % ex)
+            logger.debug("Save config failed | %s" % ex)
         if self._conn:
             try:
                 self._conn.Dispose()
@@ -2008,8 +2082,8 @@ try:
         _active_window.WindowState = framework.Windows.WindowState.Normal
     else:
         _active_window = KeynoteManagerWindow(
-            xaml_file_name='KeynoteManagerWindow.xaml',
-            reset_config=__shiftclick__  #pylint: disable=undefined-variable
+            xaml_file_name="KeynoteManagerWindow.xaml",
+            reset_config=__shiftclick__,  # pylint: disable=undefined-variable
         )
         _active_window.show(modal=False)
 except Exception as kmex:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
@@ -12,9 +12,8 @@ Features:
 Shift+Click:
 Reset window configurations and open.
 """
-
-# pylint: disable=E0401,W0613,C0111,C0103,C0302,W0703
-# pylint: disable=raise-missing-from
+#pylint: disable=E0401,W0613,C0111,C0103,C0302,W0703
+#pylint: disable=raise-missing-from
 import os
 import os.path as op
 import shutil
@@ -56,7 +55,6 @@ output = script.get_output()
 # .NET Framework 4.x (Revit 2023/2024) because IronPython can't subscript
 # ReadOnlyList[T] with [].  The fix: iterate or use .Item[0] / LINQ First().
 
-
 def _safe_first(collection):
     """Safely get first element from a .NET collection that may not
     support Python [] subscripting (ReadOnlyList, IList, etc.)."""
@@ -84,7 +82,6 @@ def _safe_first(collection):
 def _patched_get_item(adc_svc, path):
     """Patched version of adc._get_item that handles ReadOnlyList."""
     import os.path as _op
-
     path = adc._ensure_local_path(adc_svc, path)
     if not _op.isfile(path):
         raise Exception("Path does not point to a file")
@@ -126,14 +123,14 @@ def _patched_get_item_property_id_value(adc_svc, drive, item, prop_id):
 
 
 # Apply patches (only on .NET Framework, only once per engine session)
-if not HOST_APP.is_newer_than("2024") and not getattr(
-    adc, "_readonlylist_patched", False
-):
+if not HOST_APP.is_newer_than("2024") \
+        and not getattr(adc, '_readonlylist_patched', False):
     adc._get_item = _patched_get_item
     adc._get_item_lockstatus = _patched_get_item_lockstatus
     adc._get_item_property_value = _patched_get_item_property_value
     adc._get_item_property_id_value = _patched_get_item_property_id_value
     adc._readonlylist_patched = True
+
 
 
 # =============================================================================
@@ -142,7 +139,6 @@ if not HOST_APP.is_newer_than("2024") and not getattr(
 # Modeless WPF windows cannot start Revit transactions directly.
 # All write operations (transactions, PostCommand) are queued here and
 # executed on Revit's main thread via ExternalEvent.
-
 
 class RevitActionHandler(UI.IExternalEventHandler):
     """Queues callables and runs them inside Revit's valid API context."""
@@ -161,14 +157,15 @@ class RevitActionHandler(UI.IExternalEventHandler):
             try:
                 action()
             except Exception as ex:
-                logger.error("RevitActionHandler | %s" % ex)
+                logger.error('RevitActionHandler | %s' % ex)
                 try:
                     if window and window.IsLoaded:
                         window.Dispatcher.Invoke(
-                            System.Action(lambda e=str(ex): forms.alert(e))
-                        )
+                            System.Action(
+                                lambda e=str(ex): forms.alert(e)))
                 except Exception as disp_ex:
-                    logger.debug("Failed to display error in window | %s" % disp_ex)
+                    logger.debug(
+                        'Failed to display error in window | %s' % disp_ex)
             if callback:
                 try:
                     if window and window.IsLoaded:
@@ -176,7 +173,7 @@ class RevitActionHandler(UI.IExternalEventHandler):
                     else:
                         callback()
                 except Exception as cbex:
-                    logger.debug("Callback failed | %s" % cbex)
+                    logger.debug('Callback failed | %s' % cbex)
 
     def GetName(self):
         return "KeynoteManagerHandler"
@@ -194,25 +191,17 @@ _active_window = None
 # HELPERS
 # =============================================================================
 
-
 def get_keynote_pcommands():
-    return list(
-        reversed(
-            [
-                x
-                for x in coreutils.get_enum_values(UI.PostableCommand)
-                if str(x).endswith("Keynote")
-            ]
-        )
-    )
+    return list(reversed(
+        [x for x in coreutils.get_enum_values(UI.PostableCommand)
+         if str(x).endswith('Keynote')]))
 
 
 def _find_siblings(flat_keynotes, target_parent_key):
     """Return natsorted list of keynotes sharing the same parent_key."""
     return natsorted(
         [k for k in flat_keynotes if k.parent_key == target_parent_key],
-        key=lambda x: x.key,
-    )
+        key=lambda x: x.key)
 
 
 def _find_parent_of(all_categories, all_keynotes, child):
@@ -233,14 +222,12 @@ def _find_parent_of(all_categories, all_keynotes, child):
 # EDIT RECORD WINDOW (unchanged from pyRevit — works with EditRecord.xaml)
 # =============================================================================
 
-
 class EditRecordWindow(forms.WPFWindow):
     """Dialog for adding/editing a single keynote or category record."""
 
-    def __init__(
-        self, owner, conn, mode, rkeynote=None, rkey=None, text=None, pkey=None
-    ):
-        forms.WPFWindow.__init__(self, "EditRecord.xaml")
+    def __init__(self, owner, conn, mode,
+                 rkeynote=None, rkey=None, text=None, pkey=None):
+        forms.WPFWindow.__init__(self, 'EditRecord.xaml')
         self.Owner = owner
         self._res = None
         self._commited = False
@@ -303,7 +290,7 @@ class EditRecordWindow(forms.WPFWindow):
 
     @property
     def active_key(self):
-        if self.recordKey.Content and "\u25cf" not in self.recordKey.Content:
+        if self.recordKey.Content and u'\u25CF' not in self.recordKey.Content:
             return self.recordKey.Content
 
     @active_key.setter
@@ -329,73 +316,55 @@ class EditRecordWindow(forms.WPFWindow):
     def commit(self):
         if self._mode == kdb.EDIT_MODE_ADD_CATEG:
             if not self.active_key:
-                forms.alert("Please provide a unique key.")
-                return False
+                forms.alert("Please provide a unique key."); return False
             if not self.active_text.strip():
-                forms.alert("Please provide a title.")
-                return False
+                forms.alert("Please provide a title."); return False
             try:
                 self._res = kdb.add_category(
-                    self._conn, self.active_key, self.active_text
-                )
+                    self._conn, self.active_key, self.active_text)
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message)
-                return False
+                forms.alert(toutex.Message); return False
 
         elif self._mode == kdb.EDIT_MODE_EDIT_CATEG:
             if not self.active_text:
-                forms.alert("Title cannot be empty.")
-                return False
+                forms.alert("Title cannot be empty."); return False
             try:
                 if self.active_text != self._rkeynote.text:
                     kdb.update_category_title(
-                        self._conn, self.active_key, self.active_text
-                    )
+                        self._conn, self.active_key, self.active_text)
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message)
-                return False
+                forms.alert(toutex.Message); return False
 
         elif self._mode == kdb.EDIT_MODE_ADD_KEYNOTE:
             if not self.active_key:
-                forms.alert("Please provide a unique key.")
-                return False
+                forms.alert("Please provide a unique key."); return False
             if not self.active_text:
-                forms.alert("Please provide keynote text.")
-                return False
+                forms.alert("Please provide keynote text."); return False
             if not self.active_parent_key:
-                forms.alert("Please select a parent.")
-                return False
+                forms.alert("Please select a parent."); return False
             try:
                 self._res = kdb.add_keynote(
-                    self._conn,
-                    self.active_key,
-                    self.active_text,
-                    self.active_parent_key,
-                )
+                    self._conn, self.active_key,
+                    self.active_text, self.active_parent_key)
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message)
-                return False
+                forms.alert(toutex.Message); return False
 
         elif self._mode == kdb.EDIT_MODE_EDIT_KEYNOTE:
             if not self.active_text:
-                forms.alert("Keynote text cannot be empty.")
-                return False
+                forms.alert("Keynote text cannot be empty."); return False
             try:
                 if self.active_text != self._rkeynote.text:
                     kdb.update_keynote_text(
-                        self._conn, self.active_key, self.active_text
-                    )
+                        self._conn, self.active_key, self.active_text)
                 if self.active_parent_key != self._rkeynote.parent_key:
                     kdb.move_keynote(
-                        self._conn, self.active_key, self.active_parent_key
-                    )
+                        self._conn, self.active_key, self.active_parent_key)
                 kdb.end_edit(self._conn)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message)
-                return False
+                forms.alert(toutex.Message); return False
 
         return True
 
@@ -406,32 +375,28 @@ class EditRecordWindow(forms.WPFWindow):
     def pick_key(self, sender, args):
         if self._reserved_key:
             try:
-                kdb.release_key(self._conn, self._reserved_key, category=self._cat)
+                kdb.release_key(self._conn, self._reserved_key,
+                                category=self._cat)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message)
-                return
+                forms.alert(toutex.Message); return
         try:
             categories = kdb.get_categories(self._conn)
             keynotes = kdb.get_keynotes(self._conn)
             locks = kdb.get_locks(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return
+            forms.alert(toutex.Message); return
         reserved_keys = [x.key for x in categories]
         reserved_keys.extend([x.key for x in keynotes])
         reserved_keys.extend([x.LockTargetRecordKey for x in locks])
         new_key = forms.ask_for_unique_string(
             prompt="Enter a unique key:",
             title=self.Title,
-            reserved_values=reserved_keys,
-            owner=self,
-        )
+            reserved_values=reserved_keys, owner=self)
         if new_key:
             try:
                 kdb.reserve_key(self._conn, new_key, category=self._cat)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message)
-                return
+                forms.alert(toutex.Message); return
             self._reserved_key = new_key
             self.active_key = new_key
 
@@ -443,14 +408,13 @@ class EditRecordWindow(forms.WPFWindow):
         if self.active_key in available:
             available.remove(self.active_key)
         new_parent = forms.SelectFromList.show(
-            natsorted(available), title="Select Parent", multiselect=False
-        )
+            natsorted(available), title='Select Parent', multiselect=False)
         if new_parent:
             try:
-                kdb.reserve_key(self._conn, self.active_key, category=self._cat)
+                kdb.reserve_key(self._conn, self.active_key,
+                                category=self._cat)
             except System.TimeoutException as toutex:
-                forms.alert(toutex.Message)
-                return
+                forms.alert(toutex.Message); return
             self._reserved_key = self.active_key
             self.active_parent_key = new_parent
 
@@ -468,8 +432,8 @@ class EditRecordWindow(forms.WPFWindow):
 
     def select_template(self, sender, args):
         template = forms.SelectFromList.show(
-            ["RESERVED", "DO NOT USE"], title="Select Template", owner=self
-        )
+            ["RESERVED", "DO NOT USE"],
+            title="Select Template", owner=self)
         if template:
             self.active_text = template
 
@@ -488,7 +452,8 @@ class EditRecordWindow(forms.WPFWindow):
         if not self._commited:
             if self._reserved_key:
                 try:
-                    kdb.release_key(self._conn, self._reserved_key, category=self._cat)
+                    kdb.release_key(self._conn, self._reserved_key,
+                                    category=self._cat)
                 except Exception:
                     pass
             try:
@@ -500,7 +465,6 @@ class EditRecordWindow(forms.WPFWindow):
 # =============================================================================
 # MAIN KEYNOTE MANAGER WINDOW
 # =============================================================================
-
 
 class KeynoteManagerWindow(forms.WPFWindow):
     """Keynote manager with unified tree and hierarchy controls."""
@@ -515,13 +479,19 @@ class KeynoteManagerWindow(forms.WPFWindow):
             wih = WindowInteropHelper(self)
             wih.Owner = SysProcess.GetCurrentProcess().MainWindowHandle
         except Exception as ex:
-            logger.debug("WindowInteropHelper failed | %s" % ex)
+            logger.debug('WindowInteropHelper failed | %s' % ex)
 
         # Hook WndProc to intercept WM_MOUSEACTIVATE — prevents the
         # re-entrant activation crash when clicking between Revit and
         # this modeless window.
         self._hwnd_source = None
         self._activation_pending = False
+        # Pre-cache .NET types — IronPython cannot resolve System.IntPtr
+        # or System.Action from inside a Win32 WndProc callback
+        # (LookupGlobalInstruction crash in HwndSubclass.SubclassWndProc).
+        self._INTPTR_ZERO = System.IntPtr.Zero
+        self._INTPTR_MA_NOACTIVATE = System.IntPtr(3)
+        self._BG_PRIORITY = Windows.Threading.DispatcherPriority.Background
         self.SourceInitialized += self._on_source_initialized
 
         self._kfile = None
@@ -545,9 +515,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         self._close_pending = False
 
         self._search_timer = DispatcherTimer()
-        self._search_timer.Interval = TimeSpan.FromMilliseconds(
-            300
-        )  # Wait 300ms after last keystroke
+        self._search_timer.Interval = TimeSpan.FromMilliseconds(300) # Wait 300ms after last keystroke
         self._search_timer.Tick += self._on_search_timer_tick
 
         self.load_config(reset_config)
@@ -585,7 +553,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     @property
     def postcmd_options(self):
-        return [self.userknote_rb, self.materialknote_rb, self.elementknote_rb]
+        return [self.userknote_rb, self.materialknote_rb,
+                self.elementknote_rb]
 
     @property
     def postcmd_idx(self):
@@ -611,16 +580,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
         try:
             return kdb.get_categories(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return []
+            forms.alert(toutex.Message); return []
 
     @property
     def all_keynotes(self):
         try:
             return kdb.get_keynotes(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return []
+            forms.alert(toutex.Message); return []
 
     # =========================================================================
     # STATUS BAR
@@ -629,10 +596,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
     def _update_status_bar(self):
         if self._kfile:
             fname = op.basename(self._kfile)
-            handler = " ( ACC / FORMA )" if self._kfile_handler == "adc" else ""
-            self.statusLeft.Text = "{}{} \u2014 {}".format(
-                fname, handler, op.dirname(self._kfile)
-            )
+            handler = ' ( ACC / FORMA )' if self._kfile_handler == 'adc' else ''
+            self.statusLeft.Text = u"{}{} \u2014 {}".format(
+                fname, handler, op.dirname(self._kfile))
         else:
             self.statusLeft.Text = "No keynote file loaded"
 
@@ -640,11 +606,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
             cats = self.all_categories if self._conn else []
             knotes = self.all_keynotes if self._conn else []
             used = len(self._used_keysdict)
-            self.statusRight.Text = (
-                "{} groups \u00b7 {} keynotes \u00b7 {} in use".format(
-                    len(cats), len(knotes), used
-                )
-            )
+            self.statusRight.Text = \
+                u"{} groups \u00B7 {} keynotes \u00B7 {} in use".format(
+                    len(cats), len(knotes), used)
         except Exception:
             self.statusRight.Text = ""
 
@@ -671,22 +635,30 @@ class KeynoteManagerWindow(forms.WPFWindow):
             wih = WindowInteropHelper(self)
             self._hwnd_source = HwndSource.FromHwnd(wih.Handle)
             if self._hwnd_source:
+                # Cache the Action delegate — must be done after __init__
+                # so self._safe_activate is bound
+                self._activate_action = System.Action(self._safe_activate)
                 self._hwnd_source.AddHook(self._wnd_proc)
         except Exception as ex:
-            logger.debug("HwndSource hook failed | %s" % ex)
+            logger.debug('HwndSource hook failed | %s' % ex)
 
     def _wnd_proc(self, hwnd, msg, wParam, lParam, handled):
-        """Win32 WndProc hook — intercept activation messages."""
-        if msg == self.WM_MOUSEACTIVATE:
-            handled.Value = True
-            if not self._activation_pending:
-                self._activation_pending = True
-                self.Dispatcher.BeginInvoke(
-                    System.Action(self._safe_activate),
-                    Windows.Threading.DispatcherPriority.Background,
-                )
-            return System.IntPtr(self.MA_NOACTIVATE)
-        return System.IntPtr.Zero
+        """Win32 WndProc hook — intercept activation messages.
+        CRITICAL: Only use pre-cached instance variables here.
+        IronPython cannot resolve .NET types (System.IntPtr, etc.)
+        from inside a native Win32 callback."""
+        try:
+            if msg == self.WM_MOUSEACTIVATE:
+                handled.Value = True
+                if not self._activation_pending:
+                    self._activation_pending = True
+                    self.Dispatcher.BeginInvoke(
+                        self._activate_action,
+                        self._BG_PRIORITY)
+                return self._INTPTR_MA_NOACTIVATE
+        except Exception:
+            pass  # WndProc must NEVER throw
+        return self._INTPTR_ZERO
 
     def _safe_activate(self):
         """Deferred activation — runs when Revit's message loop is idle."""
@@ -695,7 +667,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             if self.IsLoaded and self.IsVisible:
                 self.Activate()
         except Exception as ex:
-            logger.debug("Deferred activation failed | %s" % ex)
+            logger.debug('Deferred activation failed | %s' % ex)
 
     # =========================================================================
     # TREE STATE PRESERVATION
@@ -740,15 +712,13 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def _set_scroll_offset(self, offset):
         """Restore the vertical scroll offset after a tree rebuild."""
-
         def _do_scroll():
             sv = self._get_scroll_viewer()
             if sv:
                 sv.ScrollToVerticalOffset(offset)
-
         self.Dispatcher.BeginInvoke(
-            System.Action(_do_scroll), Windows.Threading.DispatcherPriority.Loaded
-        )
+            System.Action(_do_scroll),
+            Windows.Threading.DispatcherPriority.Loaded)
 
     def _select_keynote_by_key(self, key):
         """Find and select the node with the given key in the new tree."""
@@ -760,19 +730,16 @@ class KeynoteManagerWindow(forms.WPFWindow):
             container = None
             parent_container = self.keynotes_tv
             for node in path:
-                if container and hasattr(container, "IsExpanded"):
+                if container and hasattr(container, 'IsExpanded'):
                     container.IsExpanded = True
                     container.UpdateLayout()
                 idx = None
                 items = parent_container.ItemContainerGenerator
-                src = (
-                    parent_container.Items
-                    if hasattr(parent_container, "Items")
+                src = parent_container.Items if hasattr(parent_container, 'Items') \
                     else parent_container.ItemsSource
-                )
                 if src:
                     for i, item in enumerate(src):
-                        if hasattr(item, "key") and item.key == node.key:
+                        if hasattr(item, 'key') and item.key == node.key:
                             idx = i
                             break
                 if idx is not None:
@@ -780,7 +747,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 else:
                     container = items.ContainerFromItem(node)
                 if container is None:
-                    if hasattr(parent_container, "UpdateLayout"):
+                    if hasattr(parent_container, 'UpdateLayout'):
                         parent_container.UpdateLayout()
                     if idx is not None:
                         container = items.ContainerFromIndex(idx)
@@ -790,13 +757,13 @@ class KeynoteManagerWindow(forms.WPFWindow):
                     return
                 parent_container = container
 
-            if container and hasattr(container, "IsSelected"):
+            if container and hasattr(container, 'IsSelected'):
                 container.IsSelected = True
                 container.BringIntoView()
 
         self.Dispatcher.BeginInvoke(
-            System.Action(_do_select), Windows.Threading.DispatcherPriority.Loaded
-        )
+            System.Action(_do_select),
+            Windows.Threading.DispatcherPriority.Loaded)
 
     def _find_node_path(self, roots, target_key):
         """Return the path [root, ..., target] from roots to the node
@@ -828,7 +795,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                     if key:
                         used[key].append(kn.Id)
         except Exception as ex:
-            logger.debug("get_used_keynotes failed | %s" % ex)
+            logger.debug('get_used_keynotes failed | %s' % ex)
         return used
 
     # =========================================================================
@@ -837,43 +804,46 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def save_config(self):
         wg = {}
-        for k, v in self._config.get_option("last_window_geom", {}).items():
+        for k, v in self._config.get_option('last_window_geom', {}).items():
             if op.exists(k):
                 wg[k] = v
         wg[self._kfile] = self.window_geom
-        self._config.set_option("last_window_geom", wg)
+        self._config.set_option('last_window_geom', wg)
 
         pc = {}
-        for k, v in self._config.get_option("last_postcmd_idx", {}).items():
+        for k, v in self._config.get_option('last_postcmd_idx', {}).items():
             if op.exists(k):
                 pc[k] = v
         pc[self._kfile] = self.postcmd_idx
-        self._config.set_option("last_postcmd_idx", pc)
+        self._config.set_option('last_postcmd_idx', pc)
 
         st = {}
         if self.search_term:
             st[self._kfile] = self.search_term
-        self._config.set_option("last_search_term", st)
+        self._config.set_option('last_search_term', st)
 
         script.save_config()
 
     def load_config(self, reset):
-        wg = {} if reset else self._config.get_option("last_window_geom", {})
+        wg = {} if reset else self._config.get_option(
+            'last_window_geom', {})
         if wg and self._kfile in wg:
             w, h, t, l = wg[self._kfile]
         else:
             w, h, t, l = (None, None, None, None)
-        if all([w, h, t, l]) and coreutils.is_box_visible_on_screens(l, t, w, h):
+        if all([w, h, t, l]) \
+                and coreutils.is_box_visible_on_screens(l, t, w, h):
             self.window_geom = (w, h, t, l)
         else:
-            self.WindowStartupLocation = (
+            self.WindowStartupLocation = \
                 framework.Windows.WindowStartupLocation.CenterScreen
-            )
 
-        pc = {} if reset else self._config.get_option("last_postcmd_idx", {})
+        pc = {} if reset else self._config.get_option(
+            'last_postcmd_idx', {})
         self.postcmd_idx = pc.get(self._kfile, 0)
 
-        st = {} if reset else self._config.get_option("last_search_term", {})
+        st = {} if reset else self._config.get_option(
+            'last_search_term', {})
         self.search_term = st.get(self._kfile, "")
 
     # =========================================================================
@@ -897,8 +867,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if self._kfile:
             return
 
-        self._kfile_ext = revit.query.get_external_keynote_file(doc=revit.doc)
-        self._kfile_handler = "unknown"
+        self._kfile_ext = \
+            revit.query.get_external_keynote_file(doc=revit.doc)
+        self._kfile_handler = 'unknown'
 
         if not self._kfile_ext:
             return
@@ -906,7 +877,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         # CRITICAL: call is_available() FIRST on a clean AppDomain.
         # No legacy DLL probing before this point.
         if adc.is_available():
-            self._kfile_handler = "adc"
+            self._kfile_handler = 'adc'
             self._resolve_adc_keynote()
             return
 
@@ -914,8 +885,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             "{} is not available.\n\n"
             "Please ensure Desktop Connector is running "
             "in the system tray.".format(adc.ADC_NAME),
-            exitscript=True,
-        )
+            exitscript=True)
 
     def _resolve_adc_keynote(self):
         """Resolve cloud keynote path to local file via ADC."""
@@ -925,14 +895,15 @@ class KeynoteManagerWindow(forms.WPFWindow):
             if not local_kfile:
                 forms.alert(
                     "Cannot resolve local path via {}.".format(adc.ADC_NAME),
-                    exitscript=True,
-                )
+                    exitscript=True)
                 return
 
             try:
                 locked, owner = adc.is_locked(self._kfile_ext)
                 if locked:
-                    forms.alert("File locked by {}.".format(owner), exitscript=True)
+                    forms.alert(
+                        "File locked by {}.".format(owner),
+                        exitscript=True)
                     return
             except Exception:
                 pass
@@ -944,13 +915,15 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 pass
 
             self._kfile = local_kfile
-            self.Title += " ( ACC / FORMA )"
+            self.Title += ' ( ACC / FORMA )'
 
         except Exception as adcex:
-            forms.alert("ADC communication failed.\n{}".format(adcex), exitscript=True)
+            forms.alert(
+                "ADC communication failed.\n{}".format(adcex),
+                exitscript=True)
 
     def _change_kfile(self):
-        kfile = forms.pick_file("txt")
+        kfile = forms.pick_file('txt')
         if kfile:
             try:
                 with revit.Transaction("Set Keynote File"):
@@ -973,12 +946,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
         except System.TimeoutException as toutex:
             forms.alert(toutex.Message, exitscript=True)
         except Exception as ex:
-            logger.debug("Connection failed | %s" % ex)
+            logger.debug('Connection failed | %s' % ex)
             res = forms.alert(
                 "Cannot connect to keynote file.\n"
                 "It may need conversion to the new format.",
-                options=["Convert", "Select Other", "Help"],
-            )
+                options=["Convert", "Select Other", "Help"])
             if res == "Convert":
                 try:
                     self._convert_existing()
@@ -986,21 +958,21 @@ class KeynoteManagerWindow(forms.WPFWindow):
                     if not self._conn:
                         forms.alert("Relaunch required.", exitscript=True)
                 except Exception as convex:
-                    forms.alert("Conversion failed: %s" % convex, exitscript=True)
+                    forms.alert("Conversion failed: %s" % convex,
+                                exitscript=True)
             elif res == "Select Other":
                 self._change_kfile()
                 self._determine_kfile()
             elif res == "Help":
                 script.open_url(
                     "https://www.notion.so/pyrevitlabs/"
-                    "Manage-Keynotes-6f083d6f66fe43d68dc5d5407c8e19da"
-                )
+                    "Manage-Keynotes-6f083d6f66fe43d68dc5d5407c8e19da")
                 script.exit()
             else:
                 forms.alert("No valid keynote file.", exitscript=True)
 
     def _convert_existing(self):
-        temp = script.get_data_file(op.basename(self._kfile), "bak")
+        temp = script.get_data_file(op.basename(self._kfile), 'bak')
         if op.exists(temp):
             script.remove_data_file(temp)
         try:
@@ -1008,7 +980,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         except Exception:
             raise Exception("Backup failed.")
         try:
-            with open(self._kfile, "w"):
+            with open(self._kfile, 'w'):
                 pass
         except Exception:
             raise Exception("File preparation failed.")
@@ -1036,7 +1008,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
             forms.alert(toutex.Message)
             return []
         except Exception as ex:
-            forms.alert("Error loading keynotes:\n%s" % ex, exitscript=True)
+            forms.alert("Error loading keynotes:\n%s" % ex,
+                        exitscript=True)
             return []
 
         # Build parent -> children map from keynotes
@@ -1049,8 +1022,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         # Recursive child population
         def _populate(node):
             node_children = natsorted(
-                children_map.get(node.key, []), key=lambda x: x.key
-            )
+                children_map.get(node.key, []), key=lambda x: x.key)
             # Replace the children list (clear first to avoid dupes)
             while node.children:
                 node.children.pop()
@@ -1085,10 +1057,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
         keynote_filter = self.search_term if self.search_term else None
 
         # Update view-only filter keys
-        if keynote_filter and kdb.RKeynoteFilters.ViewOnly.code in keynote_filter:
+        if keynote_filter \
+                and kdb.RKeynoteFilters.ViewOnly.code in keynote_filter:
             visible_keys = [
-                x.TagText for x in revit.query.get_visible_keynotes(revit.active_view)
-            ]
+                x.TagText for x in
+                revit.query.get_visible_keynotes(revit.active_view)]
             kdb.RKeynoteFilters.ViewOnly.set_keys(visible_keys)
 
         if fast_filter and keynote_filter:
@@ -1129,19 +1102,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         """Enable/disable toolbar buttons based on selection."""
         sel = self.selected_keynote
         if not sel or sel.locked:
-            for btn in [
-                self.editKeynoteBtn,
-                self.dupKeynoteBtn,
-                self.rekeyBtn,
-                self.removeBtn,
-                self.findBtn,
-                self.placeBtn,
-                self.indentBtn,
-                self.outdentBtn,
-                self.moveUpBtn,
-                self.moveDownBtn,
-                self.caseBtn,
-            ]:
+            for btn in [self.editKeynoteBtn, self.dupKeynoteBtn,
+                        self.rekeyBtn, self.removeBtn,
+                        self.findBtn, self.placeBtn,
+                        self.indentBtn, self.outdentBtn,
+                        self.moveUpBtn, self.moveDownBtn,
+                        self.caseBtn]:
                 btn.IsEnabled = False
             return
 
@@ -1164,8 +1130,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
         can_down = False
 
         if is_kn:
-            siblings = _find_siblings(self.all_keynotes, sel.parent_key)
-            idx = next((i for i, s in enumerate(siblings) if s.key == sel.key), -1)
+            siblings = _find_siblings(
+                self.all_keynotes, sel.parent_key)
+            idx = next(
+                (i for i, s in enumerate(siblings) if s.key == sel.key),
+                -1)
             can_indent = idx > 0  # has a sibling above
             # Can outdent if parent is a keynote (not a category)
             cats = self.all_categories
@@ -1176,7 +1145,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
             can_down = idx < len(siblings) - 1
         elif is_cat:
             cats = natsorted(self.all_categories, key=lambda x: x.key)
-            idx = next((i for i, c in enumerate(cats) if c.key == sel.key), -1)
+            idx = next(
+                (i for i, c in enumerate(cats) if c.key == sel.key), -1)
             can_up = idx > 0
             can_down = idx < len(cats) - 1
 
@@ -1197,7 +1167,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
             return
 
         siblings = _find_siblings(self.all_keynotes, sel.parent_key)
-        idx = next((i for i, s in enumerate(siblings) if s.key == sel.key), -1)
+        idx = next(
+            (i for i, s in enumerate(siblings) if s.key == sel.key), -1)
         if idx <= 0:
             return
 
@@ -1206,11 +1177,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
             kdb.move_keynote(self._conn, sel.key, new_parent.key)
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return
+            forms.alert(toutex.Message); return
         except Exception as ex:
-            forms.alert("Indent failed: %s" % ex)
-            return
+            forms.alert("Indent failed: %s" % ex); return
 
         self._update_full_tree()
         self._update_status_bar()
@@ -1233,13 +1202,13 @@ class KeynoteManagerWindow(forms.WPFWindow):
             forms.alert(
                 "Already at the top keynote level.\n"
                 "To make this a top-level group, use the Re-Key as "
-                "category workflow."
-            )
+                "category workflow.")
             return
 
         # Parent is a keynote — find grandparent
         all_kn = self.all_keynotes
-        parent = next((k for k in all_kn if k.key == current_parent_key), None)
+        parent = next(
+            (k for k in all_kn if k.key == current_parent_key), None)
         if not parent:
             return
 
@@ -1251,11 +1220,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
             kdb.move_keynote(self._conn, sel.key, grandparent_key)
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return
+            forms.alert(toutex.Message); return
         except Exception as ex:
-            forms.alert("Outdent failed: %s" % ex)
-            return
+            forms.alert("Outdent failed: %s" % ex); return
 
         self._update_full_tree()
         self._update_status_bar()
@@ -1281,19 +1248,21 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
         is_cat = sel.is_category
         if is_cat:
-            siblings = natsorted(self.all_categories, key=lambda x: x.key)
+            siblings = natsorted(
+                self.all_categories, key=lambda x: x.key)
         else:
-            siblings = _find_siblings(self.all_keynotes, sel.parent_key)
+            siblings = _find_siblings(
+                self.all_keynotes, sel.parent_key)
 
-        idx = next((i for i, s in enumerate(siblings) if s.key == sel.key), -1)
+        idx = next(
+            (i for i, s in enumerate(siblings) if s.key == sel.key), -1)
         target_idx = idx + direction
         if target_idx < 0 or target_idx >= len(siblings):
             return
 
         other = siblings[target_idx]
         if other.locked:
-            forms.alert("Adjacent item is locked.")
-            return
+            forms.alert("Adjacent item is locked."); return
 
         # Swap keys
         sel_key = sel.key
@@ -1309,9 +1278,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 with kdb.BulkAction(self._conn):
                     for child in self.all_keynotes:
                         if child.parent_key == sel_key:
-                            kdb.move_keynote(self._conn, child.key, other_key)
+                            kdb.move_keynote(
+                                self._conn, child.key, other_key)
                         elif child.parent_key == other_key:
-                            kdb.move_keynote(self._conn, child.key, sel_key)
+                            kdb.move_keynote(
+                                self._conn, child.key, sel_key)
             else:
                 kdb.update_keynote_key(self._conn, sel_key, temp_key)
                 kdb.update_keynote_key(self._conn, other_key, sel_key)
@@ -1320,20 +1291,20 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 with kdb.BulkAction(self._conn):
                     for child in self.all_keynotes:
                         if child.parent_key == sel_key:
-                            kdb.move_keynote(self._conn, child.key, other_key)
+                            kdb.move_keynote(
+                                self._conn, child.key, other_key)
                         elif child.parent_key == other_key:
-                            kdb.move_keynote(self._conn, child.key, sel_key)
+                            kdb.move_keynote(
+                                self._conn, child.key, sel_key)
 
             # Update references in Revit model (async via ExternalEvent)
             sk, ok = sel_key, other_key
             self._revit_run(lambda: self._swap_keynote_refs(sk, ok))
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return
+            forms.alert(toutex.Message); return
         except Exception as ex:
-            forms.alert("Swap failed: %s" % ex)
-            return
+            forms.alert("Swap failed: %s" % ex); return
 
         self._update_full_tree()
         self._update_status_bar()
@@ -1371,29 +1342,25 @@ class KeynoteManagerWindow(forms.WPFWindow):
             kns = kdb.get_keynotes(self._conn)
             locks = kdb.get_locks(self._conn)
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return
+            forms.alert(toutex.Message); return
         reserved = [x.key for x in cats]
         reserved.extend([x.key for x in kns])
         reserved.extend([x.LockTargetRecordKey for x in locks])
         return forms.ask_for_unique_string(
             prompt="Enter a unique key:",
             title="Choose Unique Key",
-            reserved_values=reserved,
-            owner=self,
-        )
+            reserved_values=reserved, owner=self)
 
     def _pick_parent(self):
         """Pick any node (category or keynote) as a parent."""
         cats = self.all_categories
         kns = self.all_keynotes
         items = natsorted(
-            ["{} — {}".format(x.key, x.text) for x in cats]
-            + ["{} — {}".format(x.key, x.text) for x in kns],
+            ["{} — {}".format(x.key, x.text) for x in cats] +
+            ["{} — {}".format(x.key, x.text) for x in kns],
         )
         chosen = forms.SelectFromList.show(
-            items, title="Select Parent", multiselect=False, owner=self
-        )
+            items, title="Select Parent", multiselect=False, owner=self)
         if chosen:
             return chosen.split(" — ")[0].strip()
         return None
@@ -1403,14 +1370,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
     # =========================================================================
 
     def search_txt_changed(self, sender, args):
-        if self.search_tb.Text == "":
+        if self.search_tb.Text == '':
             self.clrsearch_b.Visibility = Windows.Visibility.Collapsed
         else:
             self.clrsearch_b.Visibility = Windows.Visibility.Visible
-
-        # Stop and restart the timer on every keystroke.
+            
+        # Stop and restart the timer on every keystroke. 
         # The filter won't run until the typing pauses for 300ms.
-        if hasattr(self, "_search_timer"):
+        if hasattr(self, '_search_timer'):
             self._search_timer.Stop()
             self._search_timer.Start()
 
@@ -1420,7 +1387,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         self._update_full_tree(fast_filter=True)
 
     def clear_search(self, sender, args):
-        self.search_tb.Text = ""  # Removed the space to ensure clean empty string
+        self.search_tb.Text = '' # Removed the space to ensure clean empty string
         self.search_tb.Clear()
         self.search_tb.Focus()
         self._update_full_tree(fast_filter=True)
@@ -1428,9 +1395,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
     def custom_filter(self, sender, args):
         sfilter = forms.SelectFromList.show(
             kdb.RKeynoteFilters.get_available_filters(),
-            title="Select Filter",
-            owner=self,
-        )
+            title="Select Filter", owner=self)
         if sfilter:
             self.search_term = sfilter.format_term(self.search_term)
 
@@ -1452,40 +1417,28 @@ class KeynoteManagerWindow(forms.WPFWindow):
         shift = Windows.Input.ModifierKeys.Shift
 
         if key == Windows.Input.Key.F5:
-            self.refresh(sender, args)
-            args.Handled = True
+            self.refresh(sender, args); args.Handled = True
         elif key == Windows.Input.Key.F2:
             if self.selected_keynote:
-                self.edit_keynote(sender, args)
-                args.Handled = True
+                self.edit_keynote(sender, args); args.Handled = True
         elif key == Windows.Input.Key.Delete:
             if self.selected_keynote:
-                self.remove_keynote(sender, args)
-                args.Handled = True
+                self.remove_keynote(sender, args); args.Handled = True
         elif key == Windows.Input.Key.N and mods == ctrl:
-            self.add_keynote(sender, args)
-            args.Handled = True
+            self.add_keynote(sender, args); args.Handled = True
         elif key == Windows.Input.Key.D and mods == ctrl:
             if self.selected_keynote:
-                self.duplicate_keynote(sender, args)
-                args.Handled = True
+                self.duplicate_keynote(sender, args); args.Handled = True
         elif key == Windows.Input.Key.I and mods == ctrl:
-            self.import_keynotes(sender, args)
-            args.Handled = True
+            self.import_keynotes(sender, args); args.Handled = True
         elif key == Windows.Input.Key.Tab and mods == shift:
-            self.outdent_keynote(sender, args)
-            args.Handled = True
-        elif key == Windows.Input.Key.Tab and mods == getattr(
-            Windows.Input.ModifierKeys, "None"
-        ):
-            self.indent_keynote(sender, args)
-            args.Handled = True
+            self.outdent_keynote(sender, args); args.Handled = True
+        elif key == Windows.Input.Key.Tab and mods == getattr(Windows.Input.ModifierKeys, "None"):
+            self.indent_keynote(sender, args); args.Handled = True
         elif key == Windows.Input.Key.Up and mods == ctrl:
-            self.move_up(sender, args)
-            args.Handled = True
+            self.move_up(sender, args); args.Handled = True
         elif key == Windows.Input.Key.Down and mods == ctrl:
-            self.move_down(sender, args)
-            args.Handled = True
+            self.move_down(sender, args); args.Handled = True
         elif key == Windows.Input.Key.Escape:
             if self.search_term:
                 self.clear_search(sender, args)
@@ -1504,25 +1457,22 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if self._drag_start_point is None:
             return
         if args.LeftButton != Windows.Input.MouseButtonState.Pressed:
-            self._drag_start_point = None
-            return
+            self._drag_start_point = None; return
 
         pt = args.GetPosition(sender)
         diff = self._drag_start_point - pt
-        if (
-            abs(diff.X) > System.Windows.SystemParameters.MinimumHorizontalDragDistance
-            or abs(diff.Y) > System.Windows.SystemParameters.MinimumVerticalDragDistance
-        ):
+        if abs(diff.X) > System.Windows.SystemParameters.MinimumHorizontalDragDistance \
+                or abs(diff.Y) > System.Windows.SystemParameters.MinimumVerticalDragDistance:
             sel = self.selected_keynote
             if sel and not sel.locked:
                 self._is_dragging = True
                 try:
                     data = Windows.DataObject("keynote", sel)
                     Windows.DragDrop.DoDragDrop(
-                        self.keynotes_tv, data, Windows.DragDropEffects.Move
-                    )
+                        self.keynotes_tv, data,
+                        Windows.DragDropEffects.Move)
                 except Exception as ex:
-                    logger.debug("Drag failed | %s" % ex)
+                    logger.debug('Drag failed | %s' % ex)
                 finally:
                     self._is_dragging = False
                     self._drag_start_point = None
@@ -1544,14 +1494,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if args.Data.GetDataPresent("keynote"):
             args.Effects = Windows.DragDropEffects.Move
             # Visual feedback
-            if hasattr(sender, "Background"):
-                sender.Background = Windows.Media.SolidColorBrush(
-                    Windows.Media.Color.FromArgb(40, 43, 87, 154)
-                )
+            if hasattr(sender, 'Background'):
+                sender.Background = \
+                    Windows.Media.SolidColorBrush(
+                        Windows.Media.Color.FromArgb(40, 43, 87, 154))
             args.Handled = True
 
     def tree_item_drag_leave(self, sender, args):
-        if hasattr(sender, "Background"):
+        if hasattr(sender, 'Background'):
             sender.Background = None
 
     def tree_drop(self, sender, args):
@@ -1559,7 +1509,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def tree_item_drop(self, sender, args):
         """Drop handler — reparent the dragged node under the target."""
-        if hasattr(sender, "Background"):
+        if hasattr(sender, 'Background'):
             sender.Background = None
 
         if not args.Data.GetDataPresent("keynote"):
@@ -1568,7 +1518,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if not dragged:
             return
 
-        target = getattr(sender, "DataContext", None)
+        target = getattr(sender, 'DataContext', None)
         if target is None or target == dragged:
             return
 
@@ -1597,8 +1547,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
             return False
 
         if dragged.parent_key and _is_descendant(
-            new_parent_key, dragged.key, self.all_keynotes
-        ):
+                new_parent_key, dragged.key, self.all_keynotes):
             forms.alert("Cannot drop a parent onto its own descendant.")
             return
 
@@ -1606,8 +1555,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if dragged.is_category:
             forms.alert(
                 "Drag top-level groups is not supported.\n"
-                "Use Move Up / Move Down to reorder groups."
-            )
+                "Use Move Up / Move Down to reorder groups.")
             return
 
         if new_parent_key == dragged.parent_key:
@@ -1631,15 +1579,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def refresh(self, sender, args):
         if self._conn:
-
             def _query_used():
                 self._used_keysdict = self.get_used_keynote_elements()
-
             def _on_done():
                 self._update_full_tree()
                 self._update_status_bar()
                 self.search_tb.Focus()
-
             self._revit_run(_query_used, callback=_on_done)
         else:
             self.search_tb.Focus()
@@ -1650,7 +1595,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def add_category(self, sender, args):
         try:
-            new_cat = EditRecordWindow(self, self._conn, kdb.EDIT_MODE_ADD_CATEG).show()
+            new_cat = EditRecordWindow(
+                self, self._conn, kdb.EDIT_MODE_ADD_CATEG).show()
             if new_cat:
                 self._needs_update = True
         except Exception as ex:
@@ -1665,8 +1611,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if sel and sel.is_category and not sel.locked:
             try:
                 EditRecordWindow(
-                    self, self._conn, kdb.EDIT_MODE_EDIT_CATEG, rkeynote=sel
-                ).show()
+                    self, self._conn,
+                    kdb.EDIT_MODE_EDIT_CATEG,
+                    rkeynote=sel).show()
                 self._needs_update = True
             except Exception as ex:
                 forms.alert(str(ex))
@@ -1688,8 +1635,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if parent_key:
             try:
                 EditRecordWindow(
-                    self, self._conn, kdb.EDIT_MODE_ADD_KEYNOTE, pkey=parent_key
-                ).show()
+                    self, self._conn,
+                    kdb.EDIT_MODE_ADD_KEYNOTE,
+                    pkey=parent_key).show()
                 self._needs_update = True
             except Exception as ex:
                 forms.alert(str(ex))
@@ -1702,12 +1650,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if sel and sel.parent_key:
             try:
                 EditRecordWindow(
-                    self,
-                    self._conn,
+                    self, self._conn,
                     kdb.EDIT_MODE_ADD_KEYNOTE,
-                    text=sel.text,
-                    pkey=sel.parent_key,
-                ).show()
+                    text=sel.text, pkey=sel.parent_key).show()
                 self._needs_update = True
             except Exception as ex:
                 forms.alert(str(ex))
@@ -1724,8 +1669,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
             return
         try:
             EditRecordWindow(
-                self, self._conn, kdb.EDIT_MODE_EDIT_KEYNOTE, rkeynote=sel
-            ).show()
+                self, self._conn,
+                kdb.EDIT_MODE_EDIT_KEYNOTE,
+                rkeynote=sel).show()
             self._needs_update = True
         except Exception as ex:
             forms.alert(str(ex))
@@ -1740,12 +1686,15 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if sel.is_category:
             # Removing a category
             if sel.has_children():
-                forms.alert("Group '%s' has children. Remove them first." % sel.key)
+                forms.alert(
+                    "Group '%s' has children. Remove them first."
+                    % sel.key)
                 return
             if sel.used:
                 forms.alert("Group '%s' is in use." % sel.key)
                 return
-            if forms.alert("Delete group '%s'?" % sel.key, yes=True, no=True):
+            if forms.alert("Delete group '%s'?" % sel.key,
+                           yes=True, no=True):
                 try:
                     kdb.remove_category(self._conn, sel.key)
                     self._needs_update = True
@@ -1754,12 +1703,15 @@ class KeynoteManagerWindow(forms.WPFWindow):
         else:
             # Removing a keynote
             if sel.children:
-                forms.alert("Keynote '%s' has children. Remove them first." % sel.key)
+                forms.alert(
+                    "Keynote '%s' has children. Remove them first."
+                    % sel.key)
                 return
             if sel.used:
                 forms.alert("Keynote '%s' is in use." % sel.key)
                 return
-            if forms.alert("Delete keynote '%s'?" % sel.key, yes=True, no=True):
+            if forms.alert("Delete keynote '%s'?" % sel.key,
+                           yes=True, no=True):
                 try:
                     kdb.remove_keynote(self._conn, sel.key)
                     self._needs_update = True
@@ -1781,17 +1733,21 @@ class KeynoteManagerWindow(forms.WPFWindow):
             to_key = self._pick_new_key()
             if to_key and to_key != from_key:
                 if sel.is_category:
-                    kdb.update_category_key(self._conn, from_key, to_key)
+                    kdb.update_category_key(
+                        self._conn, from_key, to_key)
                     with kdb.BulkAction(self._conn):
                         for child in self.all_keynotes:
                             if child.parent_key == from_key:
-                                kdb.move_keynote(self._conn, child.key, to_key)
+                                kdb.move_keynote(
+                                    self._conn, child.key, to_key)
                 else:
-                    kdb.update_keynote_key(self._conn, from_key, to_key)
+                    kdb.update_keynote_key(
+                        self._conn, from_key, to_key)
                     with kdb.BulkAction(self._conn):
                         for child in self.all_keynotes:
                             if child.parent_key == from_key:
-                                kdb.move_keynote(self._conn, child.key, to_key)
+                                kdb.move_keynote(
+                                    self._conn, child.key, to_key)
                 # Update Revit element refs (async via ExternalEvent)
                 fk, tk = from_key, to_key
                 self._revit_run(lambda: self._rekey_refs(fk, tk))
@@ -1835,11 +1791,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 kdb.update_keynote_text(self._conn, sel.key, new_text)
             self._needs_update = True
         except System.TimeoutException as toutex:
-            forms.alert(toutex.Message)
-            return
+            forms.alert(toutex.Message); return
         except Exception as ex:
-            forms.alert("Case change failed: %s" % ex)
-            return
+            forms.alert("Case change failed: %s" % ex); return
         self._update_full_tree()
 
     def to_upper(self, sender, args):
@@ -1867,12 +1821,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
         used_snapshot = dict(self._used_keysdict)
         kids = used_snapshot.get(key, [])
         if not kids:
-            self.statusLeft.Text = "Keynote '{}' — not placed in model".format(key)
+            self.statusLeft.Text = u"Keynote '{}' — not placed in model".format(key)
             return
-
         def _do():
             for kid in kids:
-                source = viewname = ""
+                source = viewname = ''
                 kel = revit.doc.GetElement(kid)
                 if kel is None:
                     continue
@@ -1884,17 +1837,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 if vel:
                     viewname = revit.query.get_name(vel)
                 report = "Keynote: {} | Source: {} | View: {}".format(
-                    output.linkify(kid), source, viewname
-                )
+                    output.linkify(kid), source, viewname)
                 if ehist:
                     report += " | Last edit: %s" % ehist.last_changed_by
                 print(report)
-
         def _update_status():
-            self.statusLeft.Text = (
-                "Keynote '{}' — {} placements shown in output".format(key, len(kids))
-            )
-
+            self.statusLeft.Text = \
+                u"Keynote '{}' — {} placements shown in output".format(
+                    key, len(kids))
         self._revit_run(_do, callback=_update_status)
 
     def place_keynote(self, sender, args):
@@ -1904,21 +1854,18 @@ class KeynoteManagerWindow(forms.WPFWindow):
         sel_key = sel.key
         postcmd = self.postable_keynote_command
         self.Close()
-
         def _do():
-            keynotes_cat = revit.query.get_category(DB.BuiltInCategory.OST_KeynoteTags)
+            keynotes_cat = \
+                revit.query.get_category(DB.BuiltInCategory.OST_KeynoteTags)
             if keynotes_cat:
                 def_id = revit.doc.GetDefaultFamilyTypeId(keynotes_cat.Id)
                 if revit.doc.GetElement(def_id):
-                    DocumentEventUtils.PostCommandAndUpdateNewElementProperties(
-                        HOST_APP.uiapp,
-                        revit.doc,
-                        postcmd,
-                        "Update Keynotes",
-                        DB.BuiltInParameter.KEY_VALUE,
-                        sel_key,
-                    )
-
+                    DocumentEventUtils \
+                        .PostCommandAndUpdateNewElementProperties(
+                            HOST_APP.uiapp, revit.doc,
+                            postcmd,
+                            "Update Keynotes",
+                            DB.BuiltInParameter.KEY_VALUE, sel_key)
         self._revit_run(_do)
 
     # =========================================================================
@@ -1926,14 +1873,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
     # =========================================================================
 
     def change_keynote_file(self, sender, args):
-        kfile = forms.pick_file("txt")
+        kfile = forms.pick_file('txt')
         if not kfile:
             return
-
         def _set_file():
             with revit.Transaction("Set Keynote File"):
                 revit.update.set_keynote_file(kfile, doc=revit.doc)
-
         def _reload():
             self._determine_kfile()
             self._connect_kfile()
@@ -1941,21 +1886,22 @@ class KeynoteManagerWindow(forms.WPFWindow):
             try:
                 self._used_keysdict = self.get_used_keynote_elements()
             except Exception as ex:
-                logger.debug("Refresh used keys failed | %s" % ex)
+                logger.debug('Refresh used keys failed | %s' % ex)
             self._update_full_tree()
             self._update_status_bar()
-
         self._revit_run(_set_file, callback=_reload)
 
     def show_keynote_file(self, sender, args):
         coreutils.show_entry_in_explorer(self._kfile)
 
     def import_keynotes(self, sender, args):
-        kfile = forms.pick_file("txt")
+        kfile = forms.pick_file('txt')
         if kfile:
-            res = forms.alert("Skip duplicate entries?", yes=True, no=True)
+            res = forms.alert("Skip duplicate entries?",
+                              yes=True, no=True)
             try:
-                kdb.import_legacy_keynotes(self._conn, kfile, skip_dup=res)
+                kdb.import_legacy_keynotes(
+                    self._conn, kfile, skip_dup=res)
             except Exception as ex:
                 forms.alert("Import failed: %s" % ex)
             finally:
@@ -1963,7 +1909,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 self._update_status_bar()
 
     def export_keynotes(self, sender, args):
-        kfile = forms.save_file("txt")
+        kfile = forms.save_file('txt')
         if kfile:
             try:
                 kdb.export_legacy_keynotes(self._conn, kfile)
@@ -1971,13 +1917,14 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 forms.alert(str(ex))
 
     def export_visible_keynotes(self, sender, args):
-        kfile = forms.save_file("txt")
+        kfile = forms.save_file('txt')
         if kfile:
             include = set()
-            for rk in self.current_keynotes or []:
+            for rk in (self.current_keynotes or []):
                 include.update(rk.collect_keys())
             try:
-                kdb.export_legacy_keynotes(self._conn, kfile, include_keys=include)
+                kdb.export_legacy_keynotes(
+                    self._conn, kfile, include_keys=include)
             except Exception as ex:
                 forms.alert(str(ex))
 
@@ -1988,11 +1935,10 @@ class KeynoteManagerWindow(forms.WPFWindow):
     def update_model(self, sender, args):
         """Queue keynote update transaction and keep window open."""
         if self._needs_update:
-
             def _do_update():
                 with revit.Transaction("Update Keynotes"):
                     revit.update.update_linked_keynotes(doc=revit.doc)
-
+            
             def _on_update_complete():
                 self._needs_update = False
                 forms.alert("Revit model updated successfully.", title="Success")
@@ -2015,16 +1961,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
             res = forms.alert(
                 "Keynote file has been modified.\n"
                 "Sync changes to the Revit model before closing?",
-                yes=True,
-                no=True,
-            )
+                yes=True, no=True)
             if res:
                 args.Cancel = True
-
                 def _do_update():
                     with revit.Transaction("Update Keynotes"):
                         revit.update.update_linked_keynotes(doc=revit.doc)
-
                 self._close_pending = True
                 self._revit_run(_do_update, callback=self._finalize_close)
                 return
@@ -2038,7 +1980,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 pass
             self._hwnd_source = None
 
-        if self._kfile_handler == "adc":
+        if self._kfile_handler == 'adc':
             try:
                 adc.unlock_file(self._kfile_ext)
             except Exception:
@@ -2046,7 +1988,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
         try:
             self.save_config()
         except Exception as ex:
-            logger.debug("Save config failed | %s" % ex)
+            logger.debug('Save config failed | %s' % ex)
         if self._conn:
             try:
                 self._conn.Dispose()
@@ -2066,8 +2008,8 @@ try:
         _active_window.WindowState = framework.Windows.WindowState.Normal
     else:
         _active_window = KeynoteManagerWindow(
-            xaml_file_name="KeynoteManagerWindow.xaml",
-            reset_config=__shiftclick__,  # pylint: disable=undefined-variable
+            xaml_file_name='KeynoteManagerWindow.xaml',
+            reset_config=__shiftclick__  #pylint: disable=undefined-variable
         )
         _active_window.show(modal=False)
 except Exception as kmex:


### PR DESCRIPTION
# fix: restore WndProc pre-cached .NET types to prevent IronPython crash

## Description

IronPython cannot resolve System.IntPtr or System.Action from inside
a native Win32 WndProc callback (LookupGlobalInstruction crash in
HwndSubclass.SubclassWndProc). Pre-cache all .NET types as instance
variables in __init__ and wrap _wnd_proc in blanket try/except."

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.

- [ x] Changes are tested and verified to work as expected.

---


Thank you for contributing to pyRevit! 🎉
