### PR TITLE
feat(keynotes): add type filters, usage badges, and real-time refresh

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/KeynoteManagerWindow.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/KeynoteManagerWindow.xaml
@@ -30,6 +30,12 @@
         <SolidColorBrush x:Key="UsedBadgeBgBrush"   Color="#E8F5E9"/>
         <SolidColorBrush x:Key="UsedBadgeFgBrush"   Color="#2E7D32"/>
         <SolidColorBrush x:Key="CatBadgeBrush"      Color="#333333"/>
+        <SolidColorBrush x:Key="TypeElBgBrush"      Color="#E3F2FD"/>
+        <SolidColorBrush x:Key="TypeElFgBrush"      Color="#1565C0"/>
+        <SolidColorBrush x:Key="TypeMatBgBrush"     Color="#FFF3E0"/>
+        <SolidColorBrush x:Key="TypeMatFgBrush"     Color="#E65100"/>
+        <SolidColorBrush x:Key="TypeUsrBgBrush"     Color="#F3E5F5"/>
+        <SolidColorBrush x:Key="TypeUsrFgBrush"     Color="#6A1B9A"/>
 
         <!-- ============================================================ -->
         <!-- BASE BUTTON STYLES                                           -->
@@ -218,6 +224,33 @@
                                 </TextBlock.Text>
                             </TextBlock>
                         </Border>
+                        <!-- Type: Element -->
+                        <Border x:Name="typElBadge" Visibility="Collapsed"
+                                Background="{StaticResource TypeElBgBrush}"
+                                CornerRadius="8" Padding="5,1,5,2"
+                                Margin="0,0,2,0">
+                            <TextBlock Text="Element"
+                                       Foreground="{StaticResource TypeElFgBrush}"
+                                       FontSize="9" FontWeight="SemiBold"/>
+                        </Border>
+                        <!-- Type: Material -->
+                        <Border x:Name="typMatBadge" Visibility="Collapsed"
+                                Background="{StaticResource TypeMatBgBrush}"
+                                CornerRadius="8" Padding="5,1,5,2"
+                                Margin="0,0,2,0">
+                            <TextBlock Text="Material"
+                                       Foreground="{StaticResource TypeMatFgBrush}"
+                                       FontSize="9" FontWeight="SemiBold"/>
+                        </Border>
+                        <!-- Type: User -->
+                        <Border x:Name="typUsrBadge" Visibility="Collapsed"
+                                Background="{StaticResource TypeUsrBgBrush}"
+                                CornerRadius="8" Padding="5,1,5,2"
+                                Margin="0,0,4,0">
+                            <TextBlock Text="User"
+                                       Foreground="{StaticResource TypeUsrFgBrush}"
+                                       FontSize="9" FontWeight="SemiBold"/>
+                        </Border>
                         <!-- Lock badge -->
                         <Border x:Name="lockBadge" Visibility="Collapsed"
                                 Background="{StaticResource WarningBrush}"
@@ -250,6 +283,15 @@
                     <Setter TargetName="lockBadge"  Property="Visibility" Value="Visible"/>
                     <Setter TargetName="textDisplay" Property="Foreground"
                             Value="{StaticResource TextMutedBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding has_element_type}" Value="True">
+                    <Setter TargetName="typElBadge" Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding has_material_type}" Value="True">
+                    <Setter TargetName="typMatBadge" Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding has_user_type}" Value="True">
+                    <Setter TargetName="typUsrBadge" Property="Visibility" Value="Visible"/>
                 </DataTrigger>
             </HierarchicalDataTemplate.Triggers>
         </HierarchicalDataTemplate>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/keynotesdb.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/keynotesdb.py
@@ -1,5 +1,6 @@
 """Module for managing keynotes using DeffrelDB."""
-#pylint: disable=E0401,W0613
+
+# pylint: disable=E0401,W0613
 import re
 import codecs
 from collections import defaultdict
@@ -14,32 +15,32 @@ from pyrevit.labs import DeffrelDB as dfdb
 
 from natsort import natsorted
 
-#pylint: disable=W0703,C0302
-mlogger = logger.get_logger(__name__)  #pylint: disable=C0103
+# pylint: disable=W0703,C0302
+mlogger = logger.get_logger(__name__)  # pylint: disable=C0103
 
 
-KEYNOTES_DB = 'keynotesdb'
-KEYNOTES_DB_DESC = 'pyRevit Keynotes Manager DB'
+KEYNOTES_DB = "keynotesdb"
+KEYNOTES_DB_DESC = "pyRevit Keynotes Manager DB"
 
-CATEGORIES_TABLE = 'categories'
-CATEGORIES_TABLE_DESC = 'Root Keynotes Table'
-CATEGORY_KEY_FIELD = 'cat_key'
-CATEGORY_TITLE_FIELD = 'cat_title'
+CATEGORIES_TABLE = "categories"
+CATEGORIES_TABLE_DESC = "Root Keynotes Table"
+CATEGORY_KEY_FIELD = "cat_key"
+CATEGORY_TITLE_FIELD = "cat_title"
 
-KEYNOTES_TABLE = 'keynotes'
-KEYNOTES_TABLE_DESC = 'Keynotes Table'
-KEYNOTES_KEY_FIELD = 'keynote_key'
-KEYNOTES_TEXT_FIELD = 'keynote_text'
-KEYNOTES_PARENTKEY_FIELD = 'parent_key'
-
-
-EDIT_MODE_ADD_CATEG = 'add-category'
-EDIT_MODE_EDIT_CATEG = 'edit-category'
-EDIT_MODE_ADD_KEYNOTE = 'add-keynote'
-EDIT_MODE_EDIT_KEYNOTE = 'edit-keynote'
+KEYNOTES_TABLE = "keynotes"
+KEYNOTES_TABLE_DESC = "Keynotes Table"
+KEYNOTES_KEY_FIELD = "keynote_key"
+KEYNOTES_TEXT_FIELD = "keynote_text"
+KEYNOTES_PARENTKEY_FIELD = "parent_key"
 
 
-CSI_REGEX = r' \d{2}(\s|[-_.])\d{2}(\s|[-_.])\d{2}'
+EDIT_MODE_ADD_CATEG = "add-category"
+EDIT_MODE_EDIT_CATEG = "edit-category"
+EDIT_MODE_ADD_KEYNOTE = "add-keynote"
+EDIT_MODE_EDIT_KEYNOTE = "edit-keynote"
+
+
+CSI_REGEX = r" \d{2}(\s|[-_.])\d{2}(\s|[-_.])\d{2}"
 
 
 class RKeynoteFilter(object):
