### PR TITLE
fix(preflight/audit): robustness fixes for missing docstrings, unloaded links, and cloud URIs

### DIFF
--- a/extensions/pyRevitTools.extension/checks/audit_all_check.py
+++ b/extensions/pyRevitTools.extension/checks/audit_all_check.py
@@ -977,6 +977,12 @@ def audit_document(doc, output):
         links_documents_data = []
         for rvt_link_instance in q.get_linked_model_instances(doc).ToElements():
             link_doc = rvt_link_instance.GetLinkDocument()
+            if not link_doc:
+                logger.error(
+                    "Link '%s' is not loaded -- skipping.",
+                    q.get_rvt_link_instance_name(rvt_link_instance)
+                )
+                continue
             link_document_data = ReportData(link_doc)
             link_data.append(
                 [

--- a/extensions/pyRevitTools.extension/checks/audit_all_check.py
+++ b/extensions/pyRevitTools.extension/checks/audit_all_check.py
@@ -21,6 +21,7 @@ from pyrevit.output.cards import card_builder, create_frame
 from pyrevit.revit.db import ProjectInfo as RevitProjectInfo
 import sys
 import os
+
 # Add current directory to path for local imports
 _current_dir = os.path.dirname(os.path.abspath(__file__))
 if _current_dir not in sys.path:
@@ -84,7 +85,9 @@ _PresureLossReport = getattr(DB.ViewType, "PresureLossReport", None)
 _SystemsAnalysisReport = getattr(DB.ViewType, "SystemsAnalysisReport", None)
 VALID_VIEW_TYPES = list(_VALID_VIEW_TYPES_BASE)
 if _PresureLossReport is not None:
-    VALID_VIEW_TYPES.insert(VALID_VIEW_TYPES.index(DB.ViewType.LoadsReport) + 1, _PresureLossReport)
+    VALID_VIEW_TYPES.insert(
+        VALID_VIEW_TYPES.index(DB.ViewType.LoadsReport) + 1, _PresureLossReport
+    )
 if _SystemsAnalysisReport is not None:
     VALID_VIEW_TYPES.append(_SystemsAnalysisReport)
 
@@ -958,6 +961,7 @@ def audit_document(doc, output):
             "N/A",
         ]
         from check_translations import get_check_translation
+
         output.print_md("# {}".format(get_check_translation("AuditAllMainFileInfos")))
         translated_headers = [
             get_check_translation("AuditAllProjectName"),
@@ -968,7 +972,7 @@ def audit_document(doc, output):
             get_check_translation("AuditAllLinkedFileName"),
             get_check_translation("ModelCheckerInstanceName"),
             get_check_translation("AuditAllLoadedStatus"),
-            get_check_translation("ModelCheckerPinnedStatus")
+            get_check_translation("ModelCheckerPinnedStatus"),
         ]
         output.print_table([project_info], columns=translated_headers)
 
@@ -998,12 +1002,18 @@ def audit_document(doc, output):
             )
             links_documents_data.append(link_document_data)
         if link_data:
-            output.print_md("# {}".format(get_check_translation("AuditAllLinkedFilesInfos")))
+            output.print_md(
+                "# {}".format(get_check_translation("AuditAllLinkedFilesInfos"))
+            )
             output.print_table(link_data, columns=translated_headers)
             links_cards = card_builder(
-                50, data.links_info.rvtlinks_count, " {}".format(get_check_translation("AuditAllLinks"))
+                50,
+                data.links_info.rvtlinks_count,
+                " {}".format(get_check_translation("AuditAllLinks")),
             ) + card_builder(
-                0, data.links_info.rvtlinks_unpinned_count, " {}".format(get_check_translation("AuditAllLinksNotPinned"))
+                0,
+                data.links_info.rvtlinks_unpinned_count,
+                " {}".format(get_check_translation("AuditAllLinksNotPinned")),
             )
 
         output.print_md(
@@ -1015,7 +1025,9 @@ def audit_document(doc, output):
         data.export_to_csv()
 
         if data.rvtlinks_elements_items:
-            output.print_md("# {}".format(get_check_translation("ModelCheckerRVTLinks")))
+            output.print_md(
+                "# {}".format(get_check_translation("ModelCheckerRVTLinks"))
+            )
             for link_doc_data in links_documents_data:
                 generate_rvt_links_report(link_doc_data, output)
     except Exception as e:
@@ -1039,9 +1051,12 @@ def generate_rvt_links_report(link_document_data, output):
     output.print_md("___")
     links_data = ""
     from check_translations import get_check_translation
+
     if link_document_data.rvtlinks_elements_items:
         links_data = card_builder(
-            50, link_document_data.links_info.rvtlinks_count, " {}".format(get_check_translation("AuditAllLinks"))
+            50,
+            link_document_data.links_info.rvtlinks_count,
+            " {}".format(get_check_translation("AuditAllLinks")),
         ) + card_builder(
             0,
             link_document_data.links_info.rvtlinks_unpinned_count,
@@ -1055,12 +1070,13 @@ def generate_rvt_links_report(link_document_data, output):
 class ModelChecker(PreflightTestCase):
     __metaclass__ = DocstringMeta
     _docstring_key = "CheckDescription_AuditAll"
-    
+
     @property
     def name(self):
         from check_translations import get_check_translation
+
         return get_check_translation("CheckName_AuditAll")
-    
+
     author = "Jean-Marc Couffin"
 
     def setUp(self, doc, output):

--- a/extensions/pyRevitTools.extension/checks/audit_all_check.py
+++ b/extensions/pyRevitTools.extension/checks/audit_all_check.py
@@ -1,9 +1,4 @@
 # -*- coding: UTF-8 -*-
-
-__cleanengine__ = True
-__fullframeengine__ = True
-__persistentengine__ = True
-
 from traceback import format_exc
 from csv import writer, reader
 from os.path import isfile

--- a/pyrevitlib/pyrevit/preflight/__init__.py
+++ b/pyrevitlib/pyrevit/preflight/__init__.py
@@ -12,9 +12,12 @@ import os.path as op
 import imp
 import inspect
 
+from pyrevit.coreutils.logger import get_logger
 from pyrevit.extensions import extensionmgr
 from pyrevit.extensions import extpackages as extpkg
 from pyrevit.preflight.case import PreflightTestCase
+
+mlogger = get_logger(__name__)
 
 
 def _grab_test_types(module):
@@ -50,10 +53,16 @@ class PreflightCheck(object):
             if extension_pkg:
                 self.author = extension_pkg.author
 
-        desc_lines = getattr(self.check_case, "__doc__", "").strip().split('\n')
-        if desc_lines:
-            self.subtitle = desc_lines[0]
-            self.description = '\n'.join([x.strip() for x in desc_lines[1:]])
+        doc_str = (getattr(self.check_case, "__doc__", None) or "").strip()
+        if not doc_str:
+            mlogger.error(
+                "PreflightCheck '%s' in '%s' has no docstring -- "
+                "add a class-level docstring (first line becomes the subtitle).",
+                self.name, op.basename(script_path)
+            )
+        desc_lines = doc_str.split('\n') if doc_str else ['']
+        self.subtitle = desc_lines[0]
+        self.description = '\n'.join(x.strip() for x in desc_lines[1:])
 
 
 def run_preflight_check(check, doc, output):

--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -1171,11 +1171,11 @@ def get_document_clean_name(doc=None):
     document_name = db.ProjectInfo(doc or DOCS.doc).path
     if not document_name:
         return "File Not Saved"
-    if document_name.startswith("BIM 360://"):
-        path = document_name.split("://", 1)[1]
-    else:
-        path = document_name
-    return splitext(basename(path))[0]
+    # Strip any URI-style scheme (BIM 360://, ACC://, etc.)
+    if "://" in document_name:
+        document_name = document_name.split("://", 1)[1]
+
+    return splitext(basename(document_name))[0]
 
 
 def get_links(linktype=None, doc=None):

--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -1171,9 +1171,11 @@ def get_document_clean_name(doc=None):
     document_name = db.ProjectInfo(doc or DOCS.doc).path
     if not document_name:
         return "File Not Saved"
-    # Strip any URI-style scheme (BIM 360://, ACC://, etc.)
-    if "://" in document_name:
-        document_name = document_name.split("://", 1)[1]
+    _CLOUD_URI_SCHEMES = ("BIM 360://", "ACC://", "Autodesk Docs://")
+    for scheme in _CLOUD_URI_SCHEMES:
+        if document_name.startswith(scheme):
+            document_name = document_name[len(scheme):]
+            break
 
     return splitext(basename(document_name))[0]
 


### PR DESCRIPTION
## Description

- preflight/__init__.py: log a named error when a PreflightTestCase subclass has no docstring; also fix latent bug where subtitle/description could be left unset
- audit_all_check.py: skip unloaded RVT links with a named error instead of crashing; remove unneeded engine flags; black formatting
- query.py: handle cloud document URI schemes generically (BIM 360://, ACC://, etc.) instead of hard-coding BIM 360

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

