### PR TITLE
add optional reload parameter

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/ws4links_config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/ws4links_config.py
@@ -76,5 +76,5 @@ if results:
         )
         my_config.set_option("custom_prefix_dwg_value", custom_prefix_value)
 
-    script.save_config(reload=True)
+    script.save_config()
     main()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/ws4links_config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/ws4links_config.py
@@ -76,5 +76,5 @@ if results:
         )
         my_config.set_option("custom_prefix_dwg_value", custom_prefix_value)
 
-    script.save_config()
+    script.save_config(reload=True)
     main()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/ws4links_script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/ws4links_script.py
@@ -17,7 +17,7 @@ translations = TRANSLATIONS_SCRIPT.get(
 
 def main():
     """Main function to create worksets for linked elements."""
-    my_config = script.get_config()
+    my_config = script.get_config(reload=True)
 
     set_type_ws = my_config.get_option("set_type_ws", False)
     set_all = my_config.get_option("set_all", False)

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -164,7 +164,7 @@ def get_config(section=None, reload=False):
     Args:
         section (str, optional): config section name. If not provided,
             it will default to the command name plus the 'config' suffix.
-        reload (bool, optional): forces a reload, in case changes where made.
+        reload (bool, optional): forces a reload, in case changes were made.
 
     Returns:
         (pyrevit.coreutils.configparser.PyRevitConfigSectionParser):
@@ -183,19 +183,14 @@ def get_config(section=None, reload=False):
         return user_config.add_section(section)
 
 
-def save_config(reload=False):
+def save_config():
     """Save pyRevit config.
 
     Scripts should call this to save any changes they have done to their
     config section object received from script.get_config() method.
-
-    Args:
-        reload (bool, optional): forces a reload, in case a script uses newly set config.
     """
     from pyrevit.userconfig import user_config
     user_config.save_changes()
-    if reload:
-        user_config.reload()
 
 
 def reset_config(section=None):

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -158,12 +158,13 @@ def get_output():
     return output.get_output()
 
 
-def get_config(section=None):
+def get_config(section=None, reload=False):
     """Create and return config section parser object for current script.
 
     Args:
         section (str, optional): config section name. If not provided,
             it will default to the command name plus the 'config' suffix.
+        reload (bool, optional): forces a reload, in case changes where made.
 
     Returns:
         (pyrevit.coreutils.configparser.PyRevitConfigSectionParser):
@@ -173,6 +174,8 @@ def get_config(section=None):
     if not section:
         script_cfg_postfix = '_config'
         section = EXEC_PARAMS.command_name + script_cfg_postfix
+    if reload:
+        user_config.reload()
 
     try:
         return user_config.get_section(section)
@@ -180,14 +183,19 @@ def get_config(section=None):
         return user_config.add_section(section)
 
 
-def save_config():
+def save_config(reload=False):
     """Save pyRevit config.
 
     Scripts should call this to save any changes they have done to their
     config section object received from script.get_config() method.
+
+    Args:
+        reload (bool, optional): forces a reload, in case a script uses newly set config.
     """
     from pyrevit.userconfig import user_config
     user_config.save_changes()
+    if reload:
+        user_config.reload()
 
 
 def reset_config(section=None):


### PR DESCRIPTION
## Description

Adds an optional reload flag, in case a script wants to use a newly set parameter.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2409 