@@ -60,14 +61,11 @@ class RKeynoteFilter(object):
 class RKeynoteRegexFilter(RKeynoteFilter):
     """Keynote smart regular expressions filter."""
 
-    def __init__(self,
-                 name="Regular Expression (Regex)",
-                 regex=None,
-                 negate=False):
+    def __init__(self, name="Regular Expression (Regex)", regex=None, negate=False):
         super(RKeynoteRegexFilter, self).__init__(
             name=(name + "{}").format(" [Exclude]" if negate else ""),
-            code=":notregex:" if negate else ":regex:"
-            )
+            code=":notregex:" if negate else ":regex:",
+        )
         self.regex = regex or ""
 
     def format_term(self, exst_term):
@@ -100,36 +98,38 @@ class RKeynoteFilters(object):
     ViewOnly = RKeynoteViewFilter()
     UseRegex = RKeynoteRegexFilter()
     UseRegexNegate = RKeynoteRegexFilter(negate=True)
-    UseCSI = RKeynoteRegexFilter(
-        name="CSI MasterFormat Division No.",
-        regex=CSI_REGEX
-        )
+    ElementOnly = RKeynoteFilter(name="Element Keynotes Only", code=":element:")
+    MaterialOnly = RKeynoteFilter(name="Material Keynotes Only", code=":material:")
+    UserOnly = RKeynoteFilter(name="User Keynotes Only", code=":user:")
+    UseCSI = RKeynoteRegexFilter(name="CSI MasterFormat Division No.", regex=CSI_REGEX)
     UseCSINegate = RKeynoteRegexFilter(
-        name="CSI MasterFormat Division No.",
-        regex=CSI_REGEX,
-        negate=True
-        )
+        name="CSI MasterFormat Division No.", regex=CSI_REGEX, negate=True
+    )
 
     @classmethod
     def get_available_filters(cls):
         """Get available keynote filters."""
-        return [cls.UsedOnly,
-                cls.UnusedOnly,
-                cls.LockedOnly,
-                cls.UnlockedOnly,
-                cls.ViewOnly,
-                cls.UseRegex,
-                cls.UseRegexNegate,
-                cls.UseCSI,
-                cls.UseCSINegate
-                ]
+        return [
+            cls.UsedOnly,
+            cls.UnusedOnly,
+            cls.LockedOnly,
+            cls.UnlockedOnly,
+            cls.ViewOnly,
+            cls.ElementOnly,
+            cls.MaterialOnly,
+            cls.UserOnly,
+            cls.UseRegex,
+            cls.UseRegexNegate,
+            cls.UseCSI,
+            cls.UseCSINegate,
+        ]
 
     @classmethod
     def remove_filters(cls, source_string):
         """Get available keynote filters."""
         cleaned = source_string
         for code in [x.code for x in cls.get_available_filters()]:
-            cleaned = cleaned.replace(code, '').strip()
+            cleaned = cleaned.replace(code, "").strip()
         return cleaned
 
 
@@ -139,28 +139,35 @@ class RKeynote(object):
     This object also has properties for the status of the keynote e.g.
     locked by another user or being used in the current model.
     """
-    def __init__(self, key, text, parent_key=None,
-                 locked=False, owner=None, children=None):
+
+    def __init__(
+        self, key, text, parent_key=None, locked=False, owner=None, children=None
+    ):
         self.key = key
         self.text = text
-        self.parent_key = parent_key or ''
+        self.parent_key = parent_key or ""
         self.locked = locked
-        self.owner = owner or ''
+        self.owner = owner or ""
         self._children = children or []
         self._filtered_children = []
         self._filter = None
-
+        self.used_types = set()  # {'Element', 'Material', 'User'}
+        self.has_element_type = False
+        self.has_material_type = False
+        self.has_user_type = False
         self.used = False
         self.used_count = 0
-        self.tooltip = 'Referenced on views:'
+        self.tooltip = "Referenced on views:"
 
     def __str__(self):
         return repr(self)
 
     def __repr__(self):
-        return '<%s key:%s childs:%s>' % (self.__class__.__name__,
-                                          self.key,
-                                          len(self.children))
+        return "<%s key:%s childs:%s>" % (
+            self.__class__.__name__,
+            self.key,
+            len(self.children),
+        )
 
     @property
     def children(self):
@@ -199,29 +206,33 @@ class RKeynote(object):
         elif RKeynoteFilters.UnlockedOnly.code in self._filter:
             self_pass = not self.locked
 
+        elif RKeynoteFilters.ElementOnly.code in self._filter:
+            self_pass = "Element" in self.used_types
+        elif RKeynoteFilters.MaterialOnly.code in self._filter:
+            self_pass = "Material" in self.used_types
+        elif RKeynoteFilters.UserOnly.code in self._filter:
+            self_pass = "User" in self.used_types
+
         cleaned_sfilter = RKeynoteFilters.remove_filters(self._filter)
         has_smart_filter = cleaned_sfilter != self._filter
 
         if cleaned_sfilter:
-            sterm = self.key + ' ' + self.text + ' ' + self.owner
+            sterm = self.key + " " + self.text + " " + self.owner
             sterm = sterm.lower()
 
             # here is where matching against the string happens
             if use_regex or use_regex_not:
                 # check if pattern is valid
                 try:
-                    self_pass = re.search(
-                        cleaned_sfilter,
-                        sterm,
-                        re.IGNORECASE
-                        )
+                    self_pass = re.search(cleaned_sfilter, sterm, re.IGNORECASE)
                 except Exception:
                     self_pass = False
                 if use_regex_not:
                     self_pass = not self_pass
             else:
-                self_pass_keyword = \
+                self_pass_keyword = (
                     coreutils.fuzzy_search_ratio(sterm, cleaned_sfilter) > 80
+                )
 
                 if has_smart_filter:
                     self_pass = self_pass_keyword and self_pass
@@ -229,27 +240,31 @@ class RKeynote(object):
                     self_pass = self_pass_keyword
 
         # filter children now
-        self._filtered_children = \
-            [x for x in self._children if x.filter(self._filter)]
+        self._filtered_children = [x for x in self._children if x.filter(self._filter)]
 
         return self_pass or self._filtered_children
 
-    def update_used(self, used_keysdict, doc=None):
+    def update_used(self, used_keysdict, used_typesdict=None, doc=None):
         doc = doc or DOCS.doc
-        # update count, and tooltip
+        used_typesdict = used_typesdict or {}
+        # update count, tooltip, and usage types
         if self.key in used_keysdict:
             self.used = True
             self.used_count = len(used_keysdict[self.key])
+            self.used_types = set(used_typesdict.get(self.key, []))
+            self.has_element_type = "Element" in self.used_types
+            self.has_material_type = "Material" in self.used_types
+            self.has_user_type = "User" in self.used_types
             for keyid in used_keysdict[self.key]:
                 kel = doc.GetElement(keyid)
                 if not kel:
                     continue
                 owner_view = doc.GetElement(kel.OwnerViewId)
                 view_name = revit.query.get_name(owner_view)
-                self.tooltip += '\n' + view_name
+                self.tooltip += "\n" + view_name
 
         for crkey in self._children:
-            crkey.update_used(used_keysdict)
+            crkey.update_used(used_keysdict, used_typesdict)
 
     def collect_keys(self):
         keys = {self.key, self.parent_key}
@@ -263,7 +278,7 @@ def _verify_keynotesdb_def(conn):
     try:
         conn.ReadDB(KEYNOTES_DB)
     except Exception as dbex:
-        mlogger.debug('Keynotes db read failed | %s', dbex)
+        mlogger.debug("Keynotes db read failed | %s", dbex)
         dbdef = dfdb.DatabaseDefinition()
         dbdef.Description = KEYNOTES_DB_DESC
         conn.CreateDB(KEYNOTES_DB, dbdef)
@@ -272,7 +287,7 @@ def _verify_keynotesdb_def(conn):
     try:
         conn.ReadTable(KEYNOTES_DB, CATEGORIES_TABLE)
     except Exception as cattex:
-        mlogger.debug('Category table read failed | %s', cattex)
+        mlogger.debug("Category table read failed | %s", cattex)
         cat_key = dfdb.TextField(CATEGORY_KEY_FIELD)
         cat_title = dfdb.TextField(CATEGORY_TITLE_FIELD)
         cat_table_def = dfdb.TableDefinition()
@@ -284,12 +299,11 @@ def _verify_keynotesdb_def(conn):
         cat_table_def.Description = CATEGORIES_TABLE_DESC
         conn.CreateTable(KEYNOTES_DB, CATEGORIES_TABLE, cat_table_def)
 
-
     # verify keynote table
     try:
         conn.ReadTable(KEYNOTES_DB, KEYNOTES_TABLE)
     except Exception as ktex:
-        mlogger.debug('keynote table read failed | %s', ktex)
+        mlogger.debug("keynote table read failed | %s", ktex)
         keynote_key = dfdb.TextField(KEYNOTES_KEY_FIELD)
         keynote_text = dfdb.TextField(KEYNOTES_TEXT_FIELD)
         keynote_parent_key = dfdb.TextField(KEYNOTES_PARENTKEY_FIELD)
@@ -298,12 +312,11 @@ def _verify_keynotesdb_def(conn):
         keynotes_table_def.SupportsHistory = False
         keynotes_table_def.EncapsulateValues = False
         keynotes_table_def.SupportsHeaders = False
-        keynotes_table_def.Fields = \
-            [keynote_key, keynote_text, keynote_parent_key]
+        keynotes_table_def.Fields = [keynote_key, keynote_text, keynote_parent_key]
         # wiring the keynotes primary key
         keynotes_table_def.Wires = [
             dfdb.Wire(KEYNOTES_PARENTKEY_FIELD, CATEGORY_KEY_FIELD),
-            dfdb.Wire(KEYNOTES_PARENTKEY_FIELD, KEYNOTES_KEY_FIELD)
+            dfdb.Wire(KEYNOTES_PARENTKEY_FIELD, KEYNOTES_KEY_FIELD),
         ]
         keynotes_table_def.Description = KEYNOTES_TABLE_DESC
         conn.CreateTable(KEYNOTES_DB, KEYNOTES_TABLE, keynotes_table_def)
@@ -314,11 +327,11 @@ def connect(keynotes_file, username=None):
     conn = dfdb.DataBase.Connect(
         keynotes_file,
         username or HOST_APP.username,
-        sourceEncoding=framework.Encoding.GetEncoding('utf-16')
-        )
-    mlogger.debug('verifying db schemas...')
+        sourceEncoding=framework.Encoding.GetEncoding("utf-16"),
+    )
+    mlogger.debug("verifying db schemas...")
     _verify_keynotesdb_def(conn)
-    mlogger.debug('verifying db schemas completed.')
+    mlogger.debug("verifying db schemas completed.")
     return conn
 
 
@@ -329,7 +342,7 @@ class BulkAction(object):
     def __init__(self, conn, target=KEYNOTES_DB):
         self._conn = conn
         self._target = target
-    
+
     def __enter__(self):
         self._conn.BEGIN(self._target)
 
@@ -346,35 +359,46 @@ def get_locks(conn):
 
 def get_categories(conn):
     db_locks = get_locks(conn)
-    locked_records = {x.LockTargetRecordKey: x.LockRequester
-                      for x in db_locks if x.IsRecordLock}
+    locked_records = {
+        x.LockTargetRecordKey: x.LockRequester for x in db_locks if x.IsRecordLock
+    }
     cats_records = conn.ReadAllRecords(KEYNOTES_DB, CATEGORIES_TABLE)
     return natsorted(
-        [RKeynote(
-            key=x[CATEGORY_KEY_FIELD],
-            text=x[CATEGORY_TITLE_FIELD] or '',
-            parent_key='',
-            locked=x[CATEGORY_KEY_FIELD] in locked_records.keys(),
-            owner=locked_records.get(x[CATEGORY_KEY_FIELD], ''),
-            children=[]
+        [
+            RKeynote(
+                key=x[CATEGORY_KEY_FIELD],
+                text=x[CATEGORY_TITLE_FIELD] or "",
+                parent_key="",
+                locked=x[CATEGORY_KEY_FIELD] in locked_records.keys(),
+                owner=locked_records.get(x[CATEGORY_KEY_FIELD], ""),
+                children=[],
             )
-         for x in cats_records], key=lambda x: x.key)
+            for x in cats_records
+        ],
+        key=lambda x: x.key,
+    )
 
 
 def get_keynotes(conn):
     db_locks = get_locks(conn)
-    locked_records = {x.LockTargetRecordKey: x.LockRequester
-                      for x in db_locks if x.IsRecordLock}
+    locked_records = {
+        x.LockTargetRecordKey: x.LockRequester for x in db_locks if x.IsRecordLock
+    }
     keynote_records = conn.ReadAllRecords(KEYNOTES_DB, KEYNOTES_TABLE)
     return natsorted(
-        [RKeynote(
-            key=x[KEYNOTES_KEY_FIELD],
-            text=x[KEYNOTES_TEXT_FIELD] or '',
-            parent_key=x[KEYNOTES_PARENTKEY_FIELD],
-            locked=x[KEYNOTES_KEY_FIELD] in locked_records.keys(),
-            owner=locked_records.get(x[KEYNOTES_KEY_FIELD], ''),
-            children=[])
-         for x in keynote_records], key=lambda x: x.key)
+        [
+            RKeynote(
+                key=x[KEYNOTES_KEY_FIELD],
+                text=x[KEYNOTES_TEXT_FIELD] or "",
+                parent_key=x[KEYNOTES_PARENTKEY_FIELD],
+                locked=x[KEYNOTES_KEY_FIELD] in locked_records.keys(),
+                owner=locked_records.get(x[KEYNOTES_KEY_FIELD], ""),
+                children=[],
+            )
+            for x in keynote_records
+        ],
+        key=lambda x: x.key,
+    )
 
 
 def get_keynotes_tree(conn):
@@ -390,10 +414,7 @@ def get_keynotes_tree(conn):
     for catroot_rkey in keynote_records:
         if catroot_rkey.key in parents:
             catroot_rkey.children.extend(
-                natsorted(
-                    parents[catroot_rkey.key],
-                    key=lambda x: x.key
-                )
+                natsorted(parents[catroot_rkey.key], key=lambda x: x.key)
             )
 
     return natsorted(cat_roots, key=lambda x: x.key)
@@ -430,21 +451,18 @@ def release_key(conn, key, category=False):
 
 
 def add_category(conn, key, text):
-    conn.InsertRecord(KEYNOTES_DB,
-                      CATEGORIES_TABLE,
-                      key,
-                      {CATEGORY_TITLE_FIELD: text})
+    conn.InsertRecord(KEYNOTES_DB, CATEGORIES_TABLE, key, {CATEGORY_TITLE_FIELD: text})
     return RKeynote(key=key, text=text)
 
 
 def update_category_title(conn, key, new_title):
-    conn.UpdateRecord(KEYNOTES_DB, CATEGORIES_TABLE, key,
-                      {CATEGORY_TITLE_FIELD: new_title})
+    conn.UpdateRecord(
+        KEYNOTES_DB, CATEGORIES_TABLE, key, {CATEGORY_TITLE_FIELD: new_title}
+    )
 
 
 def update_category_key(conn, key, new_key):
-    conn.UpdateRecord(KEYNOTES_DB, CATEGORIES_TABLE, key,
-                      {CATEGORY_KEY_FIELD: new_key})
+    conn.UpdateRecord(KEYNOTES_DB, CATEGORIES_TABLE, key, {CATEGORY_KEY_FIELD: new_key})
 
 
 def mark_category_under_edited(conn, key):
@@ -463,18 +481,13 @@ def add_keynote(conn, key, text, parent_key):
         KEYNOTES_DB,
         KEYNOTES_TABLE,
         key,
-        {KEYNOTES_TEXT_FIELD: text,
-         KEYNOTES_PARENTKEY_FIELD: parent_key}
-        )
+        {KEYNOTES_TEXT_FIELD: text, KEYNOTES_PARENTKEY_FIELD: parent_key},
+    )
     return RKeynote(key=key, text=text, parent_key=parent_key)
 
 
 def remove_keynote(conn, key):
-    conn.DropRecord(
-        KEYNOTES_DB,
-        KEYNOTES_TABLE,
-        key
-        )
+    conn.DropRecord(KEYNOTES_DB, KEYNOTES_TABLE, key)
 
 
 def mark_keynote_under_edited(conn, key):
@@ -482,30 +495,17 @@ def mark_keynote_under_edited(conn, key):
 
 
 def update_keynote_text(conn, key, text):
-    conn.UpdateRecord(
-        KEYNOTES_DB,
-        KEYNOTES_TABLE,
-        key,
-        {KEYNOTES_TEXT_FIELD: text}
-        )
+    conn.UpdateRecord(KEYNOTES_DB, KEYNOTES_TABLE, key, {KEYNOTES_TEXT_FIELD: text})
 
 
 def update_keynote_key(conn, key, new_key):
-    conn.UpdateRecord(
-        KEYNOTES_DB,
-        KEYNOTES_TABLE,
-        key,
-        {KEYNOTES_KEY_FIELD: new_key}
-        )
+    conn.UpdateRecord(KEYNOTES_DB, KEYNOTES_TABLE, key, {KEYNOTES_KEY_FIELD: new_key})
 
 
 def move_keynote(conn, key, new_parent):
     conn.UpdateRecord(
-        KEYNOTES_DB,
-        KEYNOTES_TABLE,
-        key,
-        {KEYNOTES_PARENTKEY_FIELD: new_parent}
-        )
+        KEYNOTES_DB, KEYNOTES_TABLE, key, {KEYNOTES_PARENTKEY_FIELD: new_parent}
+    )
 
 
 # import export ---------------------------------------------------------------
@@ -514,8 +514,8 @@ def move_keynote(conn, key, new_parent):
 def _import_keynotes_from_lines(conn, lines, skip_dup=False):
     for line in lines:
         clean_line = line.strip()
-        if not clean_line.startswith('#'):
-            fields = clean_line.split('\t')
+        if not clean_line.startswith("#"):
+            fields = clean_line.split("\t")
             if len(fields) == 1:
                 # add category with empty title
                 if fields[0]:
@@ -526,8 +526,7 @@ def _import_keynotes_from_lines(conn, lines, skip_dup=False):
                             pass
                         else:
                             raise cataddex
-            elif len(fields) == 2 \
-                    or (len(fields) == 3 and not fields[2]):
+            elif len(fields) == 2 or (len(fields) == 3 and not fields[2]):
                 # add category
                 if fields[0]:
                     try:
@@ -551,38 +550,40 @@ def _import_keynotes_from_lines(conn, lines, skip_dup=False):
 
 def import_legacy_keynotes(conn, src_legacy_keynotes_file, skip_dup=False):
     # determine encoding
-    encodings = ['Windows-1252', 'ISO-8859-1', 'ascii']
-    if coreutils.check_encoding_bom(src_legacy_keynotes_file,
-                                    bom_bytes=codecs.BOM_UTF16):
-        encodings = ['utf_16_le']
-    elif coreutils.check_encoding_bom(src_legacy_keynotes_file,
-                                      bom_bytes=codecs.BOM_UTF8):
-        encodings = ['utf-8']
+    encodings = ["Windows-1252", "ISO-8859-1", "ascii"]
+    if coreutils.check_encoding_bom(
+        src_legacy_keynotes_file, bom_bytes=codecs.BOM_UTF16
+    ):
+        encodings = ["utf_16_le"]
+    elif coreutils.check_encoding_bom(
+        src_legacy_keynotes_file, bom_bytes=codecs.BOM_UTF8
+    ):
+        encodings = ["utf-8"]
 
     last_encoding_idx = len(encodings) - 1
     for idx, encoding in enumerate(encodings):
         try:
             mlogger.debug(
-                'Attempt to open keynote file with \"%s\" encoding...',
-                encoding
-                )
+                'Attempt to open keynote file with "%s" encoding...', encoding
+            )
             knote_lines = None
-            with codecs.open(src_legacy_keynotes_file, 'r', encoding) \
-                    as legacy_kfile:
+            with codecs.open(src_legacy_keynotes_file, "r", encoding) as legacy_kfile:
                 knote_lines = legacy_kfile.readlines()
                 break
         except Exception:
             if idx == last_encoding_idx:
-                mlogger.debug('Failed opening : %s', src_legacy_keynotes_file)
-                raise Exception('Unknown file encoding. Supported encodings '
-                                'are ASCII, UTF-8, and UTF-16 (UCS-2 LE)')
+                mlogger.debug("Failed opening : %s", src_legacy_keynotes_file)
+                raise Exception(
+                    "Unknown file encoding. Supported encodings "
+                    "are ASCII, UTF-8, and UTF-16 (UCS-2 LE)"
+                )
             else:
                 continue
 
     if knote_lines:
         conn.BEGIN(KEYNOTES_DB)
         try:
-            mlogger.debug('Importing categories and keynotes...')
+            mlogger.debug("Importing categories and keynotes...")
             _import_keynotes_from_lines(conn, knote_lines, skip_dup=skip_dup)
         finally:
             conn.END()
@@ -594,21 +595,21 @@ def export_legacy_keynotes(conn, dest_legacy_keynotes_file, include_keys=None):
     keynotes = get_keynotes(conn)
 
     if include_keys:
-        with codecs.open(dest_legacy_keynotes_file, 'w', 'utf_16') as lkfile:
+        with codecs.open(dest_legacy_keynotes_file, "w", "utf_16") as lkfile:
             for cat in categories:
                 if cat.key in include_keys:
-                    lkfile.write('{}\t{}\n'.format(cat.key, cat.text))
+                    lkfile.write("{}\t{}\n".format(cat.key, cat.text))
             for knote in keynotes:
                 if knote.key in include_keys:
-                    lkfile.write('{}\t{}\t{}\n'
-                                 .format(knote.key,
-                                         knote.text,
-                                         knote.parent_key))
+                    lkfile.write(
+                        "{}\t{}\t{}\n".format(knote.key, knote.text, knote.parent_key)
+                    )
 
     else:
-        with codecs.open(dest_legacy_keynotes_file, 'w', 'utf_16') as lkfile:
+        with codecs.open(dest_legacy_keynotes_file, "w", "utf_16") as lkfile:
             for cat in categories:
-                lkfile.write('{}\t{}\n'.format(cat.key, cat.text))
+                lkfile.write("{}\t{}\n".format(cat.key, cat.text))
             for knote in keynotes:
-                lkfile.write('{}\t{}\t{}\n'
-                             .format(knote.key, knote.text, knote.parent_key))
+                lkfile.write(
+                    "{}\t{}\t{}\n".format(knote.key, knote.text, knote.parent_key)
+                )

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Keynotes.pushbutton/script.py
@@ -31,7 +31,7 @@ from pyrevit import forms
 from pyrevit import script
 
 from pyrevit.framework import System, Windows
-from System.Windows.Interop import WindowInteropHelper, HwndSource
+from System.Windows.Interop import WindowInteropHelper
 from System.Diagnostics import Process as SysProcess
 from System.Windows.Threading import DispatcherTimer
 from System import TimeSpan
@@ -517,18 +517,8 @@ class KeynoteManagerWindow(forms.WPFWindow):
         except Exception as ex:
             logger.debug("WindowInteropHelper failed | %s" % ex)
 
-        # Hook WndProc to intercept WM_MOUSEACTIVATE — prevents the
-        # re-entrant activation crash when clicking between Revit and
-        # this modeless window.
-        self._hwnd_source = None
-        self._activation_pending = False
-        # Pre-cache .NET types — IronPython cannot resolve System.IntPtr
-        # or System.Action from inside a Win32 WndProc callback
-        # (LookupGlobalInstruction crash in HwndSubclass.SubclassWndProc).
-        self._intptr_zero = System.IntPtr.Zero
-        self._intptr_ma_noactivate = System.IntPtr(self.MA_NOACTIVATE)
-        self._bg_priority = Windows.Threading.DispatcherPriority.Background
-        self.SourceInitialized += self._on_source_initialized
+        # Modeless focus management — keep window always on top of Revit.
+        self.Topmost = True
 
         self._kfile = None
         self._kfile_handler = None
@@ -541,7 +531,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         self._cache = []
         self._needs_update = False
         self._config = script.get_config()
-        self._used_keysdict = self.get_used_keynote_elements()
+        self._used_keysdict = defaultdict(list)
+        self._used_typesdict = defaultdict(set)
+        try:
+            self._used_keysdict, self._used_typesdict = self.get_used_keynote_elements()
+        except Exception:
+            pass
 
         # drag state
         self._drag_start_point = None
@@ -554,6 +549,20 @@ class KeynoteManagerWindow(forms.WPFWindow):
         # Wait 300ms after last keystroke before filtering.
         self._search_timer.Interval = TimeSpan.FromMilliseconds(300)
         self._search_timer.Tick += self._on_search_timer_tick
+
+        # Auto-refresh — subscribe to Revit's DocumentChanged event
+        # so usage counts and type filters update instantly.
+        self._refresh_pending = False
+        self._doc_changed_app = None
+        try:
+            self._doc_changed_app = HOST_APP.uiapp.Application
+            self._doc_changed_app.DocumentChanged += self._on_doc_changed
+        except Exception:
+            try:
+                self._doc_changed_app = HOST_APP.app
+                self._doc_changed_app.DocumentChanged += self._on_doc_changed
+            except Exception:
+                self._doc_changed_app = None
 
         self.load_config(reset_config)
         self._update_full_tree()
@@ -662,57 +671,6 @@ class KeynoteManagerWindow(forms.WPFWindow):
         Optional callback runs on the WPF thread after the action."""
         _ext_handler.queue(action, callback, self)
         _ext_event.Raise()
-
-    # =========================================================================
-    # MODELESS FOCUS MANAGEMENT (WndProc hook)
-    # =========================================================================
-
-    WM_MOUSEACTIVATE = 0x0021
-    MA_NOACTIVATE = 3
-
-    def _on_source_initialized(self, sender, args):
-        """Hook into the Win32 message loop once the HWND exists."""
-        try:
-            wih = WindowInteropHelper(self)
-            self._hwnd_source = HwndSource.FromHwnd(wih.Handle)
-            if self._hwnd_source:
-                # Cache the Action delegate — must be done after __init__
-                # so self._safe_activate is bound
-                self._activate_action = System.Action(self._safe_activate)
-                self._hwnd_source.AddHook(self._wnd_proc)
-        except Exception as ex:
-            logger.debug("HwndSource hook failed | %s" % ex)
-
-    def _wnd_proc(self, hwnd, msg, wParam, lParam, handled):
-        """Win32 WndProc hook — intercept activation messages.
-        CRITICAL: Do not resolve .NET types/delegates by name here
-        (for example System.IntPtr or System.Action); use cached
-        members/delegates instead. Callback parameters and constants
-        are safe to use inside this native Win32 callback."""
-        try:
-            if msg == self.WM_MOUSEACTIVATE:
-                handled.Value = True
-                if not self._activation_pending:
-                    self._activation_pending = True
-                    try:
-                        self.Dispatcher.BeginInvoke(
-                            self._activate_action, self._bg_priority
-                        )
-                    except Exception:
-                        self._activation_pending = False
-                return self._intptr_ma_noactivate
-        except Exception:
-            pass  # WndProc must NEVER throw
-        return self._intptr_zero
-
-    def _safe_activate(self):
-        """Deferred activation — runs when Revit's message loop is idle."""
-        self._activation_pending = False
-        try:
-            if self.IsLoaded and self.IsVisible:
-                self.Activate()
-        except Exception as ex:
-            logger.debug("Deferred activation failed | %s" % ex)
 
     # =========================================================================
     # TREE STATE PRESERVATION
@@ -835,18 +793,33 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def get_used_keynote_elements(self):
         used = defaultdict(list)
+        used_types = defaultdict(set)
         try:
-            for kn in revit.query.get_used_keynotes(doc=revit.doc):
+            keynotes = revit.query.get_used_keynotes(doc=revit.doc)
+            if not keynotes:
+                return used, used_types
+            for kn in keynotes:
                 if kn is None:
                     continue
                 p = kn.Parameter[DB.BuiltInParameter.KEY_VALUE]
-                if p:
-                    key = p.AsString()
-                    if key:
-                        used[key].append(kn.Id)
-        except Exception as ex:
-            logger.debug("get_used_keynotes failed | %s" % ex)
-        return used
+                if not p:
+                    continue
+                key = p.AsString()
+                if not key:
+                    continue
+                used[key].append(kn.Id)
+                # Detect keynote type from the tag's source param
+                try:
+                    src = kn.Parameter[DB.BuiltInParameter.KEY_SOURCE_PARAM]
+                    if src and src.HasValue:
+                        val = src.AsString()
+                        if val:
+                            used_types[key].add(val)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        return used, used_types
 
     # =========================================================================
     # CONFIG
@@ -1115,7 +1088,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
         # Mark used
         for node in tree:
-            node.update_used(self._used_keysdict)
+            node.update_used(self._used_keysdict, self._used_typesdict)
 
         # Cache for fast re-filter
         self._cache = list(tree)
@@ -1359,19 +1332,19 @@ class KeynoteManagerWindow(forms.WPFWindow):
         """Swap Revit element references between two keynote keys."""
         temp = "__ref_{}__".format(uuid.uuid4().hex[:8])
         with revit.Transaction("Reorder Keynotes"):
-            for kid in self.get_used_keynote_elements().get(key_a, []):
+            for kid in self._used_keysdict.get(key_a, []):
                 kel = revit.doc.GetElement(kid)
                 if kel:
                     p = kel.Parameter[DB.BuiltInParameter.KEY_VALUE]
                     if p:
                         p.Set(temp)
-            for kid in self.get_used_keynote_elements().get(key_b, []):
+            for kid in self._used_keysdict.get(key_b, []):
                 kel = revit.doc.GetElement(kid)
                 if kel:
                     p = kel.Parameter[DB.BuiltInParameter.KEY_VALUE]
                     if p:
                         p.Set(key_a)
-            for kid in self.get_used_keynote_elements().get(key_a, []):
+            for kid in self._used_keysdict.get(key_a, []):
                 kel = revit.doc.GetElement(kid)
                 if kel:
                     p = kel.Parameter[DB.BuiltInParameter.KEY_VALUE]
@@ -1435,6 +1408,39 @@ class KeynoteManagerWindow(forms.WPFWindow):
         """Fires when the user stops typing."""
         self._search_timer.Stop()
         self._update_full_tree(fast_filter=True)
