### PR TITLE
add selfilter to linked pickers

### DIFF
--- a/pyrevitlib/pyrevit/revit/selection.py
+++ b/pyrevitlib/pyrevit/revit/selection.py
@@ -287,17 +287,20 @@ def pick_face(message=''):
                      message)
 
 
-def pick_linked(message=''):
+def pick_linked(message='', pick_filter=None):
     """Returns the linked element selected by the user.
 
     Args:
         message (str, optional): message to display. Defaults to ''.
+        pick_filter (object, optional): An object specifying the filter to apply
+            when picking elements. Default is None.
 
     Returns:
         (LinkedElement): The selected linked element.
     """
     return _pick_obj(UI.Selection.ObjectType.LinkedElement,
-                     message)
+                     message,
+                     selection_filter=pick_filter)
 
 
 def pick_elements(message='', pick_filter=None):
@@ -427,18 +430,21 @@ def pick_faces(message=''):
                      multiple=True)
 
 
-def pick_linkeds(message=''):
+def pick_linkeds(message='', pick_filter=None):
     """Selects linked elements.
 
     Args:
         message (str): The message to display when selecting linked elements.
+        pick_filter (object, optional): An object specifying the filter to apply
+            when picking elements. Default is None.
 
     Returns:
         (list[LinkedElement]): selected linked elements.
     """
     return _pick_obj(UI.Selection.ObjectType.LinkedElement,
                      message,
-                     multiple=True)
+                     multiple=True,
+                     selection_filter=pick_filter)
 
 
 def pick_point(message=''):

--- a/pyrevitlib/pyrevit/revit/selection.py
+++ b/pyrevitlib/pyrevit/revit/selection.py
@@ -434,7 +434,8 @@ def pick_linkeds(message='', pick_filter=None):
     """Selects linked elements.
 
     Args:
-        message (str): The message to display when selecting linked elements.
+        message (str, optional): The message to display when selecting
+            linked elements. Default is an empty string.
         pick_filter (object, optional): An object specifying the filter to apply
             when picking elements. Default is None.
 


### PR DESCRIPTION
## Description

minimal testscript

```python
from pyrevit import revit, DB, UI


class LinkedCategorySelectionFilter(UI.Selection.ISelectionFilter):
    def __init__(self, category_id):
        self.category_id = category_id

    def AllowElement(self, element):
        # Allow link instances so Revit lets us click into them
        return isinstance(element, DB.RevitLinkInstance)

    def AllowReference(self, reference, point):
        doc = revit.doc

        # Must be a linked reference
        if reference.LinkedElementId == DB.ElementId.InvalidElementId:
            return False

        link_instance = doc.GetElement(reference.ElementId)
        link_doc = link_instance.GetLinkDocument()

        if not link_doc:
            return False

        linked_element = link_doc.GetElement(reference.LinkedElementId)

        if linked_element and linked_element.Category:
            return linked_element.Category.Id == self.category_id

        return False


pick_filter = LinkedCategorySelectionFilter(DB.ElementId(DB.BuiltInCategory.OST_Walls))

print(revit.pick_linked(pick_filter=pick_filter))
print(revit.pick_linkeds(pick_filter=pick_filter))
```

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

