### PR TITLE
fix: resolve NameError 'forms' in events.py (fixes #3285)

### DIFF
--- a/pyrevitlib/pyrevit/revit/events.py
+++ b/pyrevitlib/pyrevit/revit/events.py
@@ -3,6 +3,7 @@
 from pyrevit import HOST_APP
 from pyrevit import EXEC_PARAMS, DB, UI
 from pyrevit import framework
+from pyrevit import forms
 from pyrevit import compat, PyRevitCPythonNotSupported
 from pyrevit.coreutils.logger import get_logger
 


### PR DESCRIPTION

### Description
This PR resolves a `NameError: global name 'forms' is not defined` that occurs in `pyrevit/revit/events.py` when certain tools (like Measure 3D) are executed for the first time in a clean session. 

### Details
Added missing `from pyrevit import forms` import to ensure the forms module is available within the events handler context.

Fixes #3285