+
+    def _on_doc_changed(self, sender, args):
+        """Fires on the Revit thread after any document change.
+        Refreshes keynote usage data and updates the tree."""
+        if self._refresh_pending:
+            return
+        self._refresh_pending = True
+
+        # Collect data on the Revit thread (we have API access here)
+        try:
+            new_used, new_types = self.get_used_keynote_elements()
+        except Exception:
+            self._refresh_pending = False
+            return
+
+        # Dispatch UI update to WPF thread
+        def _update_ui():
+            try:
+                self._used_keysdict = new_used
+                self._used_typesdict = new_types
+                self._update_full_tree()
+                self._update_status_bar()
+            except Exception:
+                pass
+            self._refresh_pending = False
+
+        try:
+            self.Dispatcher.BeginInvoke(
+                System.Action(_update_ui),
+                Windows.Threading.DispatcherPriority.Background,
+            )
+        except Exception:
+            self._refresh_pending = False
 
     def clear_search(self, sender, args):
         self.search_tb.Text = ""
@@ -1650,7 +1656,12 @@ class KeynoteManagerWindow(forms.WPFWindow):
         if self._conn:
 
             def _query_used():
-                self._used_keysdict = self.get_used_keynote_elements()
+                try:
+                    self._used_keysdict, self._used_typesdict = (
+                        self.get_used_keynote_elements()
+                    )
+                except Exception:
+                    pass
 
             def _on_done():
                 self._update_full_tree()
@@ -1821,7 +1832,7 @@ class KeynoteManagerWindow(forms.WPFWindow):
 
     def _rekey_refs(self, from_key, to_key):
         with revit.Transaction("Re-Key {}".format(from_key)):
-            for kid in self.get_used_keynote_elements().get(from_key, []):
+            for kid in self._used_keysdict.get(from_key, []):
                 kel = revit.doc.GetElement(kid)
                 if kel:
                     p = kel.Parameter[DB.BuiltInParameter.KEY_VALUE]
@@ -1920,23 +1931,52 @@ class KeynoteManagerWindow(forms.WPFWindow):
             return
         sel_key = sel.key
         postcmd = self.postable_keynote_command
-        self.Close()
 
         def _do():
             keynotes_cat = revit.query.get_category(DB.BuiltInCategory.OST_KeynoteTags)
-            if keynotes_cat:
-                def_id = revit.doc.GetDefaultFamilyTypeId(keynotes_cat.Id)
-                if revit.doc.GetElement(def_id):
-                    DocumentEventUtils.PostCommandAndUpdateNewElementProperties(
-                        HOST_APP.uiapp,
-                        revit.doc,
-                        postcmd,
-                        "Update Keynotes",
-                        DB.BuiltInParameter.KEY_VALUE,
-                        sel_key,
-                    )
+            if not keynotes_cat:
+                self._place_result = "no_family"
+                return
+            def_id = revit.doc.GetDefaultFamilyTypeId(keynotes_cat.Id)
+            if not def_id or not revit.doc.GetElement(def_id):
+                self._place_result = "no_family"
+                return
+            self._place_result = "ok"
+            DocumentEventUtils.PostCommandAndUpdateNewElementProperties(
+                HOST_APP.uiapp,
+                revit.doc,
+                postcmd,
+                "Update Keynotes",
+                DB.BuiltInParameter.KEY_VALUE,
+                sel_key,
+            )
 
