### PR TITLE
fix: update CPython Events test for pythonnet 3.x (#3284)

### DIFF
--- a/extensions/pyRevitDevTools.extension/pyRevitDev.tab/Debug.panel/Engine Tests.pulldown/Test CPython Events.pushbutton/script.py
+++ b/extensions/pyRevitDevTools.extension/pyRevitDev.tab/Debug.panel/Engine Tests.pulldown/Test CPython Events.pushbutton/script.py
@@ -1,19 +1,23 @@
 #! python3
+"""Test CPython event handler subscribe/unsubscribe."""
 # pylint: skip-file
-from pyrevit import HOST_APP, framework
+from pyrevit import HOST_APP
 from pyrevit import UI, DB
 
 
 def docchanged_eventhandler(sender, args):
-    UI.TaskDialog.Show("cpython", str(sender))
-    UI.TaskDialog.Show("cpython", str(args))
-    UI.TaskDialog.Show("cpython", "docchanged_eventhandler")
+    print("DocumentChanged fired: {}".format(args.GetTransactionNames()))
 
 
-docchanged_handler = \
-    framework.EventHandler[DB.Events.DocumentChangedEventArgs](
-        docchanged_eventhandler
-    )
+HOST_APP.app.DocumentChanged += docchanged_eventhandler
+print("DocumentChanged event handler registered")
 
-HOST_APP.app.DocumentChanged += docchanged_handler
-HOST_APP.app.DocumentChanged -= docchanged_handler
+try:
+    HOST_APP.app.DocumentChanged -= docchanged_eventhandler
+    print("DocumentChanged event handler unregistered")
+except Exception as ex:
+    # If unsubscribe fails, the handler only prints to the output window
+    # (no modal dialogs), so it won't disrupt the session.
+    print("Unsubscribe failed (pythonnet delegate limitation): {}".format(ex))
+
+print("CPython event test completed.")


### PR DESCRIPTION
## Update CPython Events test for pythonnet 3.x

### Problem

`Test CPython Events` button fails with `unknown event handler` because
`framework.EventHandler[DB.Events.DocumentChangedEventArgs]()` is an
IronPython generic delegate pattern that doesn't work in pythonnet 3.x.

### Fix

Use direct `+=` event subscription — pythonnet 3.x creates the delegate
automatically. Wrap `-=` unsubscribe in try/except for the known delegate
identity limitation where pythonnet creates a new wrapper on each call.

### Testing

- [x] Subscribe succeeds
- [x] Unsubscribe gracefully handled
- [x] Tested on Revit 2026 (NETCORE / .NET 8)

Related to #3284