### PR TITLE
Fix CLI clone failure by replacing bin with build in deployments

### DIFF
--- a/pyRevitfile
+++ b/pyRevitfile
@@ -26,9 +26,9 @@ assembly = 'python312.dll'
 description = 'CPython Engine'
 
 [deployments]
-core = ['bin', 'pyrevitlib', 'site-packages', 'pyRevitfile']
+core = ['build', 'pyrevitlib', 'site-packages', 'pyRevitfile']
 corex = [
-    'bin',
+    'build',
     'extensions/pyRevitCore.extension',
     'extensions/extensions.json',
     'pyrevitlib',
@@ -36,7 +36,7 @@ corex = [
     'pyRevitfile',
 ]
 base = [
-    'bin',
+    'build',
     'extensions/pyRevitBundlesCreatorExtension.extension',
     'extensions/pyRevitCore.extension',
     'extensions/pyRevitTags.extension',
@@ -47,7 +47,7 @@ base = [
     'pyRevitfile',
 ]
 basepublic = [
-    'bin',
+    'build',
     'extensions/pyRevitCore.extension',
     'extensions/pyRevitTags.extension',
     'extensions/pyRevitTools.extension',
@@ -57,4 +57,4 @@ basepublic = [
     'site-packages',
     'pyRevitfile',
 ]
-basex = ['bin', 'extensions', 'pyrevitlib', 'site-packages', 'pyRevitfile']
+basex = ['build', 'extensions', 'pyrevitlib', 'site-packages', 'pyRevitfile']

--- a/pyRevitfile
+++ b/pyRevitfile
@@ -26,9 +26,8 @@ assembly = 'python312.dll'
 description = 'CPython Engine'
 
 [deployments]
-core = ['build', 'pyrevitlib', 'site-packages', 'pyRevitfile']
+core = ['pyrevitlib', 'site-packages', 'pyRevitfile']
 corex = [
-    'build',
     'extensions/pyRevitCore.extension',
     'extensions/extensions.json',
     'pyrevitlib',
@@ -36,7 +35,6 @@ corex = [
     'pyRevitfile',
 ]
 base = [
-    'build',
     'extensions/pyRevitBundlesCreatorExtension.extension',
     'extensions/pyRevitCore.extension',
     'extensions/pyRevitTags.extension',
@@ -47,7 +45,6 @@ base = [
     'pyRevitfile',
 ]
 basepublic = [
-    'build',
     'extensions/pyRevitCore.extension',
     'extensions/pyRevitTags.extension',
     'extensions/pyRevitTools.extension',
@@ -57,4 +54,4 @@ basepublic = [
     'site-packages',
     'pyRevitfile',
 ]
-basex = ['build', 'extensions', 'pyrevitlib', 'site-packages', 'pyRevitfile']
+basex = ['extensions', 'pyrevitlib', 'site-packages', 'pyRevitfile']


### PR DESCRIPTION
This PR fixes a bug where the pyRevit CLI fails to clone because it looks for the old `bin` directory. This updates `pyRevitfile` deployments to point to the new `build` directory.

Fixes #3454