-        self._revit_run(_do)
+        def _on_placed():
+            result = getattr(self, "_place_result", None)
+            if result == "no_family":
+                forms.alert(
+                    "No Keynote Tag family is loaded in this project.\n\n"
+                    "Please load a Keynote Tag family from the library "
+                    "before placing keynotes.",
+                    title="Keynote Tag Missing",
+                )
+                return
+            try:
+                self._used_keysdict, self._used_typesdict = (
+                    self.get_used_keynote_elements()
+                )
+            except Exception:
+                pass
+            self._update_full_tree()
+            self._update_status_bar()
+            # Re-assert visibility — Revit steals focus on PostCommand
+            try:
+                self.Topmost = True
+                self.Activate()
+            except Exception:
+                pass
+
+        self._revit_run(_do, callback=_on_placed)
 
     # =========================================================================
     # FILE OPERATIONS
@@ -1956,7 +1996,9 @@ class KeynoteManagerWindow(forms.WPFWindow):
             self._connect_kfile()
             self._needs_update = True
             try:
-                self._used_keysdict = self.get_used_keynote_elements()
+                self._used_keysdict, self._used_typesdict = (
+                    self.get_used_keynote_elements()
+                )
             except Exception as ex:
                 logger.debug("Refresh used keys failed | %s" % ex)
             self._update_full_tree()
@@ -2047,14 +2089,11 @@ class KeynoteManagerWindow(forms.WPFWindow):
                 return
 
         # Proceed with cleanup
-        # Remove WndProc hook to prevent leaks
-        if self._hwnd_source:
+        if self._doc_changed_app:
             try:
-                self._hwnd_source.RemoveHook(self._wnd_proc)
+                self._doc_changed_app.DocumentChanged -= self._on_doc_changed
             except Exception:
                 pass
-            self._hwnd_source = None
-
         if self._kfile_handler == "adc":
             try:
                 adc.unlock_file(self._kfile_ext)


### PR DESCRIPTION
# feat(keynotes): Add keynote type filters, usage badges, and real-time refresh

## Description

Implements the feature requests from issue #1714 — adds keynote type filtering, usage type badges, and real-time usage tracking to the Keynote Manager.

**Keynote Type Filters:** Three new filters in the filter dropdown — "Element Keynotes Only", "Material Keynotes Only", "User Keynotes Only" — that filter the tree to show only keynotes placed with the corresponding tag type. Uses `KEY_SOURCE_PARAM` to detect the placement type.

**Usage Type Badges:** Color-coded badges next to the existing `[3x]` usage count showing how each keynote is used. Element = blue, Material = amber, User = purple. A keynote placed as both Element and User shows `[3x] [Element] [User]`. Badges auto-update in real-time.

**Real-Time Refresh:** Subscribes to Revit's `DocumentChanged` event so the tree, usage counts, type badges, and filters update instantly when keynotes are placed, deleted, or modified — no manual refresh needed.

**Additional Improvements:**
- Window stays always on top (`Topmost = True`) — no more losing the manager behind Revit
- Window persists through Place Keynote — no close/hide, users can keep it on a second monitor
- Warning alert when no Keynote Tag family is loaded in the project
- Crash guard for models with no keynotes placed
- Removed WndProc native hook entirely — eliminates the IronPython `LookupGlobalInstruction` crash in `HwndSubclass.SubclassWndProc` that occurred when clicking between Revit and the modeless window

### Files changed

- **`keynotesdb.py`** — Added `ElementOnly`, `MaterialOnly`, `UserOnly` filter definitions in `RKeynoteFilters`; added `has_element_type`, `has_material_type`, `has_user_type` boolean attributes to `RKeynote`; updated `update_used()` to accept and propagate `used_typesdict`; added type filter matching in `filter()`
- **`script.py`** — `get_used_keynote_elements()` now returns `(used_dict, types_dict)` tuple reading `KEY_SOURCE_PARAM`; `DocumentChanged` event subscription for real-time refresh; `place_keynote()` keeps window visible with missing family warning; `Topmost = True`; removed WndProc hook and all associated pre-cached .NET types
- **`KeynoteManagerWindow.xaml`** — Added type badge color brushes (blue/amber/purple); three type badge `Border` elements in the tree item template; `DataTrigger` bindings for `has_element_type`, `has_material_type`, `has_user_type`

---

## Checklist

- [x] Code follows the [[PEP 8](https://peps.python.org/pep-0008/)](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [[Black](https://github.com/psf/black)](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

- Resolves #1714 — Keynote Manager: add filter for keynote type (User, Element, Material)

---

## Additional Notes

### Testing performed

- Placed Element, Material, and User keynotes → type badges appear with correct colors
- Applied "Element Keynotes Only" filter → only Element-tagged keynotes shown
- Placed new keynote while manager open → tree updates within 1 second via DocumentChanged
- Opened manager on model with no keynotes → no crash, filters show empty (correct)
- Clicked between Revit and manager window repeatedly → no crash (WndProc removed)
- Place Keynote button → window stays visible, auto-refreshes after placement
- Place Keynote with no tag family loaded → warning alert shown

### KEY_SOURCE_PARAM values

Confirmed via Revit API testing that `DB.BuiltInParameter.KEY_SOURCE_PARAM` returns:
- `"Element"` for Element keynote tags
- `"Material"` for Material keynote tags  
- `"User"` for User keynote tags

---

Thank you for contributing to pyRevit! 🎉