### PR TITLE
Implement pruning of old NuGet package versions in CI workflow for `d…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,40 @@ jobs:
             --api-key $env:GITHUB_TOKEN `
             --skip-duplicate
 
+      - name: Prune old CI bin NuGet package versions
+        if: >
+          github.repository == env.MainRepo &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $keep = New-Object System.Collections.Generic.HashSet[string]
+          foreach ($branch in @('develop', 'master')) {
+            $runs = gh api "repos/pyrevitlabs/pyRevit/actions/workflows/ci.yml/runs" `
+              -f branch=$branch -f status=completed -f per_page=10 `
+              --jq '.workflow_runs[] | select(.conclusion=="success") | .head_sha'
+            $runs | Select-Object -First 2 | ForEach-Object { [void]$keep.Add($_) }
+          }
+          $versions = gh api --paginate "orgs/pyrevitlabs/packages/nuget/pyrevit.unsignedbin/versions" | ConvertFrom-Json
+          foreach ($version in $versions) {
+            if ($version.name -notmatch '^1\.0\.0-ci-([a-f0-9]{7})$') { continue }
+            $shortSha = $Matches[1]
+            $shouldKeep = $false
+            foreach ($fullSha in $keep) {
+              if ($fullSha.StartsWith($shortSha)) {
+                $shouldKeep = $true
+                break
+              }
+            }
+            if (-not $shouldKeep) {
+              gh api --method DELETE "orgs/pyrevitlabs/packages/nuget/pyrevit.unsignedbin/versions/$($version.id)"
+              Write-Host "Deleted package version $($version.name) (id=$($version.id))."
+            }
+          }
+
       - name: Upload stamped release metadata
         if: github.repository == env.MainRepo
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/build/README.md
+++ b/build/README.md
@@ -96,7 +96,7 @@ pyrevit attach dev default --installed
 pyrevit clones update dev --skip-bin
 ```
 
-CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`). See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
+CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`); NuGet package versions are pruned to the last **2 SHAs per branch**. See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
 
 Run unit tests:
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -74,6 +74,7 @@ After each successful CI push to **`develop`** or **`master`** on the main repo:
 2. Uploads to Release tag **`ci-binaries`** (pre-release), plus rolling **`unsigned-bin-{branch}-latest.zip`**
 3. Pushes **`PyRevit.UnsignedBin`** NuGet package to GitHub Packages (token-authenticated CLI mirror)
 4. Prunes per-SHA release assets older than the **last 3 successful CI builds** per branch (`develop`, `master`); branch-latest zips are always kept
+5. Prunes **`PyRevit.UnsignedBin`** NuGet versions older than the **last 2 successful CI builds** per branch (`develop`, `master`)
 
 Anonymous download URL pattern:
 


### PR DESCRIPTION
…evelop` and `master` branches, retaining the last 2 successful builds. Update documentation to reflect changes in asset management for CI binaries and NuGet packages.

