### PR TITLE
fix(ci): install wingetcreate before WinGet manifest update job

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -15,10 +15,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install WingetCreate
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $wingetCreate = Join-Path $env:RUNNER_TEMP 'wingetcreate.exe'
+          Invoke-WebRequest -Uri 'https://aka.ms/wingetcreate/latest' -OutFile $wingetCreate
+          "WINGET_CREATE_EXE=$wingetCreate" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Update WinGet manifests
         working-directory: build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           Publish__WingetToken: ${{ secrets.WINGET_GITHUB_TOKEN }}
           Publish__SubmitWinget: true
+          Publish__WingetCreateExe: ${{ env.WINGET_CREATE_EXE }}
         run: dotnet run -c Release -- winget

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -21,6 +21,8 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $wingetCreate = Join-Path $env:RUNNER_TEMP 'wingetcreate.exe'
           Invoke-WebRequest -Uri 'https://aka.ms/wingetcreate/latest' -OutFile $wingetCreate
+          $signature = Get-AuthenticodeSignature -FilePath $wingetCreate
+          if ($signature.Status -ne 'Valid') { throw "Downloaded wingetcreate.exe has invalid Authenticode signature: $($signature.Status)" }
           "WINGET_CREATE_EXE=$wingetCreate" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Update WinGet manifests

--- a/build/Helpers/ToolResolutionHelper.cs
+++ b/build/Helpers/ToolResolutionHelper.cs
@@ -26,6 +26,30 @@ public static class ToolResolutionHelper
         return null;
     }
 
+    public static string ResolveWingetCreateExecutable(string configuredExe)
+    {
+        if (string.IsNullOrWhiteSpace(configuredExe))
+        {
+            configuredExe = "wingetcreate.exe";
+        }
+
+        if (Path.IsPathRooted(configuredExe) && File.Exists(configuredExe))
+        {
+            return configuredExe;
+        }
+
+        var onPath = ResolveOnPath(Path.GetFileNameWithoutExtension(configuredExe));
+        if (!string.IsNullOrWhiteSpace(onPath))
+        {
+            return onPath;
+        }
+
+        throw new FileNotFoundException(
+            "wingetcreate.exe is required for WinGet publishing but was not found on PATH. "
+            + "Install it from https://aka.ms/wingetcreate/latest or set Publish__WingetCreateExe.",
+            configuredExe);
+    }
+
     public static string ResolvePowerShellExecutable()
     {
         var candidates = new[]

--- a/build/Helpers/ToolResolutionHelper.cs
+++ b/build/Helpers/ToolResolutionHelper.cs
@@ -33,9 +33,17 @@ public static class ToolResolutionHelper
             configuredExe = "wingetcreate.exe";
         }
 
-        if (Path.IsPathRooted(configuredExe) && File.Exists(configuredExe))
+        var isPath = Path.IsPathRooted(configuredExe)
+            || configuredExe.Contains(Path.DirectorySeparatorChar)
+            || configuredExe.Contains(Path.AltDirectorySeparatorChar);
+
+        if (isPath)
         {
-            return configuredExe;
+            var fullPath = Path.GetFullPath(configuredExe);
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
         }
 
         var onPath = ResolveOnPath(Path.GetFileNameWithoutExtension(configuredExe));
@@ -45,8 +53,8 @@ public static class ToolResolutionHelper
         }
 
         throw new FileNotFoundException(
-            "wingetcreate.exe is required for WinGet publishing but was not found on PATH. "
-            + "Install it from https://aka.ms/wingetcreate/latest or set Publish__WingetCreateExe.",
+            "wingetcreate.exe is required for WinGet publishing but was not found at the configured path and was not found on PATH. "
+            + "Install it from https://aka.ms/wingetcreate/latest or set Publish__WingetCreateExe to a valid path.",
             configuredExe);
     }
 

--- a/build/Modules/PublishWingetModule.cs
+++ b/build/Modules/PublishWingetModule.cs
@@ -83,8 +83,10 @@ public sealed class PublishWingetModule(IOptions<PublishOptions> publishOptions)
             arguments.Add("-s");
         }
 
+        var wingetCreate = ToolResolutionHelper.ResolveWingetCreateExecutable(publishOptions.WingetCreateExe);
+
         await context.Shell.Command.ExecuteCommandLineTool(
-            new GenericCommandLineToolOptions(publishOptions.WingetCreateExe)
+            new GenericCommandLineToolOptions(wingetCreate)
             {
                 Arguments = arguments,
             },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The **Update Winget manifests** workflow (`winget.yml`) failed on `windows-2025` because `wingetcreate.exe` is not preinstalled on the runner. `PublishWingetModule` attempted to run the tool by name and exited immediately with `Win32Exception: The system cannot find the file specified`.

This change:

1. Adds an **Install WingetCreate** step to `.github/workflows/winget.yml` that downloads the standalone executable from `https://aka.ms/wingetcreate/latest` and passes its full path to the build via `Publish__WingetCreateExe`.
2. Resolves the configured WinGet Create executable in `PublishWingetModule` through `ToolResolutionHelper.ResolveWingetCreateExecutable`, so local runs and CI both get a clear `FileNotFoundException` when the tool is missing.

The workflow approach follows the same pattern used by other Microsoft projects (e.g. Windows Terminal) that download the standalone `wingetcreate.exe` rather than relying on PATH.

## Checklist

- [x] Code follows project conventions.
- [x] Changes are tested and verified to work as expected.

## Related Issues

Fixes the `PublishWingetModule` failure observed during the `v6.5.0.26173+1406` release WinGet job.

## Additional Notes

After merging, re-run the failed **Update Winget manifests** workflow (via **workflow_dispatch** or by re-publishing the release) to submit the WinGet manifest PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ad44a8f-ad56-48eb-a485-db226f3ce3d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ad44a8f-ad56-48eb-a485-db226f3ce3d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

