### PR TITLE
feat(bim360): support custom cloud cache path introduced in Revit 2024+

### DIFF
--- a/pyrevitlib/pyrevit/revit/bim360.py
+++ b/pyrevitlib/pyrevit/revit/bim360.py
@@ -142,7 +142,7 @@ def _get_collab_cache_root(version):
         str: Normalised absolute path to the collaboration cache root.
     """
     custom = _get_custom_cache_root(version)
-    if custom:
+    if custom and op.isdir(custom):
         return custom
 
     default = op.normpath(op.expandvars(

--- a/pyrevitlib/pyrevit/revit/bim360.py
+++ b/pyrevitlib/pyrevit/revit/bim360.py
@@ -1,10 +1,10 @@
-"""BIM360-related utilities."""
-#pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
+"""BIM360-related utilities. Other names by Autodesk: ACC, Forma"""
 import os
 import os.path as op
 
 from pyrevit import HOST_APP
 from pyrevit import coreutils
+from pyrevit.compat import configparser
 from pyrevit.coreutils.logger import get_logger
 from pyrevit.revit import files
 
@@ -13,6 +13,15 @@ mlogger = get_logger(__name__)
 
 COLLAB_CACHE_PATH_FORMAT = \
     '%LOCALAPPDATA%/Autodesk/Revit/Autodesk Revit {version}/CollaborationCache'
+
+REVIT_INI_PATH_FORMAT = \
+    '%APPDATA%/Autodesk/Revit/Autodesk Revit {version}/Revit.ini'
+
+CLOUD_MODEL_CACHE_SECTION = 'CloudModelCache'
+CLOUD_MODEL_CACHE_KEY = 'CacheLocation'
+
+# Revit 2024 is the first version to support custom cloud cache paths
+CUSTOM_CACHE_MIN_VERSION = 2024
 
 
 class CollabCacheModel(object):
@@ -69,11 +78,83 @@ class CollabCache(object):
         return '<{} id={}>'.format(self.__class__.__name__, self.cache_id)
 
 
+def _get_custom_cache_root(version):
+    """Read CacheLocation from Revit.ini for Revit 2024+.
+
+    Returns the expanded, normalised path if a valid non-empty value is found,
+    otherwise returns None so the caller falls back to the default location.
+
+    Args:
+        version (str): Revit version string, e.g. '2024'.
+    """
+    try:
+        version_int = int(version)
+    except (ValueError, TypeError):
+        return None
+
+    if version_int < CUSTOM_CACHE_MIN_VERSION:
+        return None
+
+    ini_path = op.normpath(op.expandvars(
+        REVIT_INI_PATH_FORMAT.format(version=version)
+    ))
+    mlogger.debug('checking Revit.ini for custom cache path: %s', ini_path)
+
+    if not op.isfile(ini_path):
+        mlogger.debug('Revit.ini not found: %s', ini_path)
+        return None
+
+    try:
+        cfg = configparser.ConfigParser()
+        cfg.read(ini_path)
+    except Exception as ini_ex:
+        mlogger.warning('Failed to read Revit.ini @ %s | %s', ini_path, str(ini_ex))
+        return None
+
+    if not cfg.has_section(CLOUD_MODEL_CACHE_SECTION):
+        mlogger.debug('No [%s] section in Revit.ini', CLOUD_MODEL_CACHE_SECTION)
+        return None
+
+    if not cfg.has_option(CLOUD_MODEL_CACHE_SECTION, CLOUD_MODEL_CACHE_KEY):
+        mlogger.debug('No %s key in [%s]', CLOUD_MODEL_CACHE_KEY, CLOUD_MODEL_CACHE_SECTION)
+        return None
+
+    raw = cfg.get(CLOUD_MODEL_CACHE_SECTION, CLOUD_MODEL_CACHE_KEY).strip()
+    if not raw:
+        mlogger.debug('Empty CacheLocation in Revit.ini')
+        return None
+
+    custom_path = op.normpath(op.expandvars(raw))
+    mlogger.debug('custom cache root from Revit.ini: %s', custom_path)
+    return custom_path
+
+
+def _get_collab_cache_root(version):
+    """Resolve the collaboration cache root for the given Revit version.
+
+    For Revit 2024+ checks Revit.ini for a custom CacheLocation first,
+    falling back to the default %LOCALAPPDATA% path for all versions.
+
+    Args:
+        version (str): Revit version string, e.g. '2024'.
+
+    Returns:
+        str: Normalised absolute path to the collaboration cache root.
+    """
+    custom = _get_custom_cache_root(version)
+    if custom:
+        return custom
+
+    default = op.normpath(op.expandvars(
+        COLLAB_CACHE_PATH_FORMAT.format(version=version)
+    ))
+    mlogger.debug('using default cache root: %s', default)
+    return default
+
+
 def get_collab_caches():
     """Get a list of project caches stored under collaboration cache."""
-    collab_root = op.normpath(op.expandvars(
-        COLLAB_CACHE_PATH_FORMAT.format(version=HOST_APP.version)
-    ))
+    collab_root = _get_collab_cache_root(HOST_APP.version)
     mlogger.debug('cache root: %s', collab_root)
     collab_caches = []
     if op.exists(collab_root):

--- a/pyrevitlib/pyrevit/revit/bim360.py
+++ b/pyrevitlib/pyrevit/revit/bim360.py
@@ -119,7 +119,7 @@ def _get_custom_cache_root(version):
         mlogger.debug('No %s key in [%s]', CLOUD_MODEL_CACHE_KEY, CLOUD_MODEL_CACHE_SECTION)
         return None
 
-    raw = cfg.get(CLOUD_MODEL_CACHE_SECTION, CLOUD_MODEL_CACHE_KEY).strip()
+    raw = cfg.get(CLOUD_MODEL_CACHE_SECTION, CLOUD_MODEL_CACHE_KEY, raw=True).strip()
     if not raw:
         mlogger.debug('Empty CacheLocation in Revit.ini')
         return None


### PR DESCRIPTION
## Description

Revit 2024 introduced the ability to override the collaboration cache
location via [CloudModelCache] CacheLocation in Revit.ini. The previous
code always resolved the cache root from the hardcoded %LOCALAPPDATA%
default, causing custom-path caches to be silently missed.

Changes:
- Add _get_custom_cache_root() to read CacheLocation from Revit.ini
  using raw configparser.get() (avoiding PyRevitConfigParser's JSON
  decode chain which mangles bare Windows paths)
- Add _get_collab_cache_root() to consolidate root resolution: custom
  path for 2024+, default %LOCALAPPDATA% path for all other versions
- Gate ini parsing behind CUSTOM_CACHE_MIN_VERSION = 2024 so pre-2024
  versions take the fast path with no file I/O
- All failure modes (missing file, missing section/key, empty value,
  parse error) fall back to the default path gracefully

No changes to CollabCache, CollabCacheModel, or clear_model_cache.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

