### PR TITLE
fix: handle dialog cancellation in Button Creator panel name prompt

### DIFF
--- a/extensions/pyRevitBundlesCreatorExtension.extension/pyRevit Bundles Creator.tab/Button creation.panel/Button Creator.pushbutton/script.py
+++ b/extensions/pyRevitBundlesCreatorExtension.extension/pyRevit Bundles Creator.tab/Button creation.panel/Button Creator.pushbutton/script.py
@@ -19,6 +19,8 @@ up_2_folder = os.path.dirname(up_1_folder)
 # get panel name and create folder
 panel_name = forms.ask_for_string(
     default="My New Panel Name", title="New panel", prompt="Get your new panel a name")
+if not panel_name:
+    script.exit()
 panel_folder = os.path.join(up_2_folder, panel_name + ".panel")
 if not os.path.exists(panel_folder):
     os.mkdir(panel_folder)


### PR DESCRIPTION
When the user cancels the "New panel" input dialog (ESC or X),
`forms.ask_for_string()` returns None. Add a null-check before the
string concatenation at line 22 so the script exits gracefully instead
of raising a TypeError. Fixes pyrevitlabs/pyRevit#3290.

https://claude.ai/code/session_01J9QUhTsodc85zKd28PKKH9