### PR TITLE
Update get_families() in pyrevitlib\pyrevit\revit\db\query.py

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -677,14 +677,7 @@ def get_families(doc=None, only_editable=True):
               only includes families that are editable.
     """
     doc = doc or DOCS.doc
-    get_elementid_value = get_elementid_value_func()
-    families = {
-        get_elementid_value(x.Family.Id): x.Family
-        for x in set(
-            DB.FilteredElementCollector(doc).WhereElementIsElementType()
-        )
-        if isinstance(x, (DB.FamilySymbol, DB.AnnotationSymbolType))
-    }.values()
+    families = DB.FilteredElementCollector(doc).OfClass(DB.Family)
     if only_editable:
         return [x for x in families if x.IsEditable]
     return list(families)


### PR DESCRIPTION
The get_families() function has been updated.
Families are retrieved directly by the collector.
Differences from the previous algorithm:
- finds all (!!!) system families (not editable);
- runs 2-4 times faster.
