### PR TITLE
Fixes #3434: build fails after bin has been removed from repo

### DIFF
--- a/build/Helpers/ProductDataHelper.cs
+++ b/build/Helpers/ProductDataHelper.cs
@@ -40,8 +40,13 @@ public static class ProductDataHelper
             throw new FileNotFoundException("Missing product template.", templatePath);
         }
 
+        if (File.Exists(dataPath))
+        {
+            return;
+        }
+
         Directory.CreateDirectory(Path.GetDirectoryName(dataPath)!);
-        File.Copy(templatePath, dataPath, overwrite: true);
+        File.Copy(templatePath, dataPath, overwrite: false);
     }
 
     public static void InsertProduct(List<ProductRecord> products, ProductRecord product, bool cli, bool msi = false)

--- a/build/Helpers/ProductDataHelper.cs
+++ b/build/Helpers/ProductDataHelper.cs
@@ -33,6 +33,17 @@ public static class ProductDataHelper
         File.WriteAllText(path, json);
     }
 
+    public static void SeedProductsFromTemplate(string templatePath, string dataPath)
+    {
+        if (!File.Exists(templatePath))
+        {
+            throw new FileNotFoundException("Missing product template.", templatePath);
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(dataPath)!);
+        File.Copy(templatePath, dataPath, overwrite: true);
+    }
+
     public static void InsertProduct(List<ProductRecord> products, ProductRecord product, bool cli, bool msi = false)
     {
         if (products.Any(x => x.Product == product.Product && x.Version == product.Version))

--- a/build/Modules/BuildLabsModule.cs
+++ b/build/Modules/BuildLabsModule.cs
@@ -1,6 +1,7 @@
 using Build.Helpers;
 using Build.Options;
 using Microsoft.Extensions.Options;
+using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.Models;
@@ -9,6 +10,8 @@ using ModularPipelines.Options;
 
 namespace Build.Modules;
 
+[DependsOn<SeedProductDataModule>]
+[DependsOn<SetProductDataModule>]
 public sealed class BuildLabsModule(IOptions<BuildOptions> buildOptions) : Module
 {
     protected override async Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)

--- a/build/Modules/SeedProductDataModule.cs
+++ b/build/Modules/SeedProductDataModule.cs
@@ -1,0 +1,16 @@
+using Build.Helpers;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+namespace Build.Modules;
+
+public sealed class SeedProductDataModule : Module
+{
+    protected override Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)
+    {
+        ProductDataHelper.SeedProductsFromTemplate(
+            PyRevitPaths.ProductsTemplateFile,
+            PyRevitPaths.ProductsDataFile);
+        return Task.CompletedTask;
+    }
+}

--- a/build/Modules/WriteCiBinManifestModule.cs
+++ b/build/Modules/WriteCiBinManifestModule.cs
@@ -9,13 +9,14 @@ using ModularPipelines.Modules;
 namespace Build.Modules;
 
 [DependsOn<StageBinAssetsModule>]
+[DependsOn<ResolveVersioningModule>]
 public sealed class WriteCiBinManifestModule(IOptions<BuildOptions> buildOptions) : Module
 {
     protected override async Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var versionResult = await context.GetModule<StampVersionModule>();
+        var versionResult = await context.GetModule<ResolveVersioningModule>();
         var versionInfo = versionResult.ValueOrDefault
-            ?? throw new InvalidOperationException("StampVersionModule did not produce a version.");
+            ?? throw new InvalidOperationException("ResolveVersioningModule did not produce a version.");
 
         var sha = Environment.GetEnvironmentVariable("GITHUB_SHA") ?? string.Empty;
         var branch = Environment.GetEnvironmentVariable("GITHUB_REF_NAME")

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -45,6 +45,7 @@ if (runCi)
     builder.Services.AddModule<ResolveVersioningModule>();
     builder.Services.AddModule<SetCopyrightYearModule>();
     builder.Services.AddModule<StampVersionModule>();
+    builder.Services.AddModule<SeedProductDataModule>();
     builder.Services.AddModule<SetProductDataModule>();
     builder.Services.AddModule<BuildLabsModule>();
     builder.Services.AddModule<CheckDeployLocksModule>();

--- a/build/README.md
+++ b/build/README.md
@@ -57,8 +57,11 @@ dotnet run -c Debug -- ci
 
 Outputs land under `bin/` (`netfx/`, `netcore/`, engines, CLI, doctor, autocomplete, etc.). LibGit2 native DLL verification runs at the end of `ci`.
 
+`Channel=none` (the default) is valid for unsigned local builds and fork PR validation. The pipeline seeds `bin/pyrevit-products.json` from [`release/pyrevit-products.json`](../release/pyrevit-products.json) before building labs.
+
 On a **clean checkout** (no tracked `bin/`), `ci` builds in this order:
 
+0. Seed `bin/pyrevit-products.json` from `release/` (stamping may update it when `Build__Channel` is `wip` or `release` on the main repo)
 1. Labs (`pyRevitLabs.sln` + CLI/doctor)
 2. IronPython deps → seeds `bin/*/engines/IPY2712PR/` from `dev/modules/`
 3. Loaders (`pyRevitLoader.*`, not runners)

--- a/build/tests/ProductDataHelperTests.cs
+++ b/build/tests/ProductDataHelperTests.cs
@@ -134,6 +134,18 @@ public sealed class ProductDataHelperTests
             ProductDataHelper.SeedProductsFromTemplate(missingTemplate, dataPath));
     }
 
