### PR TITLE
Add BMT extension

### DIFF
--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -291,6 +291,19 @@
             "website": "https://seed43.org",
             "image": "https://github.com/Seed-43/Seed43/blob/main/Seed43.png",
             "dependencies": []
+        },
+        {
+            "builtin": "False",
+            "type": "extension",
+            "rocket_mode_compatible": "True",
+            "name": "BMT",
+            "description": "BMT - free productivity tools for Revit by Biminent.",
+            "author": "Viktor Kuzev",
+            "author_profile": "https://biminent.com",
+            "url": "https://github.com/biminent/pyRevitExtension.git",
+            "website": "https://biminent.com",
+            "image": "",
+            "dependencies": []
         }
     ]
 }


### PR DESCRIPTION
## Add BMT extension

This adds **BMT** to the community extensions list.

- **Name:** BMT
- **Author:** Viktor Kuzev (Biminent)
- **Repo:** https://github.com/biminent/pyRevitExtension
- **Website:** https://biminent.com
- **Type:** UI extension, rocket-mode compatible

BMT is a free set of productivity tools for Revit (naming/rename, selection,
review, DWG workflows). The extension repo root is the extension folder
(cloned as `BMT.extension`), with an `extension.json` already in place.

Only `extensions/extensions.json` is modified - one new entry appended.