### PR TITLE
chore: update GitHub workflows to allow issue commenting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   actions: read
+  issues: write
 
 concurrency:
   group: pyrevit-release-${{ github.ref }}

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   actions: read
+  issues: write
 
 concurrency:
   group: pyrevit-wip-${{ github.event.workflow_run.head_sha }}

--- a/dev/scripts/github.py
+++ b/dev/scripts/github.py
@@ -91,4 +91,16 @@ def post_comment(ticket: str, comment: str):
     """Post a comment on an issue thead"""
     logger.debug("posting comment on ticket #%s", ticket)
     ticket_url = API_ISSUE_COMMENTS.format(ticket=ticket)
-    _post_github(ticket_url, json.dumps({"body": comment}))
+    res = _post_github(ticket_url, json.dumps({"body": comment}))
+    if not res.ok:
+        logger.error(
+            "failed to post comment on issue #%s: %s %s",
+            ticket,
+            res.status_code,
+            res.text,
+        )
+        raise RuntimeError(
+            "failed to post comment on issue #{}: {} {}".format(
+                ticket, res.status_code, res.text
+            )
+        )


### PR DESCRIPTION
Added 'issues: write' permission to both release and WIP workflows, and enhanced the error handling in the post_comment function to log failures when posting comments on issues.

