### PR TITLE
Add file type summary to signing process

### DIFF
--- a/build/Helpers/SigningHelper.cs
+++ b/build/Helpers/SigningHelper.cs
@@ -28,11 +28,37 @@ public static class SigningHelper
         return Path.Combine(userProfile, ".dotnet", "tools", OperatingSystem.IsWindows() ? "sign.exe" : "sign");
     }
 
+    public static string BuildSigningSummary(IEnumerable<string> files)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in files)
+        {
+            var extension = Path.GetExtension(file);
+            if (string.IsNullOrEmpty(extension))
+            {
+                extension = "(no extension)";
+            }
+
+            counts.TryGetValue(extension, out var count);
+            counts[extension] = count + 1;
+        }
+
+        var total = counts.Values.Sum();
+        var breakdown = string.Join(
+            ", ",
+            counts
+                .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(kvp => string.Format("{0} {1}", kvp.Value, kvp.Key)));
+
+        return string.Format("{0} file(s): {1}", total, breakdown);
+    }
+
     public static async Task<CommandResult> SignFilesAsync(
         IModuleContext context,
         SigningOptions signingOptions,
         BuildOptions buildOptions,
         IEnumerable<string> files,
+        string summaryLabel,
         CancellationToken cancellationToken)
     {
         var fileList = files.ToArray();
@@ -40,6 +66,8 @@ public static class SigningHelper
         {
             throw new InvalidOperationException("No files were provided for signing.");
         }
+
+        context.Summary.KeyValue("Signing", summaryLabel, BuildSigningSummary(fileList));
 
         await EnsureSignToolInstalledAsync(context, cancellationToken);
 

--- a/build/Modules/SignBinariesModule.cs
+++ b/build/Modules/SignBinariesModule.cs
@@ -21,6 +21,7 @@ public sealed class SignBinariesModule(
             signingOptions.Value,
             buildOptions.Value,
             files,
+            "Binaries",
             cancellationToken);
     }
 }

--- a/build/Modules/SignChocoPackageModule.cs
+++ b/build/Modules/SignChocoPackageModule.cs
@@ -32,6 +32,7 @@ public sealed class SignChocoPackageModule(
             signingOptions.Value,
             buildOptions.Value,
             [nupkgPath],
+            "Choco",
             cancellationToken);
     }
 

--- a/build/Modules/SignInstallersModule.cs
+++ b/build/Modules/SignInstallersModule.cs
@@ -40,6 +40,7 @@ public sealed class SignDistInstallersModule(
             signingOptions.Value,
             buildOptions.Value,
             files,
+            "Installers",
             cancellationToken);
     }
 

--- a/build/tests/SigningHelperTests.cs
+++ b/build/tests/SigningHelperTests.cs
@@ -1,0 +1,32 @@
+using Build.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Build.Tests;
+
+[TestClass]
+public sealed class SigningHelperTests
+{
+    [TestMethod]
+    public void BuildSigningSummary_groups_files_by_extension()
+    {
+        var summary = SigningHelper.BuildSigningSummary(
+        [
+            @"C:\bin\pyRevitLabs.Common.dll",
+            @"C:\bin\pyrevit.exe",
+            @"C:\dist\pyRevit_1.0_signed.exe",
+            @"C:\dist\pyRevit_CLI_1.0_admin_signed.msi",
+            @"C:\dist\pyrevit-cli.1.0.0.nupkg",
+            @"C:\bin\pyRevitLabs.PyRevit.dll",
+        ]);
+
+        Assert.AreEqual("6 file(s): 2 .dll, 2 .exe, 1 .msi, 1 .nupkg", summary);
+    }
+
+    [TestMethod]
+    public void BuildSigningSummary_handles_single_file()
+    {
+        var summary = SigningHelper.BuildSigningSummary([@"C:\dist\pyrevit-cli.1.0.0.nupkg"]);
+
+        Assert.AreEqual("1 file(s): 1 .nupkg", summary);
+    }
+}


### PR DESCRIPTION
Implement a new method in SigningHelper to generate a summary of file types being signed, including counts for each extension. Update the SignBinariesModule, SignChocoPackageModule, and SignInstallersModule to include a summary label when signing files, enhancing clarity in the signing process.

