### PR TITLE
Add encoding declaration to hooks_logger.py

### DIFF
--- a/extensions/pyRevitDevHooks.extension/lib/hooks_logger.py
+++ b/extensions/pyRevitDevHooks.extension/lib/hooks_logger.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 import re
+import codecs
 import os.path as op
 import datetime
 USER_DESKTOP = op.expandvars('%userprofile%\\desktop')
@@ -14,7 +15,7 @@ def _timestamp():
 
 
 def _write_record(record_str):
-    with open(HOOK_LOGS, 'a') as f:
+    with codecs.open(HOOK_LOGS, 'a', 'utf-8') as f:
         f.write(record_str + '\n')
 
 

--- a/extensions/pyRevitDevHooks.extension/lib/hooks_logger.py
+++ b/extensions/pyRevitDevHooks.extension/lib/hooks_logger.py
@@ -1,4 +1,4 @@
-# pylint: skip-file
+# encoding: utf-8
 import re
 import os.path as op
 import datetime


### PR DESCRIPTION
Fixes https://discourse.pyrevitlabs.io/t/unicodeencodeerror-in-pyrevitdevhooks-hooks-logger-py-when-opening-projects-revit-2025/10171