+    [TestMethod]
+    public void SeedProductsFromTemplate_skips_when_destination_exists()
+    {
+        var templatePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "pyrevit-products.json");
+        var dataPath = WriteTempJson(LegacyProductJson);
+        var originalJson = File.ReadAllText(dataPath);
+
+        ProductDataHelper.SeedProductsFromTemplate(templatePath, dataPath);
+
+        Assert.AreEqual(originalJson, File.ReadAllText(dataPath));
+    }
+
     private static string WriteTempJson(string json)
     {
         var path = Path.Combine(Path.GetTempPath(), "pyrevit-products-" + Guid.NewGuid().ToString("N") + ".json");

--- a/build/tests/ProductDataHelperTests.cs
+++ b/build/tests/ProductDataHelperTests.cs
@@ -109,6 +109,31 @@ public sealed class ProductDataHelperTests
         Assert.DoesNotContain("\\u002B", outputJson);
     }
 
+    [TestMethod]
+    public void SeedProductsFromTemplate_copies_template_to_bin_path()
+    {
+        var templatePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "pyrevit-products.json");
+        var outputDir = Path.Combine(Path.GetTempPath(), "pyrevit-bin-" + Guid.NewGuid().ToString("N"));
+        var dataPath = Path.Combine(outputDir, "pyrevit-products.json");
+
+        ProductDataHelper.SeedProductsFromTemplate(templatePath, dataPath);
+
+        Assert.IsTrue(File.Exists(dataPath));
+        var products = ProductDataHelper.LoadProducts(dataPath);
+        Assert.IsGreaterThan(0, products.Count);
+        Assert.IsTrue(products.All(product => !string.IsNullOrWhiteSpace(product.Product)));
+    }
+
+    [TestMethod]
+    public void SeedProductsFromTemplate_throws_when_template_missing()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), "pyrevit-products-" + Guid.NewGuid().ToString("N") + ".json");
+        var missingTemplate = Path.Combine(Path.GetTempPath(), "missing-template-" + Guid.NewGuid().ToString("N") + ".json");
+
+        Assert.ThrowsExactly<FileNotFoundException>(() =>
+            ProductDataHelper.SeedProductsFromTemplate(missingTemplate, dataPath));
+    }
+
     private static string WriteTempJson(string json)
     {
         var path = Path.Combine(Path.GetTempPath(), "pyrevit-products-" + Guid.NewGuid().ToString("N") + ".json");

--- a/build/tests/WriteCiBinManifestModuleTests.cs
+++ b/build/tests/WriteCiBinManifestModuleTests.cs
@@ -1,0 +1,18 @@
+using Build.Modules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModularPipelines.Attributes;
+
+namespace Build.Tests;
+
+[TestClass]
+public sealed class WriteCiBinManifestModuleTests
+{
+    [TestMethod]
+    public void WriteCiBinManifestModule_depends_on_ResolveVersioningModule()
+    {
+        var dependsOn = typeof(WriteCiBinManifestModule)
+            .GetCustomAttributes(typeof(DependsOnAttribute<>).MakeGenericType(typeof(ResolveVersioningModule)), inherit: false);
+
+        Assert.HasCount(1, dependsOn);
+    }
+}

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -53,7 +53,7 @@ Doc-only or other out-of-scope changes skip CI entirely.
 
 ### Official repository vs forks
 
-The stamping steps (`set year`, `set build wip|release`, `set products`) only run when `Build__Channel` is `wip` or `release` **and** `GITHUB_REPOSITORY` is the main repo (`pyrevitlabs/pyRevit`). The downstream `wip.yml` and `release.yml` jobs are similarly gated on the main repo so secrets are never exposed to forks. Forks still get checkout and an **unsigned** product build via `ci.yml` (useful for PR validation). Unsigned builds (`Channel=none`) still seed `bin/pyrevit-products.json` from `release/` before the labs build so fork PR validation.
+The stamping steps (`set year`, `set build wip|release`, `set products`) only run when `Build__Channel` is `wip` or `release` **and** `GITHUB_REPOSITORY` is the main repo (`pyrevitlabs/pyRevit`). The downstream `wip.yml` and `release.yml` jobs are similarly gated on the main repo so secrets are never exposed to forks. Forks still get checkout and an **unsigned** product build via `ci.yml` (useful for PR validation). Unsigned builds (`Channel=none`) still seed `bin/pyrevit-products.json` from `release/` before the labs build so fork PR validation succeeds.
 
 ## Prebuilt binaries for clone
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -53,7 +53,7 @@ Doc-only or other out-of-scope changes skip CI entirely.
 
 ### Official repository vs forks
 
-The stamping steps (`set year`, `set build wip|release`, `set products`) only run when `Build__Channel` is `wip` or `release` **and** `GITHUB_REPOSITORY` is the main repo (`pyrevitlabs/pyRevit`). The downstream `wip.yml` and `release.yml` jobs are similarly gated on the main repo so secrets are never exposed to forks. Forks still get checkout and an **unsigned** product build via `ci.yml` (useful for PR validation).
+The stamping steps (`set year`, `set build wip|release`, `set products`) only run when `Build__Channel` is `wip` or `release` **and** `GITHUB_REPOSITORY` is the main repo (`pyrevitlabs/pyRevit`). The downstream `wip.yml` and `release.yml` jobs are similarly gated on the main repo so secrets are never exposed to forks. Forks still get checkout and an **unsigned** product build via `ci.yml` (useful for PR validation). Unsigned builds (`Channel=none`) still seed `bin/pyrevit-products.json` from `release/` before the labs build so fork PR validation.
 
 ## Prebuilt binaries for clone
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -97,6 +97,8 @@ pyrevit clones add dev .
 pyrevit attach dev default --installed
 ```
 
+The `ci` pipeline seeds `bin/pyrevit-products.json` from tracked `release/` templates before building labs. No manual `bin/` setup or `Build__Channel` override is required for a first local build.
+
 After pulling source changes, refresh **without** downloading CI binaries:
 
 ```shell
@@ -106,6 +108,60 @@ cd build && dotnet run -c Release -- ci && cd ..
 ```
 
 Rebuild in Debug when attaching the debugger (see [Debugging Code](#debugging-code)).
+
+#### Build channel (maintainers)
+
+Most contributors can use the default build channel (`none`) shown in Profile 2 above. **Repo admins and maintainers** who need to reproduce what CI does on the main repository — version stamping, copyright year, and product metadata in `bin/` — set `Build__Channel` before running `dotnet run -- ci`.
+
+| Channel | When to use | Matches CI on |
+|---------|-------------|---------------|
+| `none` (default) | Local dev, fork PRs, unsigned builds | Fork PR validation; any build without stamping |
+| `wip` | Testing a **develop**-style stamped build locally | Push to `develop` on `pyrevitlabs/pyRevit` |
+| `release` | Testing a **master** / tag-style stamped build locally | Push to `master` or `v*` tag on `pyrevitlabs/pyRevit` |
+
+Set the channel with the `Build__Channel` environment variable (maps to [`build/appsettings.json`](../build/appsettings.json) → `Build:Channel`). Run commands from `build/`.
+
+**PowerShell:**
+
+```powershell
+cd build
+
+# develop-style stamping (WIP version suffix, product metadata refresh)
+$env:Build__Channel = 'wip'
+dotnet run -c Release -- ci
+
+# master / release-tag stamping
+$env:Build__Channel = 'release'
+$env:DOTNET_ENVIRONMENT = 'Production'
+dotnet run -c Release -- ci
+
+# back to unsigned (default)
+Remove-Item Env:Build__Channel -ErrorAction SilentlyContinue
+Remove-Item Env:DOTNET_ENVIRONMENT -ErrorAction SilentlyContinue
+dotnet run -c Release -- ci
+```
+
+**cmd:**
+
+```bat
+cd build
+set Build__Channel=wip
+dotnet run -c Release -- ci
+```
+
+**bash:**
+
+```bash
+cd build
+export Build__Channel=wip
+dotnet run -c Release -- ci
+```
+
+!!! warning "Stamping modifies source files"
+
+    `wip` and `release` update tracked files under `pyrevitlib/`, `release/`, and installer metadata — the same steps CI runs before building products. Review `git status` before committing; do not push accidental version bumps from a local stamped build.
+
+On GitHub Actions, full stamping runs only when `Build__Channel` is `wip` or `release` **and** `GITHUB_REPOSITORY` is `pyrevitlabs/pyRevit`. Fork workflows always use `none` for stamping even if you set the variable in a custom workflow. Locally, `GITHUB_REPOSITORY` is usually unset, so setting `Build__Channel` is enough to mirror main-repo CI. See [CI/CD — Official repository vs forks](ci-cd.md#official-repository-vs-forks) and [`build/README.md`](../build/README.md).
 
 ### Set Upstream Remote
 


### PR DESCRIPTION
Add SeedProductDataModule and implement product seeding functionality

- Introduced SeedProductDataModule to seed product data during the build process.
- Added SeedProductsFromTemplate method in ProductDataHelper to copy product templates.
- Updated BuildLabsModule to depend on SeedProductDataModule.
- Enhanced documentation to reflect changes in CI pipeline and local build instructions.

fixes #3434