### PR TITLE
feat(selection): add Keep Editable filter button

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Filter.pulldown/Keep Editable.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Filter.pulldown/Keep Editable.pushbutton/bundle.yaml
@@ -1,0 +1,35 @@
+title:
+  en_us: Keep Editable
+  fr_fr: Conserver les éditables
+  ru: Удержать редактируемые
+  chinese_s: 保留可编辑图元
+  es_es: Mantener editables
+  de_de: Nur bearbeitbare Elemente in aktueller Auswahl belassen
+  pt_br: Manter Editáveis
+tooltip:
+  en_us: >-
+    Keeps only editable elements (unclaimed or owned by current user) in current
+    selection. If nothing is selected, pick a region to filter from.
+  fr_fr: >-
+    Conserve uniquement les éléments éditables (non réclamés ou appartenant à
+    l'utilisateur actuel) dans la sélection actuelle. Si rien n'est sélectionné,
+    délimitez une zone à filtrer.
+  ru: >-
+    Удерживает только редактируемые элементы (незаявленные или принадлежащие
+    текущему пользователю) в текущем выделении. Если ничего не выбрано, выберите
+    область для фильтрации.
+  chinese_s: >-
+    在当前选择中仅保留可编辑图元（未申请或由当前用户拥有）。若未选择任何内容，则框选区域进行过滤。
+  es_es: >-
+    Mantiene solo los elementos editables (no reclamados o del usuario actual) en
+    la selección actual. Si no hay nada seleccionado, delimite una región para
+    filtrar.
+  de_de: >-
+    Die aktuelle Elementauswahl wird so vermindert, dass nur bearbeitbare Elemente
+    (nicht beanspruchte oder dem aktuellen Benutzer gehörende) in der Auswahl
+    verbleiben. Wenn nichts ausgewählt ist, kann ein Bereich zum Filtern gewählt
+    werden.
+  pt_br: >-
+    Mantém apenas os elementos editáveis (não reivindicados ou do usuário atual)
+    na seleção atual. Se nada estiver selecionado, selecione uma região para
+    filtrar.

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Filter.pulldown/Keep Editable.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Filter.pulldown/Keep Editable.pushbutton/script.py
@@ -1,0 +1,42 @@
+"""Keep only editable elements in current selection.
+
+If nothing is selected, pick a region to filter editable elements from.
+Works in both workshared and non-workshared documents.
+"""
+from pyrevit import revit
+from pyrevit import DB, UI
+
+doc = revit.doc
+
+
+def is_editable(el):
+    if not doc.IsWorkshared:
+        return True
+    try:
+        status = DB.WorksharingUtils.GetCheckoutStatus(doc, el.Id)
+        return status in (
+            DB.CheckoutStatus.NotOwned,
+            DB.CheckoutStatus.OwnedByCurrentUser,
+        )
+    except Exception:
+        return True
+
+
+class EditableSelectionFilter(UI.Selection.ISelectionFilter):
+    def AllowElement(self, element):
+        return is_editable(element)
+
+    def AllowReference(self, reference, point):
+        return False
+
+
+selection = list(revit.get_selection())
+if selection:
+    editable = [el for el in selection if is_editable(el)]
+    revit.get_selection().set_to(editable)
+else:
+    try:
+        elements = revit.pick_rectangle(pick_filter=EditableSelectionFilter())
+        revit.get_selection().set_to(elements)
+    except Exception:
+        pass


### PR DESCRIPTION
Adds a new Filter pulldown button that keeps only editable elements (unclaimed or owned by the current user) from the active selection. Falls back to a pick-rectangle when nothing is selected. Gracefully passes all elements through in non-workshared documents.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.
