### PR TITLE
fix: restore module globals in execute_in_revit_context before ExternalEvent fires

### DIFF
--- a/pyrevitlib/pyrevit/revit/events.py
+++ b/pyrevitlib/pyrevit/revit/events.py
@@ -1,5 +1,6 @@
 """Revit events handler management."""
 #pylint: disable=unused-argument
+from six.moves import queue
 from pyrevit import HOST_APP
 from pyrevit import EXEC_PARAMS, DB, UI
 from pyrevit import framework
@@ -143,19 +144,25 @@ def stop_events():
 
 class _GenericExternalEventHandler(UI.IExternalEventHandler):
     def __init__(self):
-        self.func = None
-        self.args = ()
-        self.kwargs = {}
+        self._queue = queue.Queue()
 
     def Execute(self, uiapp):
         try:
-            if self.func:
-                self.func(*self.args, **self.kwargs)
-        except Exception as ex:
-            mlogger.error("ExternalEvent error: {}".format(ex))
+            while True:
+                fn = self._queue.get_nowait()
+                try:
+                    fn()
+                except Exception as ex:
+                    mlogger.error("ExternalEvent error: {}".format(ex))
+        except queue.Empty:
+            pass
 
     def GetName(self):
         return "GenericExternalEventHandler"
+
+    def schedule(self, func):
+        self._queue.put(func)
+
 
 if compat.IRONPY:
     _HANDLER = _GenericExternalEventHandler()
@@ -213,14 +220,26 @@ def execute_in_revit_context(func, *args, **kwargs):
         if type(v) is _module_type
     }
 
-    def _func_with_modules(*a, **kw):
+    def _wrapper():
+        # types.FunctionType with closures is not supported in IronPython 2,
+        # so we do a bounded mutation: save, patch, call, restore.
+        _MISSING = object()
         g = func.__globals__
-        for k, v in _saved_modules.items():
-            if k not in g:
-                g[k] = v
-        return func(*a, **kw)
+        saved = {
+            k: g.get(k, _MISSING)
+            for k in _saved_modules
+            if k not in g or g[k] is None
+        }
+        for k in saved:
+            g[k] = _saved_modules[k]
+        try:
+            func(*args, **kwargs)
+        finally:
+            for k, old in saved.items():
+                if old is _MISSING:
+                    g.pop(k, None)
+                else:
+                    g[k] = old
 
-    _HANDLER.func = _func_with_modules
-    _HANDLER.args = args
-    _HANDLER.kwargs = kwargs
+    _HANDLER.schedule(_wrapper)
     _EXTERNAL_EVENT.Raise()

--- a/pyrevitlib/pyrevit/revit/events.py
+++ b/pyrevitlib/pyrevit/revit/events.py
@@ -1,6 +1,6 @@
 """Revit events handler management."""
 #pylint: disable=unused-argument
-from six.moves import queue
+from collections import deque
 from pyrevit import HOST_APP
 from pyrevit import EXEC_PARAMS, DB, UI
 from pyrevit import framework
@@ -144,24 +144,21 @@ def stop_events():
 
 class _GenericExternalEventHandler(UI.IExternalEventHandler):
     def __init__(self):
-        self._queue = queue.Queue()
+        self._queue = deque()
 
     def Execute(self, uiapp):
-        try:
-            while True:
-                fn = self._queue.get_nowait()
-                try:
-                    fn()
-                except Exception as ex:
-                    mlogger.error("ExternalEvent error: {}".format(ex))
-        except queue.Empty:
-            pass
+        while self._queue:
+            fn = self._queue.popleft()
+            try:
+                fn()
+            except Exception as ex:
+                mlogger.error("ExternalEvent error: {}".format(ex))
 
     def GetName(self):
         return "GenericExternalEventHandler"
 
     def schedule(self, func):
-        self._queue.put(func)
+        self._queue.append(func)
 
 
 if compat.IRONPY:

--- a/pyrevitlib/pyrevit/revit/events.py
+++ b/pyrevitlib/pyrevit/revit/events.py
@@ -199,7 +199,28 @@ def execute_in_revit_context(func, *args, **kwargs):
     """
     if not compat.IRONPY:
         PyRevitCPythonNotSupported("pyrevit.revit.events.execute_in_revit_context")
-    _HANDLER.func = func
+
+    # Snapshot module-level imports from the function's globals at scheduling
+    # time. When the ExternalEvent fires asynchronously, the IronPython engine
+    # may have cleared the script scope (non-persistent engines) or module
+    # references may be stale after extension changes / session reload.
+    # This affects any module whose __init__.py uses conditional imports at
+    # load time (e.g. forms, revit submodules). Only module-type objects are
+    # restored to avoid contaminating mutable script state (doc, uidoc, etc.).
+    _module_type = type(compat)
+    _saved_modules = {
+        k: v for k, v in func.__globals__.items()
+        if type(v) is _module_type
+    }
+
+    def _func_with_modules(*a, **kw):
+        g = func.__globals__
+        for k, v in _saved_modules.items():
+            if k not in g:
+                g[k] = v
+        return func(*a, **kw)
+
+    _HANDLER.func = _func_with_modules
     _HANDLER.args = args
     _HANDLER.kwargs = kwargs
     _EXTERNAL_EVENT.Raise()


### PR DESCRIPTION
When the IronPython engine clears a non-persistent script scope, or when the cached engine for a command is the startup-script engine (same TypeId via SessionUUID:EngineType:Extension), module references like `forms`, `revit`, and any other split-backend module can disappear from `func.__globals__` before the ExternalEvent callback executes, causing NameError.

Snapshot all module-type globals at scheduling time and restore any that are missing just before the function is called. Only module objects (type(v) is type(compat)) are restored, so mutable Revit state (doc, uidoc, etc.) is never overwritten with stale values.

**Unsure, but seems to be a less of a bandaid fix than #3327. Maybe another AI has an opinion on that?**

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #3285